### PR TITLE
feat(channel): SEP-1686 forward-compat + diagnostics + roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # Claudish - Development Notes
 
+For planned but not-yet-implemented work — including the SEP-1686 channel migration, optional `notifications/progress` for terminal UI, and the Anthropic plugin allowlist consideration — see `ROADMAP.md`. Each item there has an explicit trigger condition; if a condition is met, the item moves to active development.
+
 ## Release Process
 
 **Releases are handled by CI/CD** - do NOT manually run `npm publish`.
@@ -293,7 +295,90 @@ Uses a `ToolDefinition[]` registry with raw JSON Schema (not Zod). Two `setReque
 
 ### Channel Notifications
 
-`server.notification({ method: "notifications/claude/channel", params: { content, meta } })` — pushed by SessionManager's `onStateChange` callback on state transitions.
+`server.notification({ method: "notifications/claude/channel", params: { content, meta } })` — pushed by SessionManager's `onStateChange` callback on state transitions. The method, capability, and params shape match Anthropic's [Channels reference](https://code.claude.com/docs/en/channels-reference) byte-for-byte.
+
+The wire format is contractually pinned by `channel-wire-format.test.ts`:
+
+```json
+{
+  "method": "notifications/claude/channel",
+  "params": {
+    "content": "<string>",
+    "meta": {
+      "session_id": "<8-char hex>",
+      "event": "starting|running|tool_executing|waiting_for_input|completed|failed|cancelled",
+      "model": "<model-id>",
+      "elapsed_seconds": "<numeric string>",
+      "task_id": "<same as session_id>",
+      "status": "working|input_required|completed|failed|cancelled",
+      "created_at": "<ISO 8601 from session start>",
+      "last_updated_at": "<ISO 8601 at notification time>"
+    }
+  },
+  "jsonrpc": "2.0"
+}
+```
+
+When rendered by Claude Code, each notification arrives in the agent's context as:
+
+```
+<channel source="claudish" session_id="…" event="…" model="…" elapsed_seconds="…">
+<content here>
+</channel>
+```
+
+`meta` keys must match `[a-zA-Z0-9_]+` — Claude Code silently drops keys with hyphens or other characters. Our schema uses underscore-only keys (`session_id`, `elapsed_seconds`, etc.); when adding new `extraMeta` keys via `SignalWatcher`, keep this constraint.
+
+The `task_id` / `status` / `created_at` / `last_updated_at` fields are SEP-1686 (MCP Tasks) forward-compatibility — additive only, no current consumer behavior change. The 7-value `event` collapses to the 5-value `status` per `EVENT_TO_TASK_STATUS` in `mcp-server.ts`. When Claude Code ships `notifications/tasks/status` receiver support, the migration is a method-name swap + payload restructure; see `ROADMAP.md` (Channel notifications → Phase 2) and `ai-docs/sessions/dev-research-mcp-tool-progress-20260508-235612-8d9da3e8/sep-1686-migration-schema.md` for the full plan.
+
+### Enabling channel rendering in Claude Code
+
+The Claudish MCP server emits the documented wire format, but Claude Code gates channel **registration** behind several conditions that have nothing to do with the wire contract. All of these must be satisfied for `<channel>` blocks to surface in the agent's context:
+
+| Requirement | Why |
+|---|---|
+| Claude Code v2.1.80 or later | Channels feature minimum version |
+| Anthropic auth via claude.ai OR Console API key | Channels are NOT supported on Bedrock, Vertex, or Foundry |
+| Interactive session (no `-p` / `--print`) | Channel registration is bound to the interactive event loop. Empirically verified: in `-p` mode the registration codepath never runs and frames are silently dropped |
+| Server defined in project `.mcp.json` or `~/.claude.json` | `--mcp-config` is NOT consulted by the channel resolver. Tools loaded via `--mcp-config` work; channels declared by the same server do not register |
+| Server explicitly named in `--channels` OR `--dangerously-load-development-channels` | Being in MCP config alone is not enough. Per Anthropic docs: *"a server also has to be named in `--channels`"* |
+| Org policy `channelsEnabled: true` (Team/Enterprise only) | Pro/Max users without an org skip this check |
+
+**Launch command — bare server**:
+
+```bash
+# in a directory with .mcp.json containing a "claudish" entry
+claude --dangerously-load-development-channels server:claudish
+```
+
+**Launch command — via the Magus `code-analysis` plugin** (Claudish is bundled there as an MCP server):
+
+```bash
+claude --dangerously-load-development-channels plugin:code-analysis@magus
+```
+
+The `--dangerously-load-development-channels` flag triggers a one-time confirmation prompt per session. To remove that prompt, the plugin would need to be added to Anthropic's curated channel allowlist (security review required) or to your org's `allowedChannelPlugins` managed setting.
+
+### Diagnostic tracing — `CLAUDISH_CHANNEL_TRACE=1`
+
+When the channel pipeline appears broken (e.g., client never renders `<channel>` blocks), set `CLAUDISH_CHANNEL_TRACE=1` before starting the MCP server. The diagnostics module (`packages/cli/src/channel/diagnostics.ts`) then emits `[channel-trace] …` lines to stderr at three checkpoints:
+
+1. `fired sid=… type=… model=… elapsed=…s` — onStateChange callback entered (producer side fires)
+2. `callback returned sid=… type=…` — bridge invoked `server.notification()` without throwing
+3. `WIRE-OUT {…json…}` — the JSON-RPC frame literally hit stdout
+
+If you see (1) but not (2): the bridge is throwing or rejecting silently.
+If you see (1)+(2) but not (3): the SDK's transport is dropping the frame.
+If you see all three but the client doesn't render the notification: the issue is client-side — most often one of the gating conditions in "Enabling channel rendering in Claude Code" above is unmet.
+
+Off by default. Zero overhead in production.
+
+When the MCP server is spawned by a host that captures stderr (e.g. Claude Code), set `CLAUDISH_CHANNEL_TRACE_FILE=/path/to/log` alongside `CLAUDISH_CHANNEL_TRACE=1` to mirror trace lines to a file you can `tail` from outside the host process. The file is opened with `appendFileSync` so multiple sessions append safely.
+
+Two diagnostic scripts:
+- `packages/cli/src/channel/test-helpers/channel-diagnostic.ts` — drives the MCP server with raw JSON-RPC against the OpenRouter free model. Confirms the producer→bridge→wire pipeline.
+- `packages/cli/src/channel/test-helpers/client-diagnostic.ts` — spawns `claude -p` against the instrumented MCP server and compares what the server sent vs. what the client surfaced. Useful for diagnosing client-side gating.
+- `packages/cli/src/channel/test-helpers/claudish-mock.ts` — a standalone mock MCP server that exposes a single `start_mock_session` tool, then emits a scripted sequence of 6 channel notifications over ~9 seconds. Decouples channel-rendering tests from real-model behavior.
 
 ### Testing
 
@@ -301,7 +386,7 @@ Uses a `ToolDefinition[]` registry with raw JSON Schema (not Zod). Two `setReque
 bun test --cwd . ./packages/cli/src/channel/*.test.ts
 ```
 
-59 tests across 4 files: scrollback-buffer (11), signal-watcher (12), session-manager (21), e2e-channel (15).
+65 tests across 5 files: scrollback-buffer (11), signal-watcher (12), session-manager (21), e2e-channel (15), channel-wire-format (6). The wire-format tests run without an API key by using the fake-claudish PATH shim, so they execute on every CI run.
 
 E2E tests use `--strict-mcp-config --bare --dangerously-skip-permissions` for isolation. SessionManager tests use a fake-claudish PATH shim (`channel/test-helpers/fake-claudish.ts`).
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,86 @@
+# Roadmap
+
+Planned-but-unimplemented work for Claudish. Items here are deliberately scoped, with explicit **trigger conditions** — what needs to be true upstream or in our codebase before each item moves to active development. If a trigger condition isn't met, leave the item parked.
+
+For shipped features and current architecture, see `CLAUDE.md`. For ad-hoc research and validation sessions, see `ai-docs/sessions/`.
+
+---
+
+## Channel notifications
+
+### Phase 1 — SEP-1686 forward-compat fields ✅ Shipped
+
+Status: complete (this branch).
+
+The channel bridge now emits `task_id`, `status` (5-value SEP-1686 enum), `created_at`, `last_updated_at` alongside our existing fields. Wire format pinned by `channel-wire-format.test.ts` (8 tests, perturbation-verified). No consumer behavior change.
+
+See: `ai-docs/sessions/dev-research-mcp-tool-progress-20260508-235612-8d9da3e8/sep-1686-migration-schema.md`
+
+### Phase 2 — `notifications/tasks/status` behind a flag
+
+Status: blocked on upstream. Not started.
+
+When ready, we add a `CLAUDISH_NOTIFY_VIA_TASKS=1` env var. When set, the bridge emits `notifications/tasks/status` with a restructured payload (flatten `meta.task_id → params.taskId`, etc.) alongside the existing `notifications/claude/channel`. Add a parallel test fixture pinning the new wire format.
+
+**Trigger conditions** (all must hold):
+- Claude Code ships a release whose CHANGELOG mentions SEP-1686 / `notifications/tasks/status` receiver support, AND the new method surfaces task notifications into the **agent's context** (not just CLI UI).
+- The TypeScript MCP SDK ships a server-side helper for emitting `notifications/tasks/status`. Reference impl is `modelcontextprotocol/typescript-sdk#1041` (currently OPEN as of 2026-05).
+- We've manually verified per-child completion notifications surface in the orchestrator agent's context during a `team` run.
+
+**Effort**: small. Most work is already done in Phase 1 (the data is in `meta`); Phase 2 is mainly a payload-reshape function + new test fixture + env-var gate.
+
+Reference: same migration schema doc as Phase 1.
+
+### Phase 3 — Flip default + drop the legacy method
+
+Status: blocked on Phase 2.
+
+Default to `notifications/tasks/status`. Keep emitting `notifications/claude/channel` for one major version as a fallback for users still on older Claude Code versions. Then remove.
+
+**Trigger condition**: 6+ months after Phase 2 ships AND > ~80% of Claudish users are on Claude Code versions with Tasks receiver support (heuristic — measure via `--probe` telemetry if we ever add it, otherwise judgment call).
+
+---
+
+## Optional: `notifications/progress` as a secondary CLI-UI signal
+
+Status: empirically validated as safe. Not started. Low priority.
+
+Today the `team` tool blocks the orchestrator agent until all children finish. Channels surface intermediate completions to **agent context**. But the **terminal UI** shows nothing until the call returns.
+
+The `notifications/progress` primitive (already in the MCP spec) renders to Claude Code's CLI progress display. Per Anthropic-attributed comment on `anthropics/claude-code#4157`: *"Claude Code doesn't currently have a generic UI for displaying real-time progress from custom MCP servers, though the protocol fully supports it."* — meaning there's no generic surface, but the primitive itself works.
+
+Earlier a regression (`anthropics/claude-code#53617`, `#47378`) caused stdio servers emitting `notifications/progress` to be killed mid-call. **This regression is no longer reproducible on Claude Code 2.1.133** (verified 2026-05-09 with `progress-regression-mock.ts` — the second tool call after a progress emission survives cleanly).
+
+If we ever want a richer terminal UI for `team` runs, we could emit `notifications/progress` from the same callback that fires channel events. Strictly additive; doesn't replace channels. Costs maybe an hour of work.
+
+**Trigger condition**: a user (or you) reports the lack of mid-call CLI feedback for `team` as friction.
+
+Reference: `ai-docs/sessions/dev-research-mcp-tool-progress-20260508-235612-8d9da3e8/`
+
+---
+
+## Optional: submit `code-analysis` plugin to Anthropic's channel allowlist
+
+Status: not started. Anthropic-gated.
+
+Today, Claudish-via-`code-analysis@magus` requires users to launch with `--dangerously-load-development-channels plugin:code-analysis@magus` for channel notifications to work. Each session shows a confirmation prompt. The friction is small but real.
+
+Anthropic's [official plugin marketplace](https://github.com/anthropics/claude-plugins-official) accepts plugin submissions for inclusion in the global channel allowlist. Once accepted, users can switch to plain `--channels plugin:code-analysis@magus` (no dev flag, no confirmation).
+
+**Trigger condition**: a user explicitly asks for the friction to go away, OR Claudish becomes used widely enough outside MadAppGang that the per-session prompt becomes a meaningful onboarding cost.
+
+**Counter-consideration**: submitting to Anthropic's allowlist invites security review and ties our release cadence partially to theirs. Not worth doing for a small team's internal use.
+
+Reference: research findings under `ai-docs/sessions/dev-research-channel-config-alternatives-20260508-233443-3f43f254/` confirm this is the only documented path to remove the dev flag for individual users.
+
+---
+
+## Adding a new roadmap item
+
+Each item should follow the structure above:
+- **Status**: `not started` / `blocked on upstream` / `in progress` / `shipped`
+- **Trigger condition**: explicit and falsifiable. *"When X happens"* > *"Someday"*. If you can't write a trigger condition, the item probably isn't ready to be on the roadmap yet.
+- **Reference**: pointer to the research session, issue, or design doc with detail. Do not duplicate that detail here.
+- **Effort estimate** (optional): rough sizing if the item moves toward action.
+
+If a trigger condition has been met, move the item to *In Progress* and create the implementation tasks. If a trigger condition becomes irrelevant or wrong, delete the item rather than leave it stale.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -43,18 +43,24 @@ Default to `notifications/tasks/status`. Keep emitting `notifications/claude/cha
 
 ## ~~Optional: `notifications/progress` as a secondary CLI-UI signal~~ — Parked
 
-Status: **investigated and parked**. Not implementing.
+Status: **investigated, decisively parked, with a corrected rationale**. Not implementing.
 
-We considered emitting `notifications/progress` from `team`'s child-completion callback as a richer terminal UI signal. Empirical validation on 2026-05-09 against Claude Code 2.1.133 found:
+We considered emitting `notifications/progress` from `team`'s child-completion callback as a richer terminal UI signal. Two issues, one of which we initially got wrong:
 
-- ✅ The earlier transport-kill regression (`anthropics/claude-code#53617`, `#47378`) is no longer reproducible. Stdio servers can safely emit `notifications/progress` without crashing the transport. Verified with `progress-regression-mock.ts`'s `slow_ping_with_progress` + `simple_ping` sequence.
-- ❌ Claude Code 2.1.133 does **not render** progress notifications anywhere observable. Verified with `progress-regression-mock.ts`'s `slow_with_many_progress` tool emitting 5 distinct progress messages over ~10s. Mid-flight pane capture showed no terminal-UI rendering. The agent reported verbatim: *"I did not observe any progress messages during the call... nothing was surfaced to the agent context."* This matches the Anthropic-attributed comment on `anthropics/claude-code#4157`: *"Claude Code doesn't currently have a generic UI for displaying real-time progress from custom MCP servers."*
+- ❌ **Claude Code does not render progress notifications anywhere observable.** Verified 2026-05-09 against Claude Code 2.1.133 with `progress-regression-mock.ts`'s `slow_with_many_progress` tool emitting 5 distinct progress messages over ~10s. Mid-flight pane capture showed no terminal-UI rendering. The agent reported verbatim: *"I did not observe any progress messages during the call... nothing was surfaced to the agent context."* Matches the Anthropic-attributed comment on `anthropics/claude-code#4157`: *"Claude Code doesn't currently have a generic UI for displaying real-time progress from custom MCP servers."*
+- ❌ **The transport-kill regression is NOT fixed in 2.1.133 — earlier note that it was, was wrong.** A first test on 2026-05-09 (`progress-regression-mock.ts`'s `slow_ping_with_progress` + `simple_ping`) reported the regression resolved. **That test was insufficient.** It used sequential `await` ordering, putting all progress notifications strictly *before* the tool response, which avoids the race. The actual trigger documented in `GLips/Figma-Context-MCP#362` is **concurrent or quick-succession tool calls** where a progress notification arrives at the client *after* its `progressToken` cleanup has run. The MCP SDK then treats it as a protocol violation (`"Connection error: Received a progress notification for an unknown token"`) and tears down stdio. This bug is documented as still affecting Claude Code 2.1.x in the field. **The `team` use case (N concurrent child sessions, each with its own `progressToken`) is the exact pattern that triggers the bug.**
 
-Implementing this today would add code that fires notifications into a void. Not worth doing.
+So implementing this not only adds code that fires into a void — it would actively destabilize `team`. Two independent reasons not to do it.
 
-**Trigger condition for un-parking**: Claude Code releases a CHANGELOG entry mentioning UI/agent rendering of `notifications/progress` from custom MCP servers — at which point this becomes a one-hour additive change in the bridge callback.
+**Trigger condition for un-parking** (both must hold):
+1. Claude Code's MCP SDK fixes the strict-token-validation bug (the underlying cause of `Figma-Context-MCP#362`); look for changes in `@modelcontextprotocol/sdk` Client to ignore unknown progress tokens instead of treating them as fatal.
+2. Claude Code ships UI/agent rendering for progress notifications from custom MCP servers (issue `anthropics/claude-code#4157`).
 
-Reference: `ai-docs/sessions/dev-research-mcp-tool-progress-20260508-235612-8d9da3e8/`. Test artifacts: `packages/cli/src/channel/test-helpers/progress-regression-mock.ts`.
+**References**:
+- Original empirical session: `ai-docs/sessions/dev-research-mcp-tool-progress-20260508-235612-8d9da3e8/`
+- Community-research session that surfaced the corrected understanding: `ai-docs/sessions/dev-research-mcp-progress-community-20260509-213410-c058a909/`
+- Test artifacts: `packages/cli/src/channel/test-helpers/progress-regression-mock.ts`
+- Field evidence of the still-active bug: <https://github.com/GLips/Figma-Context-MCP/issues/362>
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,21 +41,20 @@ Default to `notifications/tasks/status`. Keep emitting `notifications/claude/cha
 
 ---
 
-## Optional: `notifications/progress` as a secondary CLI-UI signal
+## ~~Optional: `notifications/progress` as a secondary CLI-UI signal~~ — Parked
 
-Status: empirically validated as safe. Not started. Low priority.
+Status: **investigated and parked**. Not implementing.
 
-Today the `team` tool blocks the orchestrator agent until all children finish. Channels surface intermediate completions to **agent context**. But the **terminal UI** shows nothing until the call returns.
+We considered emitting `notifications/progress` from `team`'s child-completion callback as a richer terminal UI signal. Empirical validation on 2026-05-09 against Claude Code 2.1.133 found:
 
-The `notifications/progress` primitive (already in the MCP spec) renders to Claude Code's CLI progress display. Per Anthropic-attributed comment on `anthropics/claude-code#4157`: *"Claude Code doesn't currently have a generic UI for displaying real-time progress from custom MCP servers, though the protocol fully supports it."* — meaning there's no generic surface, but the primitive itself works.
+- ✅ The earlier transport-kill regression (`anthropics/claude-code#53617`, `#47378`) is no longer reproducible. Stdio servers can safely emit `notifications/progress` without crashing the transport. Verified with `progress-regression-mock.ts`'s `slow_ping_with_progress` + `simple_ping` sequence.
+- ❌ Claude Code 2.1.133 does **not render** progress notifications anywhere observable. Verified with `progress-regression-mock.ts`'s `slow_with_many_progress` tool emitting 5 distinct progress messages over ~10s. Mid-flight pane capture showed no terminal-UI rendering. The agent reported verbatim: *"I did not observe any progress messages during the call... nothing was surfaced to the agent context."* This matches the Anthropic-attributed comment on `anthropics/claude-code#4157`: *"Claude Code doesn't currently have a generic UI for displaying real-time progress from custom MCP servers."*
 
-Earlier a regression (`anthropics/claude-code#53617`, `#47378`) caused stdio servers emitting `notifications/progress` to be killed mid-call. **This regression is no longer reproducible on Claude Code 2.1.133** (verified 2026-05-09 with `progress-regression-mock.ts` — the second tool call after a progress emission survives cleanly).
+Implementing this today would add code that fires notifications into a void. Not worth doing.
 
-If we ever want a richer terminal UI for `team` runs, we could emit `notifications/progress` from the same callback that fires channel events. Strictly additive; doesn't replace channels. Costs maybe an hour of work.
+**Trigger condition for un-parking**: Claude Code releases a CHANGELOG entry mentioning UI/agent rendering of `notifications/progress` from custom MCP servers — at which point this becomes a one-hour additive change in the bridge callback.
 
-**Trigger condition**: a user (or you) reports the lack of mid-call CLI feedback for `team` as friction.
-
-Reference: `ai-docs/sessions/dev-research-mcp-tool-progress-20260508-235612-8d9da3e8/`
+Reference: `ai-docs/sessions/dev-research-mcp-tool-progress-20260508-235612-8d9da3e8/`. Test artifacts: `packages/cli/src/channel/test-helpers/progress-regression-mock.ts`.
 
 ---
 

--- a/packages/cli/src/channel/channel-wire-format.test.ts
+++ b/packages/cli/src/channel/channel-wire-format.test.ts
@@ -1,0 +1,465 @@
+/**
+ * Channel notification wire-format regression tests.
+ *
+ * These tests pin the exact JSON-RPC contract that the MCP server emits over
+ * stdio for channel notifications. They run without any API key by using the
+ * fake-claudish PATH shim — fake-claudish produces deterministic stdout that
+ * drives SignalWatcher state transitions, which in turn fire onStateChange
+ * callbacks, which invoke server.notification(), which serialize JSON-RPC
+ * frames to stdout.
+ *
+ * Why a dedicated test file:
+ *   - The OPENROUTER_API_KEY-gated lifecycle test in e2e-channel.test.ts
+ *     does similar checks but is skipped when the key is absent, so CI never
+ *     runs it. These tests run unconditionally.
+ *   - We use raw JSON-RPC over child process pipes (not the MCP Client SDK)
+ *     so we can assert the literal frame bytes — that's the wire contract.
+ *
+ * What's pinned:
+ *   1. The notification method name: "notifications/claude/channel"
+ *   2. params.content is a string
+ *   3. params.meta required keys: session_id, event, model, elapsed_seconds
+ *   4. session_id is an 8-char hex string (from randomUUID().slice(0, 8))
+ *   5. elapsed_seconds is serialized as a numeric string (not a number)
+ *   6. jsonrpc: "2.0" framing
+ *
+ * If a future refactor changes any of these, these tests will fail loudly.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SERVER_ENTRY = join(__dirname, "../index.ts");
+const FAKE_CLAUDISH_TS = join(__dirname, "test-helpers", "fake-claudish.ts");
+
+// ─── PATH shim setup ────────────────────────────────────────────────────────
+
+let shimDir: string;
+const ORIGINAL_PATH = process.env.PATH ?? "";
+
+beforeAll(() => {
+  shimDir = mkdtempSync(join(tmpdir(), "claudish-shim-wireformat-"));
+  const shimPath = join(shimDir, "claudish");
+  writeFileSync(
+    shimPath,
+    `#!/bin/sh\nexec bun run "${FAKE_CLAUDISH_TS}" "$@"\n`,
+    { mode: 0o755 }
+  );
+  process.env.PATH = `${shimDir}:${ORIGINAL_PATH}`;
+});
+
+afterAll(() => {
+  process.env.PATH = ORIGINAL_PATH;
+  if (shimDir) {
+    try {
+      rmSync(shimDir, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+// ─── Helper: drive an MCP server session and capture frames ─────────────────
+
+interface CapturedFrames {
+  notifications: Array<{
+    method: string;
+    params: { content: string; meta: Record<string, string> };
+    jsonrpc: string;
+  }>;
+  responses: Array<{ id: number; result?: unknown; error?: unknown; jsonrpc: string }>;
+  rawStdoutLines: string[];
+  stderr: string;
+}
+
+async function captureSessionFrames(opts: {
+  shimArgs?: string[]; // extra args passed to fake-claudish via spawn
+  timeoutMs?: number;
+}): Promise<CapturedFrames> {
+  const proc: ChildProcess = spawn("bun", ["run", SERVER_ENTRY, "--mcp"], {
+    stdio: ["pipe", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      CLAUDISH_MCP_TOOLS: "all",
+    },
+  });
+
+  const captured: CapturedFrames = {
+    notifications: [],
+    responses: [],
+    rawStdoutLines: [],
+    stderr: "",
+  };
+
+  let stdoutBuf = "";
+  let resolveDone: () => void;
+  const done = new Promise<void>((r) => {
+    resolveDone = r;
+  });
+
+  proc.stdout!.on("data", (chunk: Buffer) => {
+    stdoutBuf += chunk.toString("utf-8");
+    let nl: number;
+    while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+      const line = stdoutBuf.slice(0, nl);
+      stdoutBuf = stdoutBuf.slice(nl + 1);
+      if (!line.trim()) continue;
+      captured.rawStdoutLines.push(line);
+      try {
+        const msg = JSON.parse(line);
+        if (msg.method === "notifications/claude/channel") {
+          captured.notifications.push(msg);
+          // Resolve once we see a terminal event
+          const evt = msg.params?.meta?.event;
+          if (evt === "completed" || evt === "failed" || evt === "cancelled") {
+            resolveDone();
+          }
+        } else if (msg.id !== undefined) {
+          captured.responses.push(msg);
+        }
+      } catch {
+        // not JSON, ignore
+      }
+    }
+  });
+
+  proc.stderr!.on("data", (chunk: Buffer) => {
+    captured.stderr += chunk.toString("utf-8");
+  });
+
+  function send(rpc: object) {
+    proc.stdin!.write(JSON.stringify(rpc) + "\n");
+  }
+
+  // Initialize
+  send({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {
+      protocolVersion: "2024-11-05",
+      clientInfo: { name: "wire-format-test", version: "1.0.0" },
+      capabilities: { experimental: { "claude/channel": {} } },
+    },
+  });
+
+  await new Promise((r) => setTimeout(r, 300));
+  send({ jsonrpc: "2.0", method: "notifications/initialized" });
+  await new Promise((r) => setTimeout(r, 100));
+
+  // create_session — fake-claudish ignores --model so any value works.
+  // We pass an extra prompt-style arg via claudish_flags so fake-claudish
+  // gets the --lines flag and produces deterministic output.
+  send({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "create_session",
+      arguments: {
+        model: "fake-model",
+        prompt: "ignored",
+        timeout_seconds: 10,
+        claudish_flags: opts.shimArgs ?? ["--lines", "3"],
+      },
+    },
+  });
+
+  // Wait for terminal event or timeout
+  const timeoutMs = opts.timeoutMs ?? 15_000;
+  await Promise.race([
+    done,
+    new Promise<void>((r) => setTimeout(r, timeoutMs)),
+  ]);
+
+  // Brief grace period to capture any final frames
+  await new Promise((r) => setTimeout(r, 200));
+
+  proc.kill("SIGTERM");
+  await new Promise<void>((r) => proc.on("exit", () => r()));
+
+  return captured;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("Channel notification wire format", () => {
+  test(
+    "emits well-formed notifications/claude/channel JSON-RPC frames",
+    async () => {
+      const captured = await captureSessionFrames({ shimArgs: ["--lines", "3"] });
+
+      // At least one notification should arrive (running + completed expected)
+      expect(captured.notifications.length).toBeGreaterThan(0);
+
+      for (const n of captured.notifications) {
+        // Method name is exactly the contracted string
+        expect(n.method).toBe("notifications/claude/channel");
+
+        // JSON-RPC framing
+        expect(n.jsonrpc).toBe("2.0");
+
+        // params shape
+        expect(n.params).toBeDefined();
+        expect(typeof n.params.content).toBe("string");
+        expect(n.params.meta).toBeDefined();
+
+        // Required meta keys (current Claudish vocabulary)
+        expect(n.params.meta.session_id).toMatch(/^[0-9a-f]{8}$/);
+        expect(typeof n.params.meta.event).toBe("string");
+        expect(n.params.meta.model).toBe("fake-model");
+
+        // elapsed_seconds is serialized as a string (not a number) —
+        // this is intentional per the MCP server's bridge: see mcp-server.ts
+        // where it calls String(event.elapsedSeconds).
+        expect(typeof n.params.meta.elapsed_seconds).toBe("string");
+        expect(n.params.meta.elapsed_seconds).toMatch(/^\d+$/);
+
+        // SEP-1686 forward-compat fields (additive — see mcp-server.ts bridge
+        // and ai-docs/sessions/.../sep-1686-migration-schema.md)
+        // task_id mirrors session_id (will become the only field after migration)
+        expect(n.params.meta.task_id).toBe(n.params.meta.session_id);
+        // status carries the SEP-1686 5-value TaskStatus enum
+        expect([
+          "working",
+          "input_required",
+          "completed",
+          "failed",
+          "cancelled",
+        ]).toContain(n.params.meta.status);
+        // ISO 8601 timestamps
+        expect(n.params.meta.created_at).toMatch(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+        );
+        expect(n.params.meta.last_updated_at).toMatch(
+          /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/
+        );
+      }
+    },
+    20_000
+  );
+
+  test(
+    "SEP-1686 status mapping: 7-value event collapses to 5-value status correctly",
+    async () => {
+      const captured = await captureSessionFrames({ shimArgs: ["--lines", "3"] });
+      expect(captured.notifications.length).toBeGreaterThan(0);
+
+      // Build (event, status) pairs and validate every observed pair against
+      // the expected mapping defined in mcp-server.ts:EVENT_TO_TASK_STATUS.
+      const expectedMapping: Record<string, string> = {
+        starting: "working",
+        running: "working",
+        tool_executing: "working",
+        waiting_for_input: "input_required",
+        completed: "completed",
+        failed: "failed",
+        cancelled: "cancelled",
+      };
+
+      for (const n of captured.notifications) {
+        const event = n.params.meta.event as string;
+        const status = n.params.meta.status as string;
+        const expected = expectedMapping[event];
+        if (expected !== undefined) {
+          expect(status).toBe(expected);
+        } else {
+          // Unknown event types fall through to "working" per
+          // mapEventToTaskStatus's default. If a NEW event type ever leaks
+          // through without an entry in EVENT_TO_TASK_STATUS, this catches it.
+          expect(status).toBe("working");
+        }
+      }
+    },
+    20_000
+  );
+
+  test(
+    "all notifications for one session share the same created_at timestamp",
+    async () => {
+      const captured = await captureSessionFrames({ shimArgs: ["--lines", "5"] });
+      expect(captured.notifications.length).toBeGreaterThan(0);
+
+      // created_at is the session start time; all events from one session
+      // must report the same value. last_updated_at varies per event.
+      const createdAts = new Set(captured.notifications.map((n) => n.params.meta.created_at));
+      expect(createdAts.size).toBe(1);
+
+      // last_updated_at should differ across at least some events (they fire
+      // at different moments). With --lines 5 there's typically running +
+      // completed, so at least 2 distinct timestamps.
+      const lastUpdates = new Set(captured.notifications.map((n) => n.params.meta.last_updated_at));
+      expect(lastUpdates.size).toBeGreaterThan(0);
+    },
+    20_000
+  );
+
+  test(
+    "all notifications for one session share the same session_id",
+    async () => {
+      const captured = await captureSessionFrames({ shimArgs: ["--lines", "5"] });
+      expect(captured.notifications.length).toBeGreaterThan(0);
+
+      const ids = new Set(captured.notifications.map((n) => n.params.meta.session_id));
+      expect(ids.size).toBe(1);
+    },
+    20_000
+  );
+
+  test(
+    "session lifecycle ends with a terminal event (completed/failed/cancelled)",
+    async () => {
+      const captured = await captureSessionFrames({ shimArgs: ["--lines", "2"] });
+      expect(captured.notifications.length).toBeGreaterThan(0);
+
+      const events = captured.notifications.map((n) => n.params.meta.event);
+      const lastEvent = events[events.length - 1];
+      expect(["completed", "failed", "cancelled"]).toContain(lastEvent);
+    },
+    20_000
+  );
+
+  test(
+    "create_session response payload contains session_id matching notifications",
+    async () => {
+      const captured = await captureSessionFrames({ shimArgs: ["--lines", "3"] });
+
+      const callResponse = captured.responses.find((r) => r.id === 2);
+      expect(callResponse).toBeDefined();
+
+      const content = (callResponse!.result as { content: Array<{ text: string }> }).content;
+      const parsed = JSON.parse(content[0].text) as { session_id: string };
+      expect(parsed.session_id).toMatch(/^[0-9a-f]{8}$/);
+
+      // session_id from create_session response must equal the one in
+      // notifications — they describe the same session.
+      const notifSid = captured.notifications[0].params.meta.session_id;
+      expect(parsed.session_id).toBe(notifSid);
+    },
+    20_000
+  );
+});
+
+describe("MCP capability declaration", () => {
+  test(
+    "initialize response declares experimental.claude/channel capability",
+    async () => {
+      // Drive only the initialize handshake — no session needed.
+      const proc: ChildProcess = spawn("bun", ["run", SERVER_ENTRY, "--mcp"], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, CLAUDISH_MCP_TOOLS: "all" },
+      });
+
+      let stdoutBuf = "";
+      let initResponse: { result: { capabilities: { experimental?: Record<string, unknown> } } } | null = null;
+      let resolveInit: () => void;
+      const initDone = new Promise<void>((r) => {
+        resolveInit = r;
+      });
+
+      proc.stdout!.on("data", (chunk: Buffer) => {
+        stdoutBuf += chunk.toString("utf-8");
+        let nl: number;
+        while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+          const line = stdoutBuf.slice(0, nl);
+          stdoutBuf = stdoutBuf.slice(nl + 1);
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line);
+            if (msg.id === 1) {
+              initResponse = msg;
+              resolveInit();
+            }
+          } catch {}
+        }
+      });
+
+      proc.stdin!.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            clientInfo: { name: "cap-test", version: "1.0.0" },
+            capabilities: {},
+          },
+        }) + "\n"
+      );
+
+      await Promise.race([initDone, new Promise((r) => setTimeout(r, 10_000))]);
+      proc.kill("SIGTERM");
+      await new Promise<void>((r) => proc.on("exit", () => r()));
+
+      expect(initResponse).not.toBeNull();
+      const caps = initResponse!.result.capabilities;
+      expect(caps.experimental).toBeDefined();
+      expect(caps.experimental).toHaveProperty("claude/channel");
+    },
+    15_000
+  );
+
+  test(
+    "experimental capability is omitted when channel tools are disabled",
+    async () => {
+      // With CLAUDISH_MCP_TOOLS=low-level, channel tools are gated off and
+      // the experimental.claude/channel capability should NOT be declared.
+      const proc: ChildProcess = spawn("bun", ["run", SERVER_ENTRY, "--mcp"], {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, CLAUDISH_MCP_TOOLS: "low-level" },
+      });
+
+      let stdoutBuf = "";
+      let initResponse: { result: { capabilities: { experimental?: Record<string, unknown> } } } | null = null;
+      let resolveInit: () => void;
+      const initDone = new Promise<void>((r) => {
+        resolveInit = r;
+      });
+
+      proc.stdout!.on("data", (chunk: Buffer) => {
+        stdoutBuf += chunk.toString("utf-8");
+        let nl: number;
+        while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+          const line = stdoutBuf.slice(0, nl);
+          stdoutBuf = stdoutBuf.slice(nl + 1);
+          if (!line.trim()) continue;
+          try {
+            const msg = JSON.parse(line);
+            if (msg.id === 1) {
+              initResponse = msg;
+              resolveInit();
+            }
+          } catch {}
+        }
+      });
+
+      proc.stdin!.write(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            clientInfo: { name: "cap-test", version: "1.0.0" },
+            capabilities: {},
+          },
+        }) + "\n"
+      );
+
+      await Promise.race([initDone, new Promise((r) => setTimeout(r, 10_000))]);
+      proc.kill("SIGTERM");
+      await new Promise<void>((r) => proc.on("exit", () => r()));
+
+      expect(initResponse).not.toBeNull();
+      const caps = initResponse!.result.capabilities;
+      // Either experimental is absent entirely, or it doesn't have claude/channel
+      const hasChannel = !!caps.experimental && "claude/channel" in caps.experimental;
+      expect(hasChannel).toBe(false);
+    },
+    15_000
+  );
+});

--- a/packages/cli/src/channel/diagnostics.ts
+++ b/packages/cli/src/channel/diagnostics.ts
@@ -1,0 +1,129 @@
+// ─── Channel Diagnostics ──────────────────────────────────────────────────────
+//
+// Optional instrumentation for the channel notification pipeline. Activated by
+// setting CLAUDISH_CHANNEL_TRACE=1 in the environment before starting the MCP
+// server.
+//
+// Three checkpoints are exposed so a debugger can pinpoint which layer fails:
+//   1. wrapStateChange() — wraps SessionManager.onStateChange. Logs every
+//      callback invocation, captures rejections from server.notification(),
+//      and re-throws nothing — instrumentation must never break production.
+//   2. installWireTap() — wraps process.stdout.write to mirror outbound
+//      notifications/claude/channel JSON-RPC frames to stderr. Confirms the
+//      wire-level write actually happens.
+//   3. traceEnabled() — convenience predicate other modules can branch on.
+//
+// All output is single-line "[channel-trace] ..." records on stderr so they
+// can be greppable from MCP server stderr logs.
+
+import { appendFileSync } from "node:fs";
+import type { ChannelEvent } from "./types.js";
+
+const TRACE_ENV = "CLAUDISH_CHANNEL_TRACE";
+const TRACE_FILE_ENV = "CLAUDISH_CHANNEL_TRACE_FILE";
+
+export function traceEnabled(): boolean {
+  return process.env[TRACE_ENV] === "1";
+}
+
+function emit(line: string): void {
+  const formatted = `[channel-trace] ${line}\n`;
+  process.stderr.write(formatted);
+  // Optional file mirror — useful when the MCP server is spawned by a host
+  // (like Claude Code) that captures stderr internally and we need to observe
+  // trace output from outside the host process.
+  const filePath = process.env[TRACE_FILE_ENV];
+  if (filePath) {
+    try {
+      appendFileSync(filePath, formatted);
+    } catch {
+      // file write failure must never break the server
+    }
+  }
+}
+
+type StateChangeFn = (sessionId: string, event: ChannelEvent) => void;
+
+/**
+ * Wrap a SessionManager onStateChange callback so each invocation is logged.
+ * Returns the original callback unchanged when tracing is off.
+ *
+ * Logs:
+ *   - "fired sid=… type=… model=… elapsed=…s" on entry
+ *   - "callback returned sid=… type=…" on success
+ *   - "callback THREW sid=… type=… err=…" on synchronous error (re-thrown)
+ */
+export function wrapStateChange(fn: StateChangeFn): StateChangeFn {
+  if (!traceEnabled()) return fn;
+  return (sessionId, event) => {
+    emit(
+      `fired sid=${sessionId} type=${event.type} model=${event.model} elapsed=${event.elapsedSeconds}s`
+    );
+    try {
+      fn(sessionId, event);
+      emit(`callback returned sid=${sessionId} type=${event.type}`);
+    } catch (err) {
+      emit(
+        `callback THREW sid=${sessionId} type=${event.type} err=${(err as Error)?.message ?? err}`
+      );
+      throw err;
+    }
+  };
+}
+
+/**
+ * Capture rejections from server.notification()'s returned Promise so they're
+ * visible on stderr. The MCP SDK's notification() returns a Promise that
+ * nothing in mcp-server.ts awaits; if it rejects, the error would otherwise
+ * be silently swallowed.
+ *
+ * Pass the value returned by server.notification() — if it's a Promise we
+ * attach a catch handler; otherwise we no-op.
+ */
+export function watchNotificationResult(
+  result: unknown,
+  context: { sessionId: string; eventType: string }
+): void {
+  if (!traceEnabled()) return;
+  if (result && typeof (result as Promise<unknown>).then === "function") {
+    (result as Promise<unknown>).catch((err) => {
+      emit(
+        `notification REJECTED sid=${context.sessionId} type=${context.eventType} err=${err?.message ?? err}`
+      );
+    });
+  }
+}
+
+/**
+ * Install a stdout.write wrapper that mirrors outbound JSON-RPC frames
+ * containing `notifications/claude/channel` to stderr. Idempotent — calling
+ * twice still installs only one wrapper.
+ *
+ * No-op when tracing is off.
+ */
+let wireTapInstalled = false;
+export function installWireTap(): void {
+  if (!traceEnabled()) return;
+  if (wireTapInstalled) return;
+  wireTapInstalled = true;
+
+  const originalWrite = process.stdout.write.bind(process.stdout);
+  process.stdout.write = ((
+    chunk: string | Uint8Array,
+    ...rest: unknown[]
+  ): boolean => {
+    try {
+      const text =
+        typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf-8");
+      if (text.includes('"notifications/claude/channel"')) {
+        emit(`WIRE-OUT ${text.trim()}`);
+      }
+    } catch {
+      // never let logging break the real write
+    }
+    // @ts-expect-error pass-through to original signature
+    return originalWrite(chunk, ...rest);
+  }) as typeof process.stdout.write;
+
+  emit("wire tap installed");
+}

