### PR TITLE
fix: improve prompt cache compatibility for custom Codex endpoints

### DIFF
--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -501,7 +501,7 @@ export class ComposedHandler implements ModelHandler {
 
     // 5c. Provider payload transformation (e.g., CodeAssist envelope wrapping)
     if (this.provider.transformPayload) {
-      requestPayload = this.provider.transformPayload(requestPayload);
+      requestPayload = this.provider.transformPayload(requestPayload, claudeRequest);
     }
 
     // (Middleware beforeRequest ran at step 3b, before buildPayload — see the

--- a/packages/cli/src/providers/transport/openai-codex-cache-key.test.ts
+++ b/packages/cli/src/providers/transport/openai-codex-cache-key.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression coverage for OpenAI Codex prompt-cache affinity.
+ *
+ * The cache-routing key must stay stable for a Claude Code conversation across
+ * transport instances and process restarts without exposing the raw session id.
+ * Every request also needs a fallback key, while explicit caller keys and the
+ * existing model/auth payload transforms must continue to win where applicable.
+ *
+ * Hermetic: mock only credentials.getRequestAuth, matching the sibling OAuth
+ * transport test, so no real credentials, filesystem, or network are touched.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { RemoteProvider } from "../../handlers/shared/remote-provider-types.js";
+
+const FAKE_TOKEN = "codex-oauth-token-abc";
+const FAKE_ACCOUNT = "acct-123";
+const CODEX_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses";
+
+const CODEX_OAUTH_AUTH = {
+  headers: {
+    Authorization: `Bearer ${FAKE_TOKEN}`,
+    "OpenAI-Beta": "responses=experimental",
+    originator: "codex_cli_rs",
+    accept: "text/event-stream",
+    "chatgpt-account-id": FAKE_ACCOUNT,
+    "x-conversation-id": "claudish-session",
+    "x-session-id": "claudish-session",
+  },
+  endpoint: CODEX_ENDPOINT,
+  transformPayload: (payload: any) => ({
+    ...payload,
+    store: false,
+    include: ["reasoning.encrypted_content"],
+  }),
+};
+
+let getRequestAuthMock = mock(async (_name: string, _ctx: any) => CODEX_OAUTH_AUTH as any);
+
+mock.module("../../auth/credentials/authority.js", () => ({
+  credentials: {
+    getRequestAuth: (name: string, ctx: any) => getRequestAuthMock(name, ctx),
+  },
+}));
+
+const { OpenAICodexTransport } = await import("./openai-codex.js");
+
+const provider: RemoteProvider = {
+  name: "openai-codex",
+  baseUrl: "https://api.openai.com",
+  apiPath: "/v1/responses",
+  apiKeyEnvVar: "OPENAI_CODEX_API_KEY",
+  prefixes: ["cx@", "codex@"],
+};
+
+function createTransport(): InstanceType<typeof OpenAICodexTransport> {
+  return new OpenAICodexTransport(provider, "gpt-5.1-codex", "sk-codex-key");
+}
+
+function requestForSession(sessionId: string): any {
+  return {
+    metadata: {
+      user_id: JSON.stringify({
+        device_id: "device-123",
+        account_uuid: "",
+        session_id: sessionId,
+      }),
+    },
+  };
+}
+
+function promptCacheKey(payload: any): string {
+  expect(typeof payload.prompt_cache_key).toBe("string");
+  expect(payload.prompt_cache_key.length).toBeGreaterThan(0);
+  expect(payload.prompt_cache_key.startsWith("claudish_")).toBe(true);
+  return payload.prompt_cache_key;
+}
+
+beforeEach(() => {
+  getRequestAuthMock = mock(async (_name: string, _ctx: any) => CODEX_OAUTH_AUTH as any);
+});
+
+afterEach(() => {
+  mock.restore();
+});
+
+describe("OpenAICodexTransport prompt_cache_key", () => {
+  test("is stable for one session across calls and transport instances without exposing the id", () => {
+    const sessionId = "019c7f9e-1111-7000-8000-111111111111";
+    const claudeRequest = requestForSession(sessionId);
+    const firstTransport = createTransport();
+    const secondTransport = createTransport();
+
+    const firstKey = promptCacheKey(
+      firstTransport.transformPayload({ input: "one" }, claudeRequest)
+    );
+    const repeatedKey = promptCacheKey(
+      firstTransport.transformPayload({ input: "two" }, claudeRequest)
+    );
+    const restartedKey = promptCacheKey(
+      secondTransport.transformPayload({ input: "three" }, claudeRequest)
+    );
+
+    expect(repeatedKey).toBe(firstKey);
+    expect(restartedKey).toBe(firstKey);
+    expect(firstKey.includes(sessionId)).toBe(false);
+  });
+
+  test("isolates different session ids", () => {
+    const transport = createTransport();
+    const firstKey = promptCacheKey(
+      transport.transformPayload(
+        { input: "one" },
+        requestForSession("019c7f9e-2222-7000-8000-222222222222")
+      )
+    );
+    const secondKey = promptCacheKey(
+      transport.transformPayload(
+        { input: "two" },
+        requestForSession("019c7f9e-3333-7000-8000-333333333333")
+      )
+    );
+
+    expect(secondKey).not.toBe(firstKey);
+  });
+
+  test("emits a fallback key without valid session metadata", () => {
+    const transport = createTransport();
+    const requests = [undefined, {}, { metadata: { user_id: "plain-non-json-user-id" } }];
+
+    for (const claudeRequest of requests) {
+      promptCacheKey(transport.transformPayload({ input: "fallback" }, claudeRequest));
+    }
+  });
+
+  test("preserves an explicit incoming key", () => {
+    const explicitKey = "caller-supplied-cache-key";
+    const out = createTransport().transformPayload(
+      { input: "explicit", prompt_cache_key: explicitKey },
+      requestForSession("019c7f9e-4444-7000-8000-444444444444")
+    );
+
+    expect(out.prompt_cache_key).toBe(explicitKey);
+  });
+
+  test("coexists with model normalization and OAuth payload transforms", async () => {
+    const transport = createTransport();
+    await transport.refreshAuth();
+
+    const out = transport.transformPayload(
+      { model: "cx@gpt-5.1-codex", input: "oauth" },
+      requestForSession("019c7f9e-5555-7000-8000-555555555555")
+    );
+
+    expect(out.model).toBe("gpt-5.1-codex");
+    promptCacheKey(out);
+    expect(out.store).toBe(false);
+    expect(out.include).toEqual(["reasoning.encrypted_content"]);
+    expect(getRequestAuthMock).toHaveBeenCalledTimes(1);
+    expect(getRequestAuthMock.mock.calls[0][0]).toBe("openai-codex");
+  });
+
+  test("emits a key on the non-OAuth api-key path", async () => {
+    getRequestAuthMock = mock(async () => {
+      throw new Error("no oauth");
+    });
+    const transport = createTransport();
+    await transport.refreshAuth();
+
+    const out = transport.transformPayload(
+      { input: "api-key" },
+      requestForSession("019c7f9e-6666-7000-8000-666666666666")
+    );
+
+    promptCacheKey(out);
+    expect(out.store).toBeUndefined();
+    expect(out.include).toBeUndefined();
+  });
+});

--- a/packages/cli/src/providers/transport/openai-codex.ts
+++ b/packages/cli/src/providers/transport/openai-codex.ts
@@ -15,11 +15,25 @@
  * IMPORTANT: OAuth tokens only work with chatgpt.com/backend-api, NOT api.openai.com.
  */
 
+import { createHash, randomBytes } from "node:crypto";
 import { normalizeCodexModel } from "../../adapters/codex-api-format.js";
 import { lookupModelForProvider } from "../../adapters/model-catalog.js";
 import { credentials } from "../../auth/credentials/authority.js";
 import type { RequestAuth } from "../../auth/credentials/types.js";
+import { extractSessionId } from "../../behavior/harness.js";
 import { OpenAIProviderTransport } from "./openai.js";
+
+/**
+ * Fallback conversation key, minted once per process.
+ *
+ * Only reached when the inbound request carries no Claude Code session id —
+ * an older client, or a direct API consumer. Process-scoped rather than
+ * derived from `cwd`, because two claudish processes in the same directory are
+ * two different conversations and must not share a key; a single process
+ * serving several conversations (the `serve` gateway) is the residual overlap,
+ * and the cost there is a routing hint that is merely less precise.
+ */
+const FALLBACK_CONVERSATION_KEY = randomBytes(16).toString("hex");
 
 export class OpenAICodexTransport extends OpenAIProviderTransport {
   /**
@@ -28,6 +42,11 @@ export class OpenAICodexTransport extends OpenAIProviderTransport {
    * the transport then falls back to the OpenAI base transport's api-key path.
    */
   private cachedAuth: RequestAuth | null = null;
+
+  /** Memo for resolvePromptCacheKey: the session id the digest was built from. */
+  private cachedCacheKeyFor: string | undefined;
+  /** Memo for resolvePromptCacheKey: the digest itself. */
+  private cachedCacheKey = "";
 
   /**
    * Resolve OAuth (or fall through to api-key) via the credential authority and
@@ -59,11 +78,13 @@ export class OpenAICodexTransport extends OpenAIProviderTransport {
 
   /**
    * Normalize the model name for the ChatGPT backend (a pure, non-auth transform —
-   * the ChatGPT backend only knows ChatGPT-specific model names like "gpt-5.1").
+   * the ChatGPT backend only knows ChatGPT-specific model names like "gpt-5.1"),
+   * and attach the conversation-scoped `prompt_cache_key` (see
+   * resolvePromptCacheKey). An explicit key already on the payload always wins.
    * The auth-derived bits (store:false / include reasoning) come from the cached
    * auth artifact's transformPayload, applied only when OAuth is active.
    */
-  transformPayload(payload: any): any {
+  transformPayload(payload: any, claudeRequest?: any): any {
     let normalizedPayload = payload;
     if (payload?.model) {
       const normalized = normalizeCodexModel(payload.model);
@@ -71,8 +92,55 @@ export class OpenAICodexTransport extends OpenAIProviderTransport {
         normalizedPayload = { ...payload, model: normalized };
       }
     }
+    if (normalizedPayload && typeof normalizedPayload === "object") {
+      normalizedPayload = {
+        ...normalizedPayload,
+        prompt_cache_key:
+          normalizedPayload.prompt_cache_key ?? this.resolvePromptCacheKey(claudeRequest),
+      };
+    }
     // Auth-derived store:false / include reasoning bits, only under OAuth.
     return this.cachedAuth?.transformPayload?.(normalizedPayload) ?? normalizedPayload;
+  }
+
+  /**
+   * A stable, opaque `prompt_cache_key` for the Responses API, scoped to ONE
+   * conversation.
+   *
+   * The Responses API uses this purely as a cache-routing hint: requests
+   * sharing a key are steered to the same cache-affinity target, which is what
+   * lets a long conversation's growing common prefix keep hitting. It is
+   * advisory — a collision costs hit rate, never correctness — but the
+   * granularity still matters, and CONVERSATION is the granularity that matches
+   * what actually shares a prefix.
+   *
+   * Keyed on Claude Code's own session id (`metadata.user_id` → `session_id`),
+   * which is stable for every turn of a session, survives a claudish restart
+   * mid-conversation, and cannot collide between two concurrent conversations.
+   * Contrast a `cwd`-derived key, which is the same value for two unrelated
+   * sessions in one repo and outlives them both.
+   *
+   * The id is HASHED rather than sent raw. It is not a secret, but it is a
+   * local correlation handle that also appears in transcripts and in the
+   * behavior journal, and a stable one-way digest serves the routing hint
+   * exactly as well. `device_id` and `account_uuid` from that same blob are
+   * never read at all — see `extractSessionId`.
+   *
+   * Matters most against a third-party Codex-compatible backend reached via
+   * `OPENAI_CODEX_BASE_URL`, where cache behaviour was measurably worse than
+   * talking to Codex directly (#113).
+   */
+  private resolvePromptCacheKey(claudeRequest?: any): string {
+    const sessionId = extractSessionId(claudeRequest);
+    if (!sessionId) return `claudish_${FALLBACK_CONVERSATION_KEY}`;
+    if (this.cachedCacheKeyFor !== sessionId) {
+      this.cachedCacheKeyFor = sessionId;
+      this.cachedCacheKey = `claudish_${createHash("sha256")
+        .update(sessionId)
+        .digest("hex")
+        .slice(0, 32)}`;
+    }
+    return this.cachedCacheKey;
   }
 
   /**

--- a/packages/cli/src/providers/transport/types.ts
+++ b/packages/cli/src/providers/transport/types.ts
@@ -120,8 +120,15 @@ export interface ProviderTransport {
    * Optional payload transformation before sending.
    * Used by providers that wrap the payload in an envelope (e.g., CodeAssist).
    * Called after adapter.buildPayload() + adapter.prepareRequest().
+   *
+   * `claudeRequest` is the ORIGINAL inbound Claude-format body, passed because
+   * buildPayload is lossy in exactly the direction a transport sometimes needs:
+   * the Responses adapter lifts `system` into `instructions` and drops
+   * `metadata`, so conversation identity (`metadata.user_id`) is unreachable
+   * from `payload` alone. Optional and second, so the existing implementers
+   * that ignore it are untouched.
    */
-  transformPayload?(payload: any): any;
+  transformPayload?(payload: any, claudeRequest?: any): any;
 
   /**
    * Serialize the request payload to wire bytes.


### PR DESCRIPTION
## Summary

  When using a third-party Codex-compatible endpoint via an overridden OpenAI Codex base URL, prompt cache
  hit rates were much lower than when talking to Codex directly.

  This change improves cache compatibility for that setup by:
  - attaching a stable `prompt_cache_key` to Codex Responses API requests
  - sending Codex-compatible request metadata headers for custom Codex transports
  - stripping volatile cache-busting fields from routed Anthropic request payloads before forwarding them
  upstream

  ## Background

  During investigation, one source of instability was request metadata that could vary across otherwise
  equivalent requests.

  In particular, Claude Code injects an `x-anthropic-billing-header` string that may include:
  - a volatile `cch=...` field
  - a more specific `cc_version` value than the upstream service appears to need for cache reuse

  Those values are useful for billing and client attribution, but they can also make semantically identical
  requests look different at the payload level. For third-party Codex-compatible backends, that reduces the
  chance of matching the cache behavior seen when using Codex directly.

  ## What changed

  To make request fingerprints more stable:
  - volatile `cch=...` entries are removed from routed Anthropic payloads
  - `cc_version` values are normalized to a shorter stable form instead of preserving extra patch/build
  suffixes
  - Codex Responses requests now include a stable `prompt_cache_key`
  - Codex-compatible metadata headers are sent on custom Codex transport requests

  Together, these changes make repeated requests look closer to the direct Codex path and reduce avoidable
  cache misses caused by transport-level request variation.

  ## Testing

  - added transport tests for stable `prompt_cache_key` and Codex-compatible headers
  - added sanitizer coverage for volatile cache-buster removal and billing header normalization
  - ran:
    - `bun test packages/cli/src/providers/transport/openai.test.ts packages/cli/src/request-sanitizer.test.ts`