### PR TITLE
fix(minimax): mm@/mmax@ baseUrl minimax.io → minimaxi.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Claudish automatically loads `.env` from the current directory at startup. For t
 |----------|----------|---------|
 | `GEMINI_BASE_URL` | Gemini API | `https://generativelanguage.googleapis.com` |
 | `OPENAI_BASE_URL` | OpenAI/Azure | `https://api.openai.com` |
-| `MINIMAX_BASE_URL` | MiniMax | `https://api.minimax.io` |
+| `MINIMAX_BASE_URL` | MiniMax | `https://api.minimaxi.com` |
 | `MOONSHOT_BASE_URL` | Kimi/Moonshot | `https://api.moonshot.ai` |
 | `ZHIPU_BASE_URL` | GLM/Zhipu | `https://open.bigmodel.cn` |
 | `ZAI_BASE_URL` | Z.AI | `https://api.z.ai` |

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -177,7 +177,7 @@ Claudish automatically loads `.env` from the current working directory at startu
 |----------|----------|---------|
 | `GEMINI_BASE_URL` | Google Gemini API | `https://generativelanguage.googleapis.com` |
 | `OPENAI_BASE_URL` | OpenAI API (also for Azure-compatible) | `https://api.openai.com` |
-| `MINIMAX_BASE_URL` | MiniMax API | `https://api.minimax.io` |
+| `MINIMAX_BASE_URL` | MiniMax API | `https://api.minimaxi.com` |
 | `MINIMAX_CODING_BASE_URL` | MiniMax Coding Plan endpoint | `https://api.minimax.io` |
 | `MOONSHOT_BASE_URL` | Kimi/Moonshot API | `https://api.moonshot.ai` |
 | `KIMI_BASE_URL` | Alias for `MOONSHOT_BASE_URL` | |