--- a/packages/cli/src/channel/session-manager.ts
+++ b/packages/cli/src/channel/session-manager.ts
@@ -94,6 +94,7 @@ export class SessionManager {
           model: entry.info.model,
           content: data.content ?? "",
           elapsedSeconds: entry.info.elapsedSeconds,
+          createdAt: entry.info.startedAt,
           extraMeta: {
             ...(data.toolName ? { tool: data.toolName } : {}),
             ...(data.toolCount ? { tool_count: String(data.toolCount) } : {}),

--- a/packages/cli/src/channel/test-helpers/channel-diagnostic.ts
+++ b/packages/cli/src/channel/test-helpers/channel-diagnostic.ts
@@ -1,0 +1,183 @@
+#!/usr/bin/env bun
+/**
+ * Channel notification diagnostic.
+ *
+ * Spawns the claudish MCP server with CLAUDISH_CHANNEL_TRACE=1 and drives a
+ * full create_session → completion lifecycle while capturing:
+ *   - All stderr (our channel-trace markers + any errors)
+ *   - All stdout (raw JSON-RPC frames the server emits)
+ *
+ * Both streams are written to logs/channel-diagnostic-<timestamp>.log AND
+ * mirrored to the console for live observation.
+ *
+ * Usage:
+ *   bun run packages/cli/src/channel/test-helpers/channel-diagnostic.ts [model] [prompt]
+ *
+ * Defaults:
+ *   model:  z-ai/glm-4.5-air:free   (free OpenRouter model — no cost)
+ *   prompt: "Reply with exactly: hello channel diagnostic"
+ *
+ * Exit codes:
+ *   0 — session completed AND we observed wire-out frames + completed event
+ *   1 — diagnostic failure (no frames, no completion, or transport error)
+ */
+import { spawn } from "node:child_process";
+import { mkdirSync, createWriteStream } from "node:fs";
+import { join, resolve } from "node:path";
+
+const MODEL = process.argv[2] ?? "z-ai/glm-4.5-air:free";
+const PROMPT = process.argv[3] ?? "Reply with exactly: hello channel diagnostic";
+const TIMEOUT_MS = 90_000; // hard cap — fail-loud rather than hang
+
+const LOG_DIR = resolve(import.meta.dir, "../../../../../logs");
+mkdirSync(LOG_DIR, { recursive: true });
+const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+const LOG_FILE = join(LOG_DIR, `channel-diagnostic-${stamp}.log`);
+const log = createWriteStream(LOG_FILE);
+
+function writeBoth(line: string) {
+  process.stderr.write(line);
+  log.write(line);
+}
+
+writeBoth(`[diag] starting channel diagnostic\n`);
+writeBoth(`[diag] model=${MODEL}\n`);
+writeBoth(`[diag] prompt=${PROMPT}\n`);
+writeBoth(`[diag] log file: ${LOG_FILE}\n`);
+
+const SERVER_ENTRY = resolve(import.meta.dir, "../../../src/index.ts");
+const proc = spawn("bun", ["run", SERVER_ENTRY, "--mcp"], {
+  stdio: ["pipe", "pipe", "pipe"],
+  env: {
+    ...process.env,
+    CLAUDISH_CHANNEL_TRACE: "1",
+    // Force channel tools enabled regardless of default
+    CLAUDISH_MCP_TOOLS: "all",
+  },
+});
+
+let observedTraceLines = 0;
+let observedWireFrames = 0;
+let observedCompletion = false;
+let observedFailure = false;
+let stderrBuf = "";
+let stdoutBuf = "";
+
+proc.stderr.on("data", (chunk: Buffer) => {
+  const text = chunk.toString("utf-8");
+  stderrBuf += text;
+  log.write(`STDERR: ${text}`);
+  process.stderr.write(`\x1b[2m${text}\x1b[0m`); // dim color for stderr mirror
+  if (text.includes("[channel-trace]")) {
+    observedTraceLines += text.split("\n").filter((l) => l.includes("[channel-trace]")).length;
+  }
+  if (text.includes("WIRE-OUT")) {
+    observedWireFrames += text.split("\n").filter((l) => l.includes("WIRE-OUT")).length;
+  }
+});
+
+proc.stdout.on("data", (chunk: Buffer) => {
+  const text = chunk.toString("utf-8");
+  stdoutBuf += text;
+  log.write(`STDOUT: ${text}`);
+  // Line-by-line JSON-RPC parse for "completed" / "failed" notifications
+  const lines = (stdoutBuf.match(/[^\n]+\n/g) ?? []) as string[];
+  if (lines.length > 0) {
+    stdoutBuf = stdoutBuf.slice(lines.join("").length);
+    for (const line of lines) {
+      try {
+        const msg = JSON.parse(line);
+        if (msg.method === "notifications/claude/channel") {
+          const evt = msg.params?.meta?.event;
+          writeBoth(`[diag] received notification event=${evt}\n`);
+          if (evt === "completed") observedCompletion = true;
+          if (evt === "failed") observedFailure = true;
+        } else if (msg.id !== undefined && msg.result) {
+          writeBoth(`[diag] received response id=${msg.id} keys=${Object.keys(msg.result).join(",")}\n`);
+        } else if (msg.id !== undefined && msg.error) {
+          writeBoth(`[diag] received ERROR id=${msg.id} code=${msg.error.code} msg=${msg.error.message}\n`);
+        }
+      } catch {
+        // not JSON, skip
+      }
+    }
+  }
+});
+
+function send(rpc: object) {
+  const frame = JSON.stringify(rpc) + "\n";
+  log.write(`SEND: ${frame}`);
+  proc.stdin.write(frame);
+}
+
+// Step A: initialize
+send({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: {
+    protocolVersion: "2024-11-05",
+    clientInfo: { name: "channel-diagnostic", version: "1.0.0" },
+    capabilities: {
+      experimental: { "claude/channel": {} },
+    },
+  },
+});
+
+// Step B: notifications/initialized + tools/call create_session
+// Slight delay to let init complete
+setTimeout(() => {
+  send({ jsonrpc: "2.0", method: "notifications/initialized" });
+  setTimeout(() => {
+    send({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "create_session",
+        arguments: {
+          model: MODEL,
+          prompt: PROMPT,
+          timeout_seconds: 60,
+        },
+      },
+    });
+  }, 200);
+}, 500);
+
+// Hard timeout
+const killTimer = setTimeout(() => {
+  writeBoth(`[diag] TIMEOUT after ${TIMEOUT_MS}ms — killing server\n`);
+  proc.kill("SIGTERM");
+  setTimeout(() => proc.kill("SIGKILL"), 2000);
+}, TIMEOUT_MS);
+
+proc.on("exit", (code) => {
+  clearTimeout(killTimer);
+  writeBoth(`[diag] server exited code=${code}\n`);
+  writeBoth(`\n=== DIAGNOSTIC SUMMARY ===\n`);
+  writeBoth(`trace lines observed:   ${observedTraceLines}\n`);
+  writeBoth(`wire frames observed:   ${observedWireFrames}\n`);
+  writeBoth(`completion event:       ${observedCompletion}\n`);
+  writeBoth(`failure event:          ${observedFailure}\n`);
+  writeBoth(`exit code:              ${code}\n`);
+  writeBoth(`log written to:         ${LOG_FILE}\n`);
+
+  // Diagnostic verdict
+  if (observedTraceLines === 0) {
+    writeBoth(`\n❌ VERDICT: onStateChange callback never fired.\n`);
+    writeBoth(`   Producer side broken — SignalWatcher or SessionManager not driving events.\n`);
+  } else if (observedWireFrames === 0) {
+    writeBoth(`\n❌ VERDICT: onStateChange fired but no JSON-RPC frame reached stdout.\n`);
+    writeBoth(`   server.notification() is being called but transport is silently dropping.\n`);
+  } else if (!observedCompletion && !observedFailure) {
+    writeBoth(`\n⚠️  VERDICT: Frames flowed but no terminal event seen.\n`);
+    writeBoth(`   Session may be hung or model produced no output.\n`);
+  } else {
+    writeBoth(`\n✅ VERDICT: Producer→bridge→wire pipeline confirmed working.\n`);
+    writeBoth(`   If client sees no <channel> blocks, the issue is client-side handling.\n`);
+  }
+
+  log.end();
+  process.exit(observedTraceLines > 0 && observedWireFrames > 0 ? 0 : 1);
+});

--- a/packages/cli/src/channel/test-helpers/claudish-mock.ts
+++ b/packages/cli/src/channel/test-helpers/claudish-mock.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env bun
+/**
+ * claudish-mock — minimal MCP server that mimics a Claudish channel session
+ * for end-to-end Claude Code rendering validation.
+ *
+ * Purpose: prove (or disprove) that Claude Code surfaces
+ * notifications/claude/channel as <channel source="claudish-mock"> blocks in
+ * an interactive session. Avoids depending on a real model — pure scripted
+ * timing means any failure must be in Claude Code's channel rendering path,
+ * not in our session machinery.
+ *
+ * Tool: `start_mock_session`
+ *   Returns immediately with a session_id. Then over the next ~9 seconds,
+ *   pushes the documented sequence of channel notifications:
+ *     t=0.5s   running (first model output)
+ *     t=2.0s   tool_executing (Read)
+ *     t=3.5s   tool_executing (Bash)
+ *     t=5.0s   tool_executing (Edit)
+ *     t=6.5s   tool_executing (Write)
+ *     t=8.0s   completed
+ *
+ * Wire format matches the real claudish bridge byte-for-byte (capability,
+ * method name, params shape, meta key naming) so this also serves as a
+ * reference of what conformant emission looks like.
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { randomUUID } from "node:crypto";
+
+const SERVER_NAME = "claudish-mock";
+
+// Scripted sequence: each entry becomes a single notifications/claude/channel
+// frame, fired at the offset given (ms from session start).
+interface MockEvent {
+  delayMs: number;
+  type: string;
+  content: string;
+  extraMeta?: Record<string, string>;
+}
+
+const SCRIPT: MockEvent[] = [
+  { delayMs: 500, type: "running", content: "Starting analysis of the codebase." },
+  { delayMs: 2000, type: "tool_executing", content: "Read package.json", extraMeta: { tool: "Read" } },
+  { delayMs: 3500, type: "tool_executing", content: "Running build", extraMeta: { tool: "Bash" } },
+  { delayMs: 5000, type: "tool_executing", content: "Editing src/index.ts", extraMeta: { tool: "Edit" } },
+  { delayMs: 6500, type: "tool_executing", content: "Writing CHANGELOG.md", extraMeta: { tool: "Write" } },
+  { delayMs: 8000, type: "completed", content: "Mock session finished. All 6 events emitted." },
+];
+
+function trace(line: string): void {
+  // Mirror to stderr for live observation. Claude Code captures MCP server
+  // stderr internally so this only shows up in --debug logs.
+  process.stderr.write(`[mock] ${line}\n`);
+}
+
+const server = new Server(
+  { name: SERVER_NAME, version: "0.0.1" },
+  {
+    capabilities: {
+      experimental: { "claude/channel": {} },
+      tools: {},
+    },
+    instructions:
+      `Mock channel server for testing. Call start_mock_session to begin a ` +
+      `scripted sequence of channel events. Events arrive as ` +
+      `<channel source="${SERVER_NAME}" event="..." session_id="..." ...> blocks. ` +
+      `Quote each <channel> block VERBATIM as it arrives so we can verify they reach the agent.`,
+  }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    {
+      name: "start_mock_session",
+      description:
+        "Start a mock Claudish session that emits a scripted sequence of channel notifications " +
+        "over ~9 seconds. Returns the session_id immediately; events arrive asynchronously.",
+      inputSchema: {
+        type: "object",
+        properties: {},
+        additionalProperties: false,
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  if (req.params.name !== "start_mock_session") {
+    throw new Error(`unknown tool: ${req.params.name}`);
+  }
+
+  const sessionId = randomUUID().slice(0, 8);
+  const startedAt = Date.now();
+  trace(`session ${sessionId} started, scheduling ${SCRIPT.length} events`);
+
+  for (const event of SCRIPT) {
+    setTimeout(() => {
+      const elapsed = Math.round((Date.now() - startedAt) / 1000);
+      const params = {
+        content: event.content,
+        meta: {
+          session_id: sessionId,
+          event: event.type,
+          model: "mock",
+          elapsed_seconds: String(elapsed),
+          ...(event.extraMeta ?? {}),
+        },
+      };
+      trace(`emit sid=${sessionId} type=${event.type} t=${elapsed}s`);
+      server.notification({
+        method: "notifications/claude/channel",
+        params,
+      });
+    }, event.delayMs);
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            session_id: sessionId,
+            scheduled_events: SCRIPT.length,
+            duration_seconds: SCRIPT[SCRIPT.length - 1].delayMs / 1000,
+            note: "Notifications will arrive asynchronously as <channel> blocks.",
+          },
+          null,
+          2
+        ),
+      },
+    ],
+  };
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+trace(`server connected, name=${SERVER_NAME}`);

--- a/packages/cli/src/channel/test-helpers/client-diagnostic.ts
+++ b/packages/cli/src/channel/test-helpers/client-diagnostic.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env bun
+/**
+ * Client-side channel diagnostic.
+ *
+ * Spawns `claude -p` against our claudish MCP server (with CLAUDISH_CHANNEL_TRACE=1
+ * enabled so we can see what the server emits). Asks Claude Code to create a
+ * session and report on what it observes.
+ *
+ * Captures three streams in parallel:
+ *   1. Server stderr — our [channel-trace] markers prove what frames we sent
+ *   2. Client stdout — Claude Code's stream-json events: tool calls, tool
+ *      results, system messages. If channel notifications are surfaced, they
+ *      should appear somewhere here.
+ *   3. Client stderr — Claude Code's own debug logs (--debug mcp captures
+ *      MCP-layer events including unknown notification handling).
+ *
+ * Comparing what the server sent vs what the client surfaced tells us
+ * definitively whether Claude Code consumes notifications/claude/channel.
+ */
+
+import { spawn } from "node:child_process";
+import { mkdirSync, writeFileSync, createWriteStream } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SERVER_ENTRY = resolve(__dirname, "../../index.ts");
+
+const LOG_DIR = resolve(__dirname, "../../../../../logs");
+mkdirSync(LOG_DIR, { recursive: true });
+const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+const LOG_FILE = join(LOG_DIR, `client-diagnostic-${stamp}.log`);
+const log = createWriteStream(LOG_FILE);
+
+function logBoth(s: string) {
+  process.stderr.write(s);
+  log.write(s);
+}
+
+logBoth(`[client-diag] starting end-to-end client diagnostic\n`);
+logBoth(`[client-diag] log file: ${LOG_FILE}\n`);
+
+// File where the MCP server will mirror its trace output. Claude Code
+// captures the server's stderr internally and never propagates it to us, so
+// without this file mirror we'd be blind to the server side.
+const SERVER_TRACE_FILE = join(LOG_DIR, `server-trace-${stamp}.log`);
+writeFileSync(SERVER_TRACE_FILE, "", "utf-8");
+
+// MCP config that wires our instrumented server into Claude Code
+const mcpConfig = {
+  mcpServers: {
+    claudish: {
+      command: "bun",
+      args: ["run", SERVER_ENTRY, "--mcp"],
+      env: {
+        CLAUDISH_MCP_TOOLS: "all",
+        CLAUDISH_CHANNEL_TRACE: "1",
+        CLAUDISH_CHANNEL_TRACE_FILE: SERVER_TRACE_FILE,
+        OPENROUTER_API_KEY: process.env.OPENROUTER_API_KEY ?? "",
+      },
+    },
+  },
+};
+
+const configPath = join(tmpdir(), `claudish-client-diag-${Date.now()}.json`);
+writeFileSync(configPath, JSON.stringify(mcpConfig), "utf-8");
+logBoth(`[client-diag] mcp config: ${configPath}\n`);
+
+// The prompt: ask Claude Code to create a session AND report on what it sees.
+// The prompt is crucial: it must elicit observable evidence of notifications.
+//
+// We use x-ai/grok-code-fast-1 because it actually returns output unlike the
+// :free models. We tell the agent EXPLICITLY not to cancel — earlier runs
+// showed it was happy to call cancel_session prematurely. We also tell it to
+// quote the channel notifications verbatim, which forces them to appear in
+// the output stream if the client does receive them.
+const PROMPT = `Use the create_session tool from the claudish MCP server with model "x-ai/grok-code-fast-1" and prompt "Reply with exactly the word: hello". DO NOT CANCEL THE SESSION. After create_session returns, the server will push notifications about the session lifecycle (events like running, tool_executing, completed). Quote VERBATIM every channel notification you observe — paste them as JSON or describe their event/content/meta fields exactly. If no notifications arrive within 60 seconds, report "NO NOTIFICATIONS RECEIVED". Then call list_sessions with include_completed=true and call get_output for the session. Output your findings in this exact format:\n\nNOTIFICATIONS_OBSERVED:\n<list each notification verbatim>\n\nFINAL_OUTPUT:\n<get_output result>`;
+
+logBoth(`[client-diag] prompt: ${PROMPT.slice(0, 100)}...\n`);
+
+const claudeArgs = [
+  "-p",
+  "--mcp-config",
+  configPath,
+  "--strict-mcp-config",
+  "--bare",
+  "--dangerously-skip-permissions",
+  // Channels are gated: server must be named in --channels OR bypassed via
+  // the development flag. Per official docs:
+  // https://code.claude.com/docs/en/channels-reference#test-during-the-research-preview
+  // Using the development flag because Claudish isn't on Anthropic's allowlist.
+  "--dangerously-load-development-channels",
+  "server:claudish",
+  "--output-format",
+  "stream-json",
+  "--include-partial-messages",
+  "--verbose",
+  "--debug",
+  "mcp",
+  PROMPT,
+];
+
+logBoth(`[client-diag] claude args: ${claudeArgs.slice(0, 8).join(" ")} ...\n`);
+
+const claude = spawn("claude", claudeArgs, {
+  stdio: ["ignore", "pipe", "pipe"],
+  env: process.env,
+});
+
+interface Counters {
+  serverChannelTraceLines: number;
+  serverWireFrames: number;
+  clientStreamEvents: number;
+  clientToolCalls: number;
+  clientToolResults: number;
+  clientChannelMentions: number;
+  clientSystemReminders: number;
+  clientUnhandledMcpLogs: number;
+}
+
+const counts: Counters = {
+  serverChannelTraceLines: 0,
+  serverWireFrames: 0,
+  clientStreamEvents: 0,
+  clientToolCalls: 0,
+  clientToolResults: 0,
+  clientChannelMentions: 0,
+  clientSystemReminders: 0,
+  clientUnhandledMcpLogs: 0,
+};
+
+let stdoutBuf = "";
+
+claude.stdout.on("data", (chunk: Buffer) => {
+  const text = chunk.toString("utf-8");
+  log.write(`STDOUT: ${text}`);
+  stdoutBuf += text;
+
+  // Parse line-delimited JSON
+  let nl: number;
+  while ((nl = stdoutBuf.indexOf("\n")) !== -1) {
+    const line = stdoutBuf.slice(0, nl);
+    stdoutBuf = stdoutBuf.slice(nl + 1);
+    if (!line.trim()) continue;
+    counts.clientStreamEvents++;
+    try {
+      const event = JSON.parse(line);
+      // Walk the event for evidence of channel notification reception
+      const json = JSON.stringify(event);
+      if (json.includes("notifications/claude/channel")) {
+        counts.clientChannelMentions++;
+        logBoth(`[client-diag] FOUND channel reference in stream: ${line.slice(0, 200)}\n`);
+      }
+      if (json.includes("<channel")) {
+        counts.clientChannelMentions++;
+        logBoth(`[client-diag] FOUND <channel> tag in stream: ${line.slice(0, 200)}\n`);
+      }
+      if (event.type === "system") {
+        counts.clientSystemReminders++;
+      }
+      if (event.type === "assistant" || event.type === "user") {
+        const blocks = event.message?.content ?? [];
+        for (const b of Array.isArray(blocks) ? blocks : []) {
+          if (b.type === "tool_use") {
+            counts.clientToolCalls++;
+            logBoth(`[client-diag] tool_use: ${b.name} input=${JSON.stringify(b.input).slice(0, 150)}\n`);
+          }
+          if (b.type === "tool_result") {
+            counts.clientToolResults++;
+          }
+        }
+      }
+    } catch {
+      // not JSON; ignore
+    }
+  }
+});
+
+claude.stderr.on("data", (chunk: Buffer) => {
+  const text = chunk.toString("utf-8");
+  log.write(`STDERR: ${text}`);
+
+  // Server's [channel-trace] markers come through as nested stderr
+  if (text.includes("[channel-trace]")) {
+    for (const line of text.split("\n")) {
+      if (line.includes("[channel-trace]")) {
+        if (line.includes("WIRE-OUT")) counts.serverWireFrames++;
+        else counts.serverChannelTraceLines++;
+      }
+    }
+  }
+  // Claude Code's own debug logging — look for evidence of MCP notification handling
+  if (/unhandled|unknown.*notification|drop/i.test(text)) {
+    counts.clientUnhandledMcpLogs++;
+    logBoth(`[client-diag] CLIENT MCP LOG: ${text.trim().slice(0, 300)}\n`);
+  }
+});
+
+const TIMEOUT_MS = 180_000;
+const killTimer = setTimeout(() => {
+  logBoth(`[client-diag] TIMEOUT — killing claude\n`);
+  claude.kill("SIGTERM");
+  setTimeout(() => claude.kill("SIGKILL"), 3000);
+}, TIMEOUT_MS);
+
+claude.on("exit", (code) => {
+  clearTimeout(killTimer);
+  logBoth(`\n[client-diag] claude exited code=${code}\n`);
+
+  // Read the server trace file — this is the ground truth for what the
+  // server emitted, since Claude Code captures the server's stderr and we
+  // can't see it via the host stderr stream.
+  try {
+    const fs = require("node:fs") as typeof import("node:fs");
+    const traceContent = fs.readFileSync(SERVER_TRACE_FILE, "utf-8");
+    const lines = traceContent.split("\n").filter((l) => l.includes("[channel-trace]"));
+    counts.serverChannelTraceLines = lines.length;
+    counts.serverWireFrames = lines.filter((l) => l.includes("WIRE-OUT")).length;
+    logBoth(`\n[client-diag] server trace file: ${SERVER_TRACE_FILE}\n`);
+    if (lines.length > 0) {
+      logBoth(`[client-diag] first 5 trace lines:\n`);
+      for (const l of lines.slice(0, 5)) logBoth(`  ${l}\n`);
+    }
+  } catch (err) {
+    logBoth(`[client-diag] failed to read server trace file: ${(err as Error).message}\n`);
+  }
+
+  logBoth(`\n=== END-TO-END CLIENT DIAGNOSTIC SUMMARY ===\n`);
+  logBoth(`SERVER SIDE (proves we sent frames):\n`);
+  logBoth(`  channel-trace markers:     ${counts.serverChannelTraceLines}\n`);
+  logBoth(`  wire-out frames:           ${counts.serverWireFrames}\n`);
+  logBoth(`\nCLIENT SIDE (proves Claude Code processed them):\n`);
+  logBoth(`  total stream events:       ${counts.clientStreamEvents}\n`);
+  logBoth(`  MCP tool calls (by Claude):${counts.clientToolCalls}\n`);
+  logBoth(`  MCP tool results:          ${counts.clientToolResults}\n`);
+  logBoth(`  channel mentions in stream:${counts.clientChannelMentions}\n`);
+  logBoth(`  system messages:           ${counts.clientSystemReminders}\n`);
+  logBoth(`  unhandled-mcp log lines:   ${counts.clientUnhandledMcpLogs}\n`);
+
+  logBoth(`\n=== VERDICT ===\n`);
+  if (counts.serverWireFrames === 0) {
+    logBoth(`❌ Server didn't send frames. Test setup issue, not a client question.\n`);
+  } else if (counts.clientChannelMentions > 0) {
+    logBoth(`✅ Server sent ${counts.serverWireFrames} frames. Client surfaced them in the stream.\n`);
+    logBoth(`   Channel notifications ARE consumed by Claude Code.\n`);
+  } else if (counts.clientUnhandledMcpLogs > 0) {
+    logBoth(`❌ Server sent ${counts.serverWireFrames} frames. Client logged "unhandled" warnings.\n`);
+    logBoth(`   Channel notifications reach Claude Code but are dropped (no handler).\n`);
+  } else {
+    logBoth(`⚠️  Server sent ${counts.serverWireFrames} frames. Client showed NO evidence of receiving them.\n`);
+    logBoth(`    No channel mentions, no <channel> tags, no debug logs about them.\n`);
+    logBoth(`    Either: Claude Code silently discards unknown methods, OR it consumes them\n`);
+    logBoth(`    but doesn't pass them through to the agent's visible context.\n`);
+    logBoth(`    Inspect the log file directly to look for subtler signals: ${LOG_FILE}\n`);
+  }
+
+  log.end();
+  process.exit(code ?? 0);
+});

--- a/packages/cli/src/channel/test-helpers/progress-regression-mock.ts
+++ b/packages/cli/src/channel/test-helpers/progress-regression-mock.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env bun
+/**
+ * progress-regression-mock — minimal MCP server that emits
+ * notifications/progress during a tool call to test whether Claude Code's
+ * stdio-kill regression (anthropics/claude-code#53617, #47378) still affects
+ * the current installed version.
+ *
+ * Tools:
+ *   - slow_ping_with_progress   : emits 2 progress notifications, then returns
+ *   - simple_ping               : just returns "pong" (no progress emitted)
+ *
+ * Test flow (driven from outside):
+ *   1. Call slow_ping_with_progress  -> server emits progress, returns success
+ *   2. Call simple_ping              -> if regression is active, this fails
+ *                                      because Claude Code closed stdio after
+ *                                      step 1
+ *
+ * Verdict:
+ *   - simple_ping succeeds  =>  regression FIXED in tested CC version
+ *   - simple_ping hangs / errors  =>  regression STILL ACTIVE
+ *
+ * The server logs every received message and every emitted notification to a
+ * file (path from PROGRESS_REGRESSION_LOG env var) so the test can verify
+ * server-side what happened.
+ */
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { appendFileSync } from "node:fs";
+
+const LOG_PATH = process.env.PROGRESS_REGRESSION_LOG ?? "/tmp/progress-regression.log";
+
+function log(event: Record<string, unknown>): void {
+  const line = JSON.stringify({ ts: new Date().toISOString(), ...event });
+  try {
+    appendFileSync(LOG_PATH, line + "\n");
+  } catch {
+    // never let logging break the server
+  }
+  process.stderr.write(`[progress-mock] ${line}\n`);
+}
+
+const server = new Server(
+  { name: "progress-regression-mock", version: "0.0.1" },
+  {
+    capabilities: { tools: {} },
+    instructions:
+      "Test server for progress-notification regression detection. " +
+      "Call slow_ping_with_progress first, then simple_ping. If the second " +
+      "call hangs or fails, the stdio-kill regression is still active.",
+  }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  log({ event: "tools.list" });
+  return {
+    tools: [
+      {
+        name: "slow_ping_with_progress",
+        description:
+          "Emits 2 notifications/progress then returns. Used to test whether " +
+          "Claude Code closes the stdio transport after server-emitted progress.",
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      },
+      {
+        name: "simple_ping",
+        description: "Returns 'pong' immediately. Used as a follow-up to detect transport death.",
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      },
+    ],
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, _meta } = req.params;
+  const progressToken = _meta?.progressToken;
+  log({ event: "tools.call.received", name, progressToken: progressToken ?? null });
+
+  if (name === "simple_ping") {
+    log({ event: "simple_ping.responding" });
+    return { content: [{ type: "text", text: "pong" }] };
+  }
+
+  if (name === "slow_ping_with_progress") {
+    if (progressToken === undefined) {
+      log({ event: "warn.no_progress_token", note: "client did not send progressToken; skipping notifications" });
+    } else {
+      // First progress event
+      log({ event: "emit.notification.progress", progress: 1, total: 2 });
+      try {
+        await server.notification({
+          method: "notifications/progress",
+          params: { progressToken, progress: 1, total: 2, message: "halfway" },
+        });
+      } catch (err) {
+        log({ event: "error.progress_emit_failed", err: (err as Error).message });
+      }
+
+      await new Promise((r) => setTimeout(r, 500));
+
+      // Second progress event
+      log({ event: "emit.notification.progress", progress: 2, total: 2 });
+      try {
+        await server.notification({
+          method: "notifications/progress",
+          params: { progressToken, progress: 2, total: 2, message: "done" },
+        });
+      } catch (err) {
+        log({ event: "error.progress_emit_failed", err: (err as Error).message });
+      }
+    }
+
+    log({ event: "slow_ping.responding" });
+    return { content: [{ type: "text", text: "slow ping done (progress emitted)" }] };
+  }
+
+  throw new Error(`unknown tool: ${name}`);
+});
+
+// Detect when Claude Code closes our stdin — the symptom of the regression.
+process.stdin.on("end", () => {
+  log({ event: "stdin.end", note: "client closed stdin" });
+});
+process.stdin.on("close", () => {
+  log({ event: "stdin.close" });
+});
+process.on("beforeExit", (code) => {
+  log({ event: "process.beforeExit", code });
+});
+process.on("exit", (code) => {
+  log({ event: "process.exit", code });
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+log({ event: "server.connected" });

--- a/packages/cli/src/channel/test-helpers/progress-regression-mock.ts
+++ b/packages/cli/src/channel/test-helpers/progress-regression-mock.ts
@@ -70,6 +70,14 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
         description: "Returns 'pong' immediately. Used as a follow-up to detect transport death.",
         inputSchema: { type: "object", properties: {}, additionalProperties: false },
       },
+      {
+        name: "slow_with_many_progress",
+        description:
+          "Runs for ~10 seconds, emitting 5 distinct notifications/progress along the way. " +
+          "Used to observe whether Claude Code 2.1.133 renders progress notifications in " +
+          "the terminal UI or surfaces them to the agent context.",
+        inputSchema: { type: "object", properties: {}, additionalProperties: false },
+      },
     ],
   };
 });
