### PR TITLE
fix: add glm-5.1 to model catalog

### DIFF
--- a/packages/cli/src/adapters/model-catalog.ts
+++ b/packages/cli/src/adapters/model-catalog.ts
@@ -39,6 +39,7 @@ export const MODEL_CATALOG: ModelEntry[] = [
   { pattern: "grok", contextWindow: 131_072 },
 
   // ── GLM ─────────────────────────────────────────────
+  { pattern: "glm-5.1", contextWindow: 128_000, supportsVision: true },
   { pattern: "glm-5-turbo", contextWindow: 202_752 },
   { pattern: "glm-5", contextWindow: 80_000, supportsVision: true },
   { pattern: "glm-4.7-flash", contextWindow: 202_752 },

--- a/packages/cli/src/e2e-model-catalog.test.ts
+++ b/packages/cli/src/e2e-model-catalog.test.ts
@@ -50,6 +50,13 @@ describe("Group 1: Model Catalog — lookupModel()", () => {
     expect(entry!.temperatureRange).toBeUndefined();
   });
 
+  test("glm-5.1 → contextWindow 128000, supportsVision true", () => {
+    const entry = lookupModel("glm-5.1");
+    expect(entry).toBeDefined();
+    expect(entry!.contextWindow).toBe(128_000);
+    expect(entry!.supportsVision).toBe(true);
+  });
+
   test("glm-5 → contextWindow 80000, supportsVision true", () => {
     const entry = lookupModel("glm-5");
     expect(entry).toBeDefined();


### PR DESCRIPTION
## Problem

When using `glm-5.1` model via claudish, the status line shows wrong context usage (always 100%) because `glm-5.1` is not in the model catalog. It falls through to the generic `glm-` fallback which has 131k context window - probably not matching the real context window of the model.

The claudish-bot comment on #90 already identified this: "glm-5.1 isn't in the model catalog yet — only glm-5 and glm-4.7 are listed."

## Fix

Added `glm-5.1` entry to the model catalog in `model-catalog.ts`:

```typescript
{ pattern: "glm-5.1", contextWindow: 128_000, supportsVision: true },
```

Placed before `glm-5-turbo` and `glm-5` entries (catalog is ordered by specificity, first match wins) so `glm-5.1` matches exactly instead of falling through to the shorter `glm-5` pattern.

Set `supportsVision: true` same as `glm-5` since the 5.x series supports vision.

Also added a test case in `e2e-model-catalog.test.ts` verifying the new entry returns correct context window and vision support.

## Note

This addresses only part of #90 (the model catalog gap). The other parts (model name display from token file, and usage tracking for Z.AI provider) are separate issues that need investigation with `--debug` logs as the bot suggested.

Ref #90