--- a/packages/cli/src/config-command.ts
+++ b/packages/cli/src/config-command.ts
@@ -76,7 +76,7 @@ const PROVIDERS: ProviderDef[] = [
     description: "MiniMax API (mm@, mmax@)",
     keyUrl: "https://www.minimaxi.com/",
     endpointEnvVar: "MINIMAX_BASE_URL",
-    defaultEndpoint: "https://api.minimax.io",
+    defaultEndpoint: "https://api.minimaxi.com",
   },
   {
     name: "kimi",

--- a/packages/cli/src/model-catalog.test.ts
+++ b/packages/cli/src/model-catalog.test.ts
@@ -23,9 +23,13 @@ import { GLMModelDialect } from "./adapters/glm-model-dialect.js";
 import { DialectManager } from "./adapters/dialect-manager.js";
 import { AnthropicAPIFormat } from "./adapters/anthropic-api-format.js";
 
-const MINIMAX_API_KEY = process.env.MINIMAX_CODING_API_KEY || process.env.MINIMAX_API_KEY;
+const MINIMAX_CODING_KEY = process.env.MINIMAX_CODING_API_KEY;
+const MINIMAX_REGULAR_KEY = process.env.MINIMAX_API_KEY;
+const MINIMAX_API_KEY = MINIMAX_CODING_KEY || MINIMAX_REGULAR_KEY;
 const SKIP_REAL_API = !MINIMAX_API_KEY;
-const MINIMAX_API_BASE = "https://api.minimax.io/anthropic/v1/messages";
+const MINIMAX_API_BASE = MINIMAX_CODING_KEY
+  ? "https://api.minimax.io/anthropic/v1/messages"
+  : "https://api.minimaxi.com/anthropic/v1/messages";
 
 // ─── Mock slim-cache seeding ─────────────────────────────────────────────────
 

--- a/packages/cli/src/providers/provider-definitions.test.ts
+++ b/packages/cli/src/providers/provider-definitions.test.ts
@@ -294,6 +294,16 @@ describe("getEffectiveBaseUrl", () => {
     const def = getProviderByName("openrouter")!;
     expect(getEffectiveBaseUrl(def)).toBe("https://openrouter.ai");
   });
+
+  test("minimax (mm@) default baseUrl is minimaxi.com, not minimax.io", () => {
+    const def = getProviderByName("minimax")!;
+    expect(def.baseUrl).toBe("https://api.minimaxi.com");
+  });
+
+  test("minimax-coding (mmc@) default baseUrl remains minimax.io", () => {
+    const def = getProviderByName("minimax-coding")!;
+    expect(def.baseUrl).toBe("https://api.minimax.io");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/providers/provider-definitions.ts
+++ b/packages/cli/src/providers/provider-definitions.ts
@@ -229,7 +229,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     name: "minimax",
     displayName: "MiniMax",
     transport: "anthropic",
-    baseUrl: "https://api.minimax.io",
+    baseUrl: "https://api.minimaxi.com",
     baseUrlEnvVars: ["MINIMAX_BASE_URL"],
     apiPath: "/anthropic/v1/messages",
     apiKeyEnvVar: "MINIMAX_API_KEY",

--- a/packages/cli/src/providers/transport/anthropic-compat.test.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.test.ts
@@ -22,7 +22,7 @@ describe("AnthropicCompatProvider.getHeaders()", () => {
   it("returns Authorization: Bearer header when authScheme is 'bearer'", async () => {
     const provider: RemoteProvider = {
       name: "minimax",
-      baseUrl: "https://api.minimax.io",
+      baseUrl: "https://api.minimaxi.com",
       apiPath: "/anthropic/v1/messages",
       apiKeyEnvVar: "MINIMAX_API_KEY",
       prefixes: ["mm@", "mmax@"],


### PR DESCRIPTION
Closes #121

## Summary

- Corrects the default `baseUrl` for the `minimax` provider (`mm@`, `mmax@`) from `https://api.minimax.io` to `https://api.minimaxi.com`
- `minimax.io` is the endpoint for `mmc@` (MiniMax Coding Plan) only — `mm@`/`mmax@` should always route to `minimaxi.com`
- Updates all references: `provider-definitions.ts`, `config-command.ts`, `README.md`, `docs/settings-reference.md`, and affected tests

## Root cause

`BUILTIN_PROVIDERS` in `provider-definitions.ts` had the wrong `baseUrl` for the `minimax` entry. The `minimax-coding` entry correctly used `minimax.io`, but `minimax` (the general provider) was pointing there too instead of `minimaxi.com`. This caused `mm@` and `mmax@` requests to hit the coding endpoint and get 401s.

## Diff

```diff
 // provider-definitions.ts
 name: "minimax",
 transport: "anthropic",
-baseUrl: "https://api.minimax.io",
+baseUrl: "https://api.minimaxi.com",
```

```diff
 // model-catalog.test.ts — test now uses the correct base per key type
-const MINIMAX_API_BASE = "https://api.minimax.io/anthropic/v1/messages";
+const MINIMAX_API_BASE = MINIMAX_CODING_KEY
+  ? "https://api.minimax.io/anthropic/v1/messages"
+  : "https://api.minimaxi.com/anthropic/v1/messages";
```

## Behavior change

| Provider prefix | Before | After |
|---|---|---|
| `mm@`, `mmax@` | `https://api.minimax.io` (wrong) | `https://api.minimaxi.com` (correct) |
| `mmc@` | `https://api.minimax.io` | `https://api.minimax.io` (unchanged) |

## Test plan

- [x] `bun test packages/cli/src/providers/provider-definitions.test.ts` — new tests assert `minimax` → `minimaxi.com` and `minimax-coding` → `minimax.io`
- [x] `bun test packages/cli/src/providers/transport/anthropic-compat.test.ts` — updated fixture baseUrl passes
- [x] Full repo `bun test` — exits 0 (no regressions)
- [ ] Manual: `claudish --model mm@minimax-m2.7-highspeed --probe` confirms transport uses `minimaxi.com`