### PR TITLE
fix: resolve spawn EINVAL on Windows for .cmd binaries

### DIFF
--- a/packages/cli/src/claude-runner.ts
+++ b/packages/cli/src/claude-runner.ts
@@ -381,11 +381,14 @@ export async function runClaudeWithProxy(
   }
 
   // Spawn claude CLI process using Node.js child_process (works on both Node.js and Bun)
-  // Use the found binary path directly
-  const proc = spawn(claudeBinary, claudeArgs, {
+  // On Windows, .cmd files require shell:true — spawn() throws EINVAL without it.
+  // When using shell mode, quote the binary path to handle spaces (e.g. "C:\Program Files\...")
+  const needsShell = isWindows() && claudeBinary.endsWith(".cmd");
+  const spawnCommand = needsShell ? `"${claudeBinary}"` : claudeBinary;
+  const proc = spawn(spawnCommand, claudeArgs, {
     env,
     stdio: "inherit", // Stream stdin/stdout/stderr to parent
-    shell: false, // No shell needed when using direct path
+    shell: needsShell,
   });
 
   // Handle process termination signals (includes cleanup)


### PR DESCRIPTION
## Summary

- **Fix `spawn EINVAL` (errno -4071) on Windows** when `findClaudeBinary()` resolves to a `.cmd` file (e.g. npm global `claude.cmd`). Node.js `spawn()` with `shell: false` cannot execute `.cmd` batch scripts on Windows.
- **Fix path-with-spaces breakage** when using `shell: true` — the binary path is now quoted to handle paths like `C:\Program Files\...`.

## Details

On Windows, claudish crashes immediately after model selection:

```
[claudish] Fatal error: Error: spawn EINVAL
    at ChildProcess.spawn (node:internal/child_process:421:11)
```

**Root cause**: `findClaudeBinary()` finds `claude.cmd` from npm global install. `spawn(claudeBinary, args, { shell: false })` throws `EINVAL` because Windows cannot execute `.cmd` files without a shell.

**Fix**: Detect `.cmd` binaries on Windows and set `shell: true` for those, with the binary path quoted to handle spaces. No behavior change on Linux/macOS — `isWindows()` gates both changes.

## Test plan

- [x] Verified fix resolves `EINVAL` on Windows 11 with npm-global `claude.cmd`
- [x] Verified quoted path handles spaces in binary path
- [x] Confirmed no code path change on non-Windows (guarded by `isWindows()`)

> [!NOTE]
> This PR and all code changes were generated with AI assistance (Claude Code / Claude Opus 4.6).