### PR TITLE
fix(routing): recognize runtime provider credentials in routing

### DIFF
--- a/packages/cli/src/providers/routing-rules.ts
+++ b/packages/cli/src/providers/routing-rules.ts
@@ -12,6 +12,7 @@ import {
   isProviderAvailable,
 } from "./provider-definitions.js";
 import { buildCredentialHint } from "./routing-hints.js";
+import { getRuntimeProviders } from "./runtime-providers.js";
 
 /**
  * Pure merge — defaults < global < local. Exposed for testability so callers
@@ -216,6 +217,10 @@ export type RoutePlan =
  */
 function hasCredentialsForProvider(provider: string): boolean {
   if (isLocalTransport(provider)) return isLocalProviderEnabled(provider);
+
+  // Custom endpoints registered at runtime always have credentials —
+  // the loader validates apiKey presence before registration.
+  if (getRuntimeProviders().has(provider)) return true;
 
   if (provider === "native-anthropic") {
     return !!process.env.ANTHROPIC_API_KEY || !!process.env.ANTHROPIC_AUTH_TOKEN;


### PR DESCRIPTION
## Summary

- Custom endpoints registered at runtime via `registerRuntimeProvider()` have credentials validated at load time
- But `hasCredentialsForProvider()` didn't know about them, so routing excluded them from the candidate chain
- Fix: check `getRuntimeProviders()` before falling through to env var checks
- Without this fix, custom endpoints with valid API keys in config are excluded from routing

## Changes

One file touched: `packages/cli/src/providers/routing-rules.ts`

- Added import of `getRuntimeProviders` from `runtime-providers.js`
- Added early-return check in `hasCredentialsForProvider()` that recognizes runtime-registered providers as always credentialed (the loader validates `apiKey` presence before registration)

## Test plan

- [ ] Configure a custom endpoint in `~/.claudish/config.json` under `customEndpoints` with a valid API key
- [ ] Run `claudish --probe <custom-endpoint-model>` — should show the custom endpoint in the routing chain instead of `no-route`
- [ ] Run `claudish --model <custom-endpoint>@<model> "hello"` — should route successfully without credential errors

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)