### PR TITLE
fix: default to interactive mode when only flags are passed (no prompt)

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -366,12 +366,16 @@ export async function parseArgs(args: string[]): Promise<ClaudishConfig> {
       config.claudeArgs.push(arg);
       if (i + 1 < args.length && !args[i + 1].startsWith("-")) {
         config.claudeArgs.push(args[++i]);
+        // The consumed value is a flag argument, not a positional prompt.
+        // Mark it so the interactive-mode detection below doesn't mistake it for one.
+        config._hasFlagValue = true;
       }
     } else {
       // Positional argument (prompt text): pass through to Claude Code in order.
       // Example: claudish --model grok "hello world"
       //          → claudeArgs = ['hello world']
       config.claudeArgs.push(arg);
+      config._hasPositionalPrompt = true;
     }
 
     i++;
@@ -380,7 +384,10 @@ export async function parseArgs(args: string[]): Promise<ClaudishConfig> {
   // Determine if this will be interactive mode BEFORE API key check
   // If no prompt provided and not explicitly interactive, default to interactive mode
   // Exception: --stdin mode reads prompt from stdin, so don't default to interactive
-  if ((!config.claudeArgs || config.claudeArgs.length === 0) && !config.stdin) {
+  // A "prompt" is a positional arg that appears outside of flag-value pairs.
+  // Flags like "--session-id uuid --dangerously-skip-permissions" have no prompt,
+  // so they should be interactive too.
+  if (!config._hasPositionalPrompt && !config.stdin) {
     config.interactive = true;
   }
 

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -21,6 +21,8 @@ export interface ClaudishConfig {
   freeOnly?: boolean; // Show only free models in selector
   profile?: string; // Profile name to use for model mapping
   claudeArgs: string[];
+  _hasPositionalPrompt?: boolean; // Internal: true when a positional prompt arg was found (not a flag value)
+  _hasFlagValue?: boolean; // Internal: true when a flag consumed a value (not a prompt)
 
   // Model Mapping
   modelOpus?: string;


### PR DESCRIPTION
When claudish receives only flags like --session-id and --dangerously-skip-permissions without a positional prompt argument, it incorrectly defaulted to single-shot mode, adding -p (print mode) to the claude invocation. This caused "Input must be provided either through stdin or as a prompt argument when using --print" errors.

Track whether a positional prompt was found during arg parsing (_hasPositionalPrompt) instead of checking claudeArgs.length, since flag values (e.g. a UUID) don't start with '-' but aren't prompts either.