### PR TITLE
fix: strip x-anthropic-billing-header to fix vLLM prefix caching

### DIFF
--- a/packages/cli/src/handlers/shared/format/identity-filter.test.ts
+++ b/packages/cli/src/handlers/shared/format/identity-filter.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from "bun:test";
+import { filterIdentity } from "./identity-filter.js";
+
+describe("filterIdentity", () => {
+  describe("x-anthropic-billing-header stripping", () => {
+    it("strips billing header with cch hash", () => {
+      const input = "Some system prompt\nx-anthropic-billing-header: cc_version=2.1.92.a35; cc_entrypoint=cli; cch=8ae40;\nMore content";
+      const result = filterIdentity(input);
+      expect(result).not.toContain("x-anthropic-billing-header");
+      expect(result).toContain("More content");
+    });
+
+    it("strips billing header with different cch values", () => {
+      const result1 = filterIdentity("prefix\nx-anthropic-billing-header: cc_version=2.1.92; cch=8ae40;\nsuffix");
+      const result2 = filterIdentity("prefix\nx-anthropic-billing-header: cc_version=2.1.92; cch=4e20a;\nsuffix");
+      // After stripping, both should produce identical output
+      expect(result1).toBe(result2);
+    });
+
+    it("handles header at start of content", () => {
+      const input = "x-anthropic-billing-header: cc_version=2.1.92; cch=abc;\nRest of prompt";
+      const result = filterIdentity(input);
+      expect(result).not.toContain("x-anthropic-billing-header");
+      expect(result).toContain("Rest of prompt");
+    });
+
+    it("handles header at end of content without trailing newline", () => {
+      const input = "Some prompt\nx-anthropic-billing-header: cc_version=2.1.92; cch=abc;";
+      const result = filterIdentity(input);
+      expect(result).not.toContain("x-anthropic-billing-header");
+    });
+
+    it("preserves surrounding content intact", () => {
+      const input = "Line 1\nx-anthropic-billing-header: cc_version=2.1.92; cch=abc;\nLine 3";
+      const result = filterIdentity(input);
+      expect(result).toContain("Line 1");
+      expect(result).toContain("Line 3");
+    });
+  });
+
+  describe("Claude identity replacement", () => {
+    it("replaces Claude Code identity", () => {
+      const result = filterIdentity("You are Claude Code, Anthropic's official CLI tool.");
+      expect(result).toContain("This is Claude Code, an AI-powered CLI tool");
+      expect(result).not.toContain("Anthropic's official CLI");
+    });
+
+    it("replaces model name reference", () => {
+      const result = filterIdentity("You are powered by the model named Claude 3.5 Sonnet.");
+      expect(result).toContain("You are powered by an AI model.");
+    });
+
+    it("strips claude_background_info blocks", () => {
+      const result = filterIdentity("Before\n<claude_background_info>secret</claude_background_info>\nAfter");
+      expect(result).not.toContain("claude_background_info");
+      expect(result).not.toContain("secret");
+    });
+
+    it("prepends non-Claude identity instruction", () => {
+      const result = filterIdentity("Hello");
+      expect(result).toMatch(/^IMPORTANT: You are NOT Claude/);
+    });
+  });
+});

--- a/packages/cli/src/handlers/shared/format/identity-filter.ts
+++ b/packages/cli/src/handlers/shared/format/identity-filter.ts
@@ -10,6 +10,9 @@
  */
 export function filterIdentity(content: string): string {
   return content
+    // Strip Anthropic billing header — contains a per-turn hash (cch=) that
+    // breaks vLLM prefix caching by making the system prompt differ every turn
+    .replace(/x-anthropic-billing-header:[^\n]*\n?/g, "")
     .replace(
       /You are Claude Code, Anthropic's official CLI/gi,
       "This is Claude Code, an AI-powered CLI tool"


### PR DESCRIPTION
## Summary

- Strip `x-anthropic-billing-header` from system prompts in `filterIdentity` to fix vLLM prefix caching
- Add unit tests for the identity filter

## Problem

Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=<hash>` into the system prompt on every turn. The `cch` (conversation context hash) changes per turn, making the system prompt tokens differ between requests. This breaks vLLM's prefix cache for the **entire** ~31k token prompt — reducing cache hits from 99% to 0.15% (only 48 tokens cached).

## Root Cause Analysis

1. Sent 4 identical "test" messages via claudish → MiniMax M2.5 on vLLM
2. VictoriaMetrics showed prefix cache metrics were healthy (~50% cluster-wide)
3. But per-request `cached_tokens` was stuck at 48 out of ~31k
4. Dumped full request payloads and diffed between turns
5. Found the only difference: `cch=8ae40` → `cch=4e20a` → `cch=ad80e` in the system prompt

## Fix

Added `.replace(/x-anthropic-billing-header:[^\n]*\n?/g, "")` as the first filter in `filterIdentity()`. This is safe because `filterIdentity` only runs for non-Anthropic providers (OpenAI-compat, Gemini, LiteLLM, OpenRouter, local) — never for native Anthropic passthrough where the header is meaningful.

## Validation

Before fix: `cached_tokens` = 48 / 31k on every turn (0.15%)
After fix: `cached_tokens` = 31,728 / 31,749 by 4th turn (99.9%)

| Turn | Before Fix | After Fix |
|------|-----------|-----------|
| 1st | 48 (0.15%) | 32 (cold) |
| 2nd | 48 (0.15%) | 24,864 (79%) |
| 3rd | 48 (0.15%) | 31,296 (99%) |
| 4th | 48 (0.15%) | 31,728 (99.9%) |

## Test plan

- [x] `bun test identity-filter.test.ts` — 9 tests pass
- [x] `bun run build` — compiles clean
- [ ] Manual: run claudish with `--debug`, send "test" twice, verify `cached_tokens` grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)