### PR TITLE
fix(stream-parsers): forward real input_tokens in message_delta for autocompact

### DIFF
--- a/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
@@ -62,7 +62,7 @@ export function createGeminiSseStream(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });
@@ -113,7 +113,7 @@ export function createGeminiSseStream(
           send("message_delta", {
             type: "message_delta",
             delta: { stop_reason: hasToolCalls ? "tool_use" : "end_turn", stop_sequence: null },
-            usage: { output_tokens: outputTokens },
+            usage: { input_tokens: inputTokens, output_tokens: outputTokens },
           });
           send("message_stop", { type: "message_stop" });
         }

--- a/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
@@ -50,7 +50,7 @@ export function createOllamaJsonlStream(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });
@@ -75,7 +75,7 @@ export function createOllamaJsonlStream(
           send("message_delta", {
             type: "message_delta",
             delta: { stop_reason: "end_turn", stop_sequence: null },
-            usage: { output_tokens: completionTokens },
+            usage: { input_tokens: promptTokens, output_tokens: completionTokens },
           });
           send("message_stop", { type: "message_stop" });
         }

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
@@ -66,7 +66,7 @@ export function createResponsesStreamHandler(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -138,7 +138,7 @@ export function createStreamingResponseHandler(
             model: target,
             stop_reason: null,
             stop_sequence: null,
-            usage: { input_tokens: 100, output_tokens: 1 },
+            usage: { input_tokens: 0, output_tokens: 0 },
           },
         });
         send("ping", { type: "ping" });
@@ -293,7 +293,10 @@ export function createStreamingResponseHandler(
             send("message_delta", {
               type: "message_delta",
               delta: { stop_reason: stopReason, stop_sequence: null },
-              usage: { output_tokens: state.usage?.completion_tokens || 0 },
+              usage: {
+                input_tokens: state.usage?.prompt_tokens || 0,
+                output_tokens: state.usage?.completion_tokens || 0,
+              },
             });
             send("message_stop", { type: "message_stop" });
           }
@@ -312,7 +315,7 @@ export function createStreamingResponseHandler(
               log(
                 `[Streaming] No usage data from provider, estimating: ~${estimatedOutputTokens} output tokens`
               );
-              onTokenUpdate(100, estimatedOutputTokens); // Use 100 as placeholder for input
+              onTokenUpdate(0, estimatedOutputTokens);
             }
           }
 


### PR DESCRIPTION
## Summary

- Fix hardcoded `input_tokens: 100` in `message_start` and missing `input_tokens` in `message_delta` across all 4 non-Anthropic stream parsers
- This breaks Claude Code's autocompact/condensation for every non-Anthropic provider (GLM, Qwen, Gemini, Ollama, Codex, OpenRouter, LiteLLM)

## Problem

Claude Code accumulates token usage from SSE events via `updateUsage()` in `claude.ts`:
1. `message_start` seeds `usage.input_tokens = 100` (hardcoded placeholder)
2. `message_delta` sends `{ output_tokens: N }` but **never includes `input_tokens`**
3. `updateUsage()` only replaces `input_tokens` when the new value is `> 0` — since it's never sent, it stays at 100 forever
4. `tokenCountWithEstimation()` computes ~30k instead of ~80k for a typical session
5. Autocompact threshold is never reached → context grows unbounded → agents stall/crash

## Root Cause

```
message_start:  usage: { input_tokens: 100, output_tokens: 1 }   ← hardcoded
message_delta:  usage: { output_tokens: <real> }                  ← missing input_tokens
```

The real `input_tokens` (from `state.usage.prompt_tokens` / `usageMetadata.promptTokenCount` / `prompt_eval_count`) is available in the parser but never forwarded to Claude Code.

## Changes

| File | Before | After |
|------|--------|-------|
| openai-sse.ts:141 | `input_tokens: 100` | `input_tokens: 0` |
| openai-sse.ts:296 | `{ output_tokens }` | `{ input_tokens, output_tokens }` |
| openai-sse.ts:315 | `onTokenUpdate(100, ...)` | `onTokenUpdate(0, ...)` |
| gemini-sse.ts:65 | `input_tokens: 100` | `input_tokens: 0` |
| gemini-sse.ts:116 | `{ output_tokens }` | `{ input_tokens, output_tokens }` |
| ollama-jsonl.ts:53 | `input_tokens: 100` | `input_tokens: 0` |
| ollama-jsonl.ts:78 | `{ output_tokens }` | `{ input_tokens, output_tokens }` |
| openai-responses-sse.ts:69 | `input_tokens: 100` | `input_tokens: 0` |

Note: `openai-responses-sse.ts` already sent `input_tokens` in its `message_delta` — only the `message_start` placeholder needed fixing.

## Validation

- `bun run build` — compiles clean
- Deployed on our cluster for 24h — autocompact triggers correctly at the configured threshold (80%)
- `/context` now shows accurate token counts instead of "100 / 200k (0%)"

Fixes #90

## Test plan

- [ ] `bun run build` passes
- [ ] Start proxy with a non-Anthropic model, send messages, verify `/context` shows accurate usage
- [ ] Verify autocompact triggers at the expected threshold
- [ ] Run `bun test packages/cli/src/format-translation.test.ts` — SSE replay tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)