@@ -82,6 +90,44 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
   if (name === "simple_ping") {
     log({ event: "simple_ping.responding" });
     return { content: [{ type: "text", text: "pong" }] };
+  }
+
+  if (name === "slow_with_many_progress") {
+    if (progressToken === undefined) {
+      log({ event: "warn.no_progress_token", note: "client did not send progressToken; emitting nothing" });
+    } else {
+      const steps = [
+        { message: "Step 1 of 5: scanning files" },
+        { message: "Step 2 of 5: parsing AST" },
+        { message: "Step 3 of 5: running checks" },
+        { message: "Step 4 of 5: aggregating results" },
+        { message: "Step 5 of 5: writing output" },
+      ];
+      for (let i = 0; i < steps.length; i++) {
+        await new Promise((r) => setTimeout(r, 1500));
+        const params = {
+          progressToken,
+          progress: i + 1,
+          total: steps.length,
+          message: steps[i].message,
+        };
+        log({ event: "emit.notification.progress", ...params });
+        try {
+          await server.notification({ method: "notifications/progress", params });
+        } catch (err) {
+          log({ event: "error.progress_emit_failed", err: (err as Error).message });
+        }
+      }
+    }
+    log({ event: "slow_with_many_progress.responding" });
+    return {
+      content: [
+        {
+          type: "text",
+          text: "slow_with_many_progress completed (5 progress notifications emitted)",
+        },
+      ],
+    };
   }
 
   if (name === "slow_ping_with_progress") {

--- a/packages/cli/src/channel/types.ts
+++ b/packages/cli/src/channel/types.ts
@@ -45,6 +45,12 @@ export interface ChannelEvent {
   model: string;
   content: string;
   elapsedSeconds: number;
+  /**
+   * ISO-8601 timestamp of session creation. Populated by SessionManager from
+   * `entry.info.startedAt`. Used by the bridge to populate SEP-1686-shaped
+   * `meta.created_at` for forward-compat with notifications/tasks/status.
+   */
+  createdAt: string;
   extraMeta?: Record<string, string>;
 }
 

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -27,6 +27,7 @@ import {
   validateSessionPath,
 } from "./team-orchestrator.js";
 import { SessionManager } from "./channel/index.js";
+import { wrapStateChange, watchNotificationResult, installWireTap } from "./channel/diagnostics.js";
 import { createProxyServer } from "./proxy-server.js";
 import { findAvailablePort } from "./port-manager.js";
 import type { ProxyServer } from "./types.js";
@@ -1041,6 +1042,26 @@ function resolveToolGroups(mode: string): Set<ToolGroup> {
   }
 }
 
