### PR TITLE
feat: API key provenance tracking in debug logs and --probe

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -22,6 +22,11 @@ import {
   matchRoutingRule,
   buildRoutingChain,
 } from "./providers/routing-rules.js";
+import {
+  resolveApiKeyProvenance,
+  formatProvenanceProbe,
+  type KeyProvenance,
+} from "./providers/api-key-provenance.js";
 // Re-export from centralized provider-resolver for backwards compatibility
 export {
   resolveModelProvider,
@@ -1271,6 +1276,26 @@ async function probeModelRouting(models: string[], jsonOutput: boolean): Promise
 
   const results: ProbeResult[] = [];
 
+  const API_KEY_MAP: Record<string, { envVar: string; aliases?: string[] }> = {
+    litellm: { envVar: "LITELLM_API_KEY" },
+    openrouter: { envVar: "OPENROUTER_API_KEY" },
+    google: { envVar: "GEMINI_API_KEY" },
+    openai: { envVar: "OPENAI_API_KEY" },
+    minimax: { envVar: "MINIMAX_API_KEY" },
+    "minimax-coding": { envVar: "MINIMAX_CODING_API_KEY" },
+    kimi: { envVar: "MOONSHOT_API_KEY", aliases: ["KIMI_API_KEY"] },
+    "kimi-coding": { envVar: "KIMI_CODING_API_KEY" },
+    glm: { envVar: "ZHIPU_API_KEY", aliases: ["GLM_API_KEY"] },
+    "glm-coding": { envVar: "GLM_CODING_API_KEY", aliases: ["ZAI_CODING_API_KEY"] },
+    zai: { envVar: "ZAI_API_KEY" },
+    ollamacloud: { envVar: "OLLAMA_API_KEY" },
+    "opencode-zen": { envVar: "OPENCODE_API_KEY" },
+    "opencode-zen-go": { envVar: "OPENCODE_API_KEY" },
+    "gemini-codeassist": { envVar: "GEMINI_API_KEY" },
+    vertex: { envVar: "VERTEX_API_KEY", aliases: ["VERTEX_PROJECT"] },
+    poe: { envVar: "POE_API_KEY" },
+  };
+
   for (const modelInput of models) {
     const parsed = parseModelSpec(modelInput);
     const chain = (() => {
@@ -1311,37 +1336,19 @@ async function probeModelRouting(models: string[], jsonOutput: boolean): Promise
     })();
 
     // Check credentials for each route
-    const API_KEY_MAP: Record<string, { envVar: string; aliases?: string[] }> = {
-      litellm: { envVar: "LITELLM_API_KEY" },
-      openrouter: { envVar: "OPENROUTER_API_KEY" },
-      google: { envVar: "GEMINI_API_KEY" },
-      openai: { envVar: "OPENAI_API_KEY" },
-      minimax: { envVar: "MINIMAX_API_KEY" },
-      "minimax-coding": { envVar: "MINIMAX_CODING_API_KEY" },
-      kimi: { envVar: "MOONSHOT_API_KEY", aliases: ["KIMI_API_KEY"] },
-      "kimi-coding": { envVar: "KIMI_CODING_API_KEY" },
-      glm: { envVar: "ZHIPU_API_KEY", aliases: ["GLM_API_KEY"] },
-      "glm-coding": { envVar: "GLM_CODING_API_KEY", aliases: ["ZAI_CODING_API_KEY"] },
-      zai: { envVar: "ZAI_API_KEY" },
-      ollamacloud: { envVar: "OLLAMA_API_KEY" },
-      "opencode-zen": { envVar: "OPENCODE_API_KEY" },
-      "opencode-zen-go": { envVar: "OPENCODE_API_KEY" },
-      "gemini-codeassist": { envVar: "GEMINI_API_KEY" },
-      vertex: { envVar: "VERTEX_API_KEY", aliases: ["VERTEX_PROJECT"] },
-      poe: { envVar: "POE_API_KEY" },
-    };
-
     const chainDetails = chain.routes.map((route) => {
       const keyInfo = API_KEY_MAP[route.provider];
       let hasCredentials = false;
       let credentialHint: string | undefined;
+      let provenance: KeyProvenance | undefined;
 
       if (!keyInfo) {
         hasCredentials = true; // Unknown provider — assume OK
       } else if (!keyInfo.envVar) {
         hasCredentials = true; // No key needed (free/OAuth)
       } else {
-        hasCredentials = !!process.env[keyInfo.envVar];
+        provenance = resolveApiKeyProvenance(keyInfo.envVar, keyInfo.aliases);
+        hasCredentials = !!provenance.effectiveValue;
         if (!hasCredentials && keyInfo.aliases) {
           hasCredentials = keyInfo.aliases.some((a) => !!process.env[a]);
         }
@@ -1356,6 +1363,7 @@ async function probeModelRouting(models: string[], jsonOutput: boolean): Promise
         modelSpec: route.modelSpec,
         hasCredentials,
         credentialHint,
+        provenance,
       };
     });
 
@@ -1478,6 +1486,26 @@ async function probeModelRouting(models: string[], jsonOutput: boolean): Promise
       console.log(
         `  ${GREEN}  Direct → ${result.nativeProvider}${RESET}  (explicit provider prefix, no fallback chain)`
       );
+
+      // Show API key provenance layers for explicit provider routing
+      const directKeyInfo = API_KEY_MAP[result.nativeProvider];
+      if (directKeyInfo?.envVar) {
+        const provenance = resolveApiKeyProvenance(directKeyInfo.envVar, directKeyInfo.aliases);
+        console.log("");
+        if (provenance.effectiveValue) {
+          console.log(`  ${DIM}  API Key Resolution:${RESET}`);
+          for (const line of formatProvenanceProbe(provenance, "    ")) {
+            // Colorize the active layer
+            if (line.includes(">>>")) {
+              console.log(`  ${GREEN}${line}${RESET}`);
+            } else {
+              console.log(`  ${DIM}${line}${RESET}`);
+            }
+          }
+        } else {
+          console.log(`  ${RED}  API key: ${directKeyInfo.envVar} not set!${RESET}`);
+        }
+      }
     } else if (result.chain.length === 0) {
       console.log(`  ${RED}  No providers available${RESET} — no credentials configured`);
     } else {
@@ -1520,6 +1548,19 @@ async function probeModelRouting(models: string[], jsonOutput: boolean): Promise
         console.log(
           `\n  ${DIM}  Will use: ${RESET}${GREEN}${firstReady.displayName}${RESET}${DIM} (${readyCount}/${result.chain.length} providers available)${RESET}`
         );
+
+        // Show API key provenance for the active provider
+        if (firstReady.provenance?.effectiveValue) {
+          console.log("");
+          console.log(`  ${DIM}  API Key Resolution:${RESET}`);
+          for (const line of formatProvenanceProbe(firstReady.provenance, "    ")) {
+            if (line.includes(">>>")) {
+              console.log(`  ${GREEN}${line}${RESET}`);
+            } else {
+              console.log(`  ${DIM}${line}${RESET}`);
+            }
+          }
+        }
 
         if (result.wiring) {
           const w = result.wiring;

--- a/packages/cli/src/providers/api-key-provenance.ts
+++ b/packages/cli/src/providers/api-key-provenance.ts
@@ -1,0 +1,178 @@
+/**
+ * API Key Provenance — traces where an API key comes from across all resolution layers.
+ *
+ * Resolution order (first non-empty wins):
+ *   1. process.env (shell profile, e.g. ~/.config/env-keys.sh sourced by .zshenv)
+ *   2. .env file in CWD (loaded by dotenv at startup, does NOT override existing env vars)
+ *   3. ~/.claudish/config.json apiKeys (loaded at startup, does NOT override existing env vars)
+ *
+ * Since dotenv and config.json never override, the value in process.env at runtime
+ * always comes from whichever source set it first. This module inspects all three
+ * sources independently so the user can see what WOULD have been used from each layer.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { parse as parseDotenv } from "dotenv";
+
+export interface KeyLayer {
+  source: string;
+  maskedValue: string | null;
+  isActive: boolean;
+}
+
+export interface KeyProvenance {
+  envVar: string;
+  effectiveValue: string | null;
+  effectiveMasked: string | null;
+  effectiveSource: string;
+  layers: KeyLayer[];
+}
+
+function maskKey(key: string | undefined | null): string | null {
+  if (!key) return null;
+  if (key.length <= 8) return "***";
+  return `${key.substring(0, 8)}...`;
+}
+
+/**
+ * Resolve the provenance of an API key by checking all possible sources.
+ *
+ * @param envVar - Primary env var name (e.g. "GEMINI_API_KEY")
+ * @param aliases - Alternative env var names to check
+ */
+export function resolveApiKeyProvenance(envVar: string, aliases?: string[]): KeyProvenance {
+  const layers: KeyLayer[] = [];
+  const effectiveValue = process.env[envVar] || null;
+  let effectiveSource = "not set";
+
+  // Check all env var names (primary + aliases)
+  const allVars = [envVar, ...(aliases || [])];
+
+  // Layer 1: .env file in CWD
+  const dotenvValue = readDotenvKey(allVars);
+  layers.push({
+    source: `.env (${resolve(".env")})`,
+    maskedValue: maskKey(dotenvValue),
+    isActive: false, // determined below
+  });
+
+  // Layer 2: ~/.claudish/config.json
+  const configValue = readConfigKey(envVar);
+  layers.push({
+    source: `~/.claudish/config.json`,
+    maskedValue: maskKey(configValue),
+    isActive: false,
+  });
+
+  // Layer 3: process.env (final runtime value — includes shell profile, dotenv, config.json)
+  // Check aliases too
+  let runtimeVar = envVar;
+  let runtimeValue = process.env[envVar] || null;
+  if (!runtimeValue && aliases) {
+    for (const alias of aliases) {
+      if (process.env[alias]) {
+        runtimeVar = alias;
+        runtimeValue = process.env[alias]!;
+        break;
+      }
+    }
+  }
+
+  layers.push({
+    source: `process.env[${runtimeVar}]`,
+    maskedValue: maskKey(runtimeValue),
+    isActive: !!runtimeValue,
+  });
+
+  // Determine which source is active
+  if (runtimeValue) {
+    if (dotenvValue && dotenvValue === runtimeValue) {
+      effectiveSource = ".env";
+      layers[0].isActive = true;
+      layers[2].isActive = false;
+    } else if (configValue && configValue === runtimeValue) {
+      effectiveSource = "~/.claudish/config.json";
+      layers[1].isActive = true;
+      layers[2].isActive = false;
+    } else {
+      effectiveSource = "shell environment";
+      // layers[2] already marked active
+    }
+  }
+
+  return {
+    envVar: runtimeVar,
+    effectiveValue: runtimeValue,
+    effectiveMasked: maskKey(runtimeValue),
+    effectiveSource,
+    layers,
+  };
+}
+
+/**
+ * Format provenance for debug log output (single line).
+ */
+export function formatProvenanceLog(p: KeyProvenance): string {
+  if (!p.effectiveValue) {
+    return `${p.envVar}=(not set)`;
+  }
+  return `${p.envVar}=${p.effectiveMasked} [from: ${p.effectiveSource}]`;
+}
+
+/**
+ * Format provenance for --probe TUI output (multi-line with all layers).
+ */
+export function formatProvenanceProbe(
+  p: KeyProvenance,
+  indent: string = "    ",
+): string[] {
+  const lines: string[] = [];
+
+  if (!p.effectiveValue) {
+    lines.push(`${indent}${p.envVar}: not set`);
+    return lines;
+  }
+
+  lines.push(`${indent}${p.envVar} = ${p.effectiveMasked}  [from: ${p.effectiveSource}]`);
+
+  for (const layer of p.layers) {
+    const marker = layer.isActive ? ">>>" : "   ";
+    const value = layer.maskedValue || "(not set)";
+    lines.push(`${indent}  ${marker} ${layer.source}: ${value}`);
+  }
+
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function readDotenvKey(envVars: string[]): string | null {
+  try {
+    const dotenvPath = resolve(".env");
+    if (!existsSync(dotenvPath)) return null;
+    const parsed = parseDotenv(readFileSync(dotenvPath, "utf-8"));
+    for (const v of envVars) {
+      if (parsed[v]) return parsed[v];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function readConfigKey(envVar: string): string | null {
+  try {
+    const configPath = join(homedir(), ".claudish", "config.json");
+    if (!existsSync(configPath)) return null;
+    const cfg = JSON.parse(readFileSync(configPath, "utf-8")) as {
+      apiKeys?: Record<string, string>;
+    };
+    return cfg.apiKeys?.[envVar] || null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/cli/src/providers/provider-profiles.ts
+++ b/packages/cli/src/providers/provider-profiles.ts
@@ -34,6 +34,7 @@ import { DefaultAdapter } from "../adapters/base-adapter.js";
 import { getRegisteredRemoteProviders } from "./remote-provider-registry.js";
 import { getVertexConfig, validateVertexOAuthConfig } from "../auth/vertex-auth.js";
 import { log, logStderr } from "../logger.js";
+import { resolveApiKeyProvenance, formatProvenanceLog } from "./api-key-provenance.js";
 import type { ModelHandler } from "../handlers/types.js";
 
 // ---------------------------------------------------------------------------
@@ -347,5 +348,13 @@ export function createHandlerForProvider(ctx: ProfileContext): ModelHandler | nu
   if (!profile) {
     return null; // Unknown provider — caller should fall through to OpenRouter or return null
   }
+
+  // Log API key provenance so debug logs show exactly which key is used and where it came from
+  if (ctx.provider.apiKeyEnvVar) {
+    const provenance = resolveApiKeyProvenance(ctx.provider.apiKeyEnvVar);
+    log(`[Proxy] API key: ${formatProvenanceLog(provenance)}`);
+  }
+  log(`[Proxy] Handler: provider=${ctx.provider.name}, model=${ctx.modelName}`);
+
   return profile.createHandler(ctx);
 }


### PR DESCRIPTION
## Summary
- New `resolveApiKeyProvenance()` utility traces API keys across all resolution layers (shell env, `.env`, `~/.claudish/config.json`)
- `--debug` logs now show which API key is used and where it came from: `[Proxy] API key: GEMINI_API_KEY=AIzaSyBb... [from: shell environment]`
- `--probe` shows the full resolution chain with `>>>` marking the active source
- Moved `API_KEY_MAP` out of the per-model loop in probe for correctness

## Test plan
- [x] `bun run build` passes
- [x] `claudish --probe google@gemini-3.1-pro-preview` shows provenance layers
- [x] `claudish --probe gemini-3.1-pro-preview` shows provenance for auto-routed chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)