### PR TITLE
fix(proxy): strip Claude Code billing header from prompt for non-Anthropic providers

### DIFF
--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -571,6 +571,29 @@ export async function createProxyServer(
       const body = await c.req.json();
       const handler = await getHandlerForRequest(body.model);
 
+      // Strip Claude Code billing header from system prompt for non-Anthropic
+      // providers. Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
+      // into the prompt body — the `cch=` token changes every request, breaking
+      // prefix caching on self-hosted inference (vLLM, Ollama). Only Anthropic
+      // needs this header.
+      if (!(handler instanceof NativeHandler)) {
+        if (typeof body.system === "string") {
+          body.system = body.system.replace(
+            /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+            ""
+          );
+        } else if (Array.isArray(body.system)) {
+          for (const block of body.system) {
+            if (block.type === "text" && typeof block.text === "string") {
+              block.text = block.text.replace(
+                /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+                ""
+              );
+            }
+          }
+        }
+      }
+
       // Route
       return handler.handle(c, body);
     } catch (e) {


### PR DESCRIPTION
## Summary

Strips the `x-anthropic-billing-header: cc_version=...; cch=XXXXX;` line that Claude Code injects into the system prompt body when the request is **not** routed to Anthropic's native API.

## Problem

Claude Code injects a billing header into the `system` field of every `/v1/messages` request. The `cch=` token changes on every request, which **breaks prefix caching on self-hosted inference engines** (vLLM, Ollama, LM Studio) that use strict hash matching for KV cache hits. Each request is treated as a unique prefix, resulting in zero cache hits and wasted GPU compute re-processing the same system prompt repeatedly.

## Fix

- In the `/v1/messages` handler, after resolving the handler and before forwarding, check if the handler is a `NativeHandler` (Anthropic direct).
- If **not** native (i.e., OpenRouter, local models, custom endpoints, etc.), strip the billing header line from `body.system` using a regex.
- Handles both `string` and `array` (block) forms of the `system` field per the Anthropic API spec.
- **Zero impact on Anthropic routing** — native requests pass through unchanged.

## Testing

- Verified diff scope: only `packages/cli/src/proxy-server.ts` touched (23 insertions, 0 deletions).
- The `NativeHandler` import already exists in the file — no new dependencies.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>