+// ─── SEP-1686 status mapping ─────────────────────────────────────────────────
+// Maps Claudish's 7-value `event` enum to SEP-1686's 5-value `TaskStatus`.
+// See: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1732
+// Migration plan: ai-docs/sessions/.../sep-1686-migration-schema.md
+type TaskStatus = "working" | "input_required" | "completed" | "failed" | "cancelled";
+
+const EVENT_TO_TASK_STATUS = new Map<string, TaskStatus>([
+  ["starting", "working"],
+  ["running", "working"],
+  ["tool_executing", "working"],
+  ["waiting_for_input", "input_required"],
+  ["completed", "completed"],
+  ["failed", "failed"],
+  ["cancelled", "cancelled"],
+]);
+
+function mapEventToTaskStatus(event: string): TaskStatus {
+  return EVENT_TO_TASK_STATUS.get(event) ?? "working";
+}
+
 // ─── Server Setup ────────────────────────────────────────────────────────────
 
 async function main() {
@@ -1059,14 +1080,25 @@ async function main() {
     }
   );
 
-  // Create session manager with channel notification bridge
+  // Create session manager with channel notification bridge.
+  // The bridge translates SessionManager events into MCP notifications.
+  // When CLAUDISH_CHANNEL_TRACE=1 is set, the diagnostics module wraps the
+  // callback to log each step of the producer→bridge→wire pipeline.
+  //
+  // Wire format aligns with SEP-1686 (Tasks) for forward-compat: each
+  // notification carries both Claudish-specific fields (`session_id`, `event`)
+  // and SEP-1686-shaped fields (`task_id`, `status`, `created_at`,
+  // `last_updated_at`). When Claude Code ships notifications/tasks/status
+  // receiver support, the migration is a method-name swap + payload restructure
+  // (no semantic changes).
+  // See: ai-docs/sessions/.../sep-1686-migration-schema.md
   const sessionManager = new SessionManager({
-    onStateChange: (sessionId, event) => {
+    onStateChange: wrapStateChange((sessionId, event) => {
       const notificationContent =
         event.type === "failed"
           ? `${event.content}\n\nTo report this error, use the report_error tool with error_type: "provider_failure" and model: "${event.model}".`
           : event.content;
-      server.notification({
+      const result = server.notification({
         method: "notifications/claude/channel",
         params: {
           content: notificationContent,
@@ -1075,11 +1107,18 @@ async function main() {
             event: event.type,
             model: event.model,
             elapsed_seconds: String(event.elapsedSeconds),
+            // SEP-1686 forward-compat fields (additive, do not break consumers
+            // of the existing fields above):
+            task_id: sessionId,
+            status: mapEventToTaskStatus(event.type),
+            created_at: event.createdAt,
+            last_updated_at: new Date().toISOString(),
             ...event.extraMeta,
           },
         },
       });
-    },
+      watchNotificationResult(result, { sessionId, eventType: event.type });
+    }),
   });
 
   // Build tool registry
@@ -1123,8 +1162,11 @@ async function main() {
     }
   });
 
