### PR TITLE
fix: update OpenAI API path to be provider agnostic

### DIFF
--- a/packages/cli/src/providers/provider-definitions.ts
+++ b/packages/cli/src/providers/provider-definitions.ts
@@ -143,7 +143,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     tokenStrategy: "delta-aware",
     baseUrl: "https://api.openai.com",
     baseUrlEnvVars: ["OPENAI_BASE_URL"],
-    apiPath: "/v1/chat/completions",
+    apiPath: "/chat/completions",
     apiKeyEnvVar: "OPENAI_API_KEY",
     apiKeyDescription: "OpenAI API Key",
     apiKeyUrl: "https://platform.openai.com/api-keys",


### PR DESCRIPTION
This pull request makes a small change to the OpenAI provider configuration. The `apiPath` for the OpenAI API has been updated to use `/chat/completions` instead of `/v1/chat/completions`. This is to handle custom providers which do not work with /v1/ endpoint, like kilo gateway.

- Changed the `apiPath` for the OpenAI provider in `provider-definitions.ts` from `/v1/chat/completions` to `/chat/completions`.