### PR TITLE
fix(model-loader): gate sync resolver on isFreshEnough TTL

### DIFF
--- a/packages/cli/src/model-loader.test.ts
+++ b/packages/cli/src/model-loader.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Regression tests for model-loader.ts.
+ *
+ * Run: bun test packages/cli/src/model-loader.test.ts
+ */
+
+import { describe, test, expect } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const MODEL_LOADER_SOURCE = readFileSync(
+  join(__dirname, "model-loader.ts"),
+  "utf-8"
+);
+
+describe("getRecommendedModelsSync — TTL gate (source-level regression guard)", () => {
+  // Guards against the sync resolver serving disk-cache of unbounded age.
+  // The async resolver gates its disk-cache read with `isFreshEnough()`
+  // (FIREBASE_CACHE_TTL_HOURS); the sync path must do the same so callers
+  // (loadModelInfo, getAvailableModels) cannot silently surface stale models
+  // in --model flag help text.
+
+  test("getRecommendedModelsSync gates the cached doc on isFreshEnough", () => {
+    // Extract the body of getRecommendedModelsSync for targeted assertions.
+    const fnStart = MODEL_LOADER_SOURCE.indexOf(
+      "export function getRecommendedModelsSync"
+    );
+    expect(fnStart).toBeGreaterThan(-1);
+
+    // The next top-level export marks the end of this function's body.
+    const fnEnd = MODEL_LOADER_SOURCE.indexOf("\nexport ", fnStart + 1);
+    const fnBody = MODEL_LOADER_SOURCE.slice(
+      fnStart,
+      fnEnd === -1 ? undefined : fnEnd
+    );
+
+    expect(fnBody).toContain("isFreshEnough(");
+  });
+
+  test("isFreshEnough is defined and uses FIREBASE_CACHE_TTL_HOURS", () => {
+    expect(MODEL_LOADER_SOURCE).toContain("function isFreshEnough(");
+    expect(MODEL_LOADER_SOURCE).toContain("FIREBASE_CACHE_TTL_HOURS");
+  });
+});

--- a/packages/cli/src/model-loader.ts
+++ b/packages/cli/src/model-loader.ts
@@ -469,7 +469,7 @@ export function getRecommendedModelsSync(): RecommendedModelsDoc {
       const cacheData = JSON.parse(
         readFileSync(RECOMMENDED_MODELS_CACHE_PATH, "utf-8")
       ) as RecommendedModelsDoc;
-      if (cacheData.models && cacheData.models.length > 0) {
+      if (cacheData.models && cacheData.models.length > 0 && isFreshEnough(cacheData)) {
         _cachedRecommendedModels = cacheData;
         return cacheData;
       }


### PR DESCRIPTION
## Summary

- Adds the missing `isFreshEnough()` check to `getRecommendedModelsSync`'s disk-cache branch so it matches the async path's TTL semantics
- Two remaining sync callers (`loadModelInfo`, `getAvailableModels`) feed `--model` flag help text; without this gate, they silently serve months-old data once a cache exists
- Adds a static-analysis regression test in the same style as the v7.1.1 `mcp-server.test.ts` guard

## Why this is a follow-up to v7.1.1

v7.1.1 fixed the user-visible `list_models` staleness by switching the MCP handler to the async resolver. That closed the highest-traffic path. This PR closes the structural footgun behind it.

The async resolver at `model-loader.ts:413` gates its disk-cache read with `isFreshEnough(cacheData)`:

```ts
if (cacheData.models && cacheData.models.length > 0 && isFreshEnough(cacheData)) {
```

The sync resolver at line 472 (pre-PR) was missing exactly that conjunct. So a cache file written months ago was returned unconditionally to any sync caller. The two remaining callers are cosmetic (`--model` flag help) — but every refactor that wires a new feature to the sync API re-opens the original bug.

## Diff

```diff
-      if (cacheData.models && cacheData.models.length > 0) {
+      if (cacheData.models && cacheData.models.length > 0 && isFreshEnough(cacheData)) {
         _cachedRecommendedModels = cacheData;
         return cacheData;
       }
```

`isFreshEnough` is already declared at `model-loader.ts:496` and uses the shared `FIREBASE_CACHE_TTL_HOURS`. No new imports, no new constants.

## Behavior change

| Cache state | Before | After |
|---|---|---|
| Fresh (< TTL) | returned | returned (unchanged) |
| Stale (≥ TTL) | returned | falls through to empty doc |
| Missing | empty doc | empty doc (unchanged) |

Existing callers (`loadModelInfo`, `getAvailableModels`) already handle empty `data.models` cleanly — empty `Record`/`Array` results.

### `generatedAt` defaulting caveat

`isFreshEnough` returns `true` when `generatedAt` is absent (`model-loader.ts:496-505`):

```ts
if (!generatedAt) return true;
```

Old cache files written before `generatedAt` was added by Firebase will always be considered fresh. The TTL gate kicks in once those caches are overwritten by an async fetch with a `generatedAt`-bearing payload. Acceptable for a low-severity surface; flagging it for visibility.

If you'd prefer stricter behavior, change line 498 to `if (!generatedAt) return false;` — old caches would force-refresh on next async call. Happy to add that to this PR if you want.

## Test plan

- [x] `bun test packages/cli/src/model-loader.test.ts` — 2 new tests pass (4 total expects)
- [x] `bun test packages/cli/src/mcp-server.test.ts` — existing v7.1.1 regression guards still pass
- [x] Full repo `bun test` — exits 0 (no regressions)
- [ ] Manual verification: warm cache via `curl`, edit `generatedAt` to >24h ago, run a path that hits `loadModelInfo` (e.g. `claudish --help`), confirm fallback to empty/help text

## Out of scope

These were considered but left for future PRs:

1. **Convert `loadModelInfo` and `getAvailableModels` to async** — removes the sync API entirely. Bigger surface area; deferred.
2. **Generalize the static-analysis guard** in `mcp-server.test.ts` to lock all production-source callers, not just `mcp-server.ts`. Sketched in the bug report below.
3. **Drop bundled `recommended-models.json`** — empty-doc fallback (introduced in v7.1.x) made the bundled file effectively dead code on the sync path. The `loadBundledRecommendedModels` helper at `model-loader.ts` is still used elsewhere; out of scope here.

## Background

Filed under Magus's tracking docs:
- Original bug: [`claudish-list-models-stale-bug.md`](https://github.com/MadAppGang/magus/blob/main/ai-docs/claudish-list-models-stale-bug.md) — fixed in v7.1.1
- This follow-up: [`claudish-sync-resolver-no-ttl-followup.md`](https://github.com/MadAppGang/magus/blob/main/ai-docs/claudish-sync-resolver-no-ttl-followup.md)