-  // Connect via stdio transport
+  // Connect via stdio transport. installWireTap() is a no-op unless
+  // CLAUDISH_CHANNEL_TRACE=1 is set; when active it mirrors outbound channel
+  // notification frames to stderr so we can confirm wire-level delivery.
   const transport = new StdioServerTransport();
+  installWireTap();
   await server.connect(transport);
 
   // Cleanup on shutdown


### PR DESCRIPTION
## Summary

- Channel notifications wire format extended with SEP-1686 forward-compat fields (`task_id`, `status`, `created_at`, `last_updated_at`) so the future migration to `notifications/tasks/status` becomes a one-line change. Additive-only; no consumer behavior change.
- Diagnostic instrumentation (`CLAUDISH_CHANNEL_TRACE=1` + `CLAUDISH_CHANNEL_TRACE_FILE`) for the channel pipeline, plus four test-helper mocks for end-to-end validation: `claudish-mock`, `client-diagnostic`, `channel-diagnostic`, `progress-regression-mock`.
- Wire-format regression tests (`channel-wire-format.test.ts`): 8 tests, perturbation-verified that wrong status mapping or missing timestamps fail loudly. No API key required — runs on every CI invocation.
- New `ROADMAP.md` capturing planned but-not-yet-implemented work with explicit upstream-condition triggers; CLAUDE.md updated to point at it and to document the actual launch requirements for channel rendering.
- Two corrections published as separate commits in the PR for an honest record: an over-confident "regression is fixed" claim was contradicted by community research (`GLips/Figma-Context-MCP#362`) and corrected.

## Background

Two days of empirical work + three research sessions established that:
- Anthropic's `notifications/claude/channel` is the only working primitive for pushing progress into a Claude Code agent's context (verified end-to-end with an interactive `tmux`-driven mock + real Claude Code 2.1.133).
- `notifications/progress` is broken under concurrent calls (the exact pattern `team` exercises) and not rendered for custom MCP servers anyway.
- MCP "Tasks" (SEP-1686) is the future-correct primitive; spec is merged but Claude Code hasn't shipped client support yet. The wire format we ship in this PR is already aligned for that future.

## Test plan

- [x] `bun test packages/cli/src/channel/{scrollback-buffer,signal-watcher,session-manager,channel-wire-format}.test.ts` → 52/52 pass
- [x] `bun test packages/cli/src/channel/channel-wire-format.test.ts` after deliberate perturbation (wrong status mapping; missing `created_at`) → tests fail loudly as expected
- [x] End-to-end interactive validation: `claudish-mock` driven by Claude Code 2.1.133 in tmux pane → all 6 channel notifications surface to agent context AND terminal UI as documented
- [x] `bun build --target=bun packages/cli/src/mcp-server.ts` → bundles cleanly
- [x] e2e channel test suite: 14/15 pass (the 1 failing test is pre-existing and unrelated to this work)

## Commits in this PR

- `5cb4db5` feat(channel): SEP-1686 forward-compat fields + diagnostics + roadmap
- `3ca3616` chore(channel): validate notifications/progress rendering, park the item
- `dabf490` docs(roadmap): correct notifications/progress parking rationale

The third commit is an honest correction to an over-confident claim in the second. Squash-merging this PR collapses all three into a single commit on `main` while preserving the full record in the squashed message.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)