### PR TITLE
fix(stream-parsers): clamp content block indices in Anthropic SSE passthrough

### DIFF
--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -503,8 +503,12 @@ describe("Regression: Anthropic SSE abandoned streams emit a terminal tail", () 
     });
 
     const events = await parseClaudeSseStream(response);
+    // Under index clamping (see anthropic-sse index-clamping tests), the
+    // client sees the block at the renumbered sequential index (0), not the
+    // upstream index (3) — so the synthetic tail must close the index the
+    // client actually has open.
     const blockStopIndex = events.findIndex(
-      (event) => event.data?.type === "content_block_stop" && event.data?.index === 3
+      (event) => event.data?.type === "content_block_stop" && event.data?.index === 0
     );
     const messageStopIndex = events.findIndex((event) => event.data?.type === "message_stop");
 

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse-index-clamping.test.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse-index-clamping.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { createAnthropicPassthroughStream } from "./anthropic-sse.js";
+
+const FIXTURES_DIR = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../test-fixtures/sse-responses"
+);
 
 const ctx: any = {
   body: (stream: any, init: any) => new Response(stream, init),
@@ -63,6 +71,25 @@ const messageDelta = () =>
   });
 
 const messageStop = () => frame("message_stop", { type: "message_stop" });
+
+/** Replay a whole fixture file (stripping its `# ` metadata lines) through the parser. */
+const runFixture = async (name: string): Promise<string> => {
+  const text = readFileSync(join(FIXTURES_DIR, name), "utf-8")
+    .split("\n")
+    .filter((l) => !l.startsWith("# "))
+    .join("\n");
+  return stripPingFrames(await run([text]));
+};
+
+/** Parse a parser-emitted wire into its data payloads, in order. */
+const parseEmitted = (wire: string): any[] =>
+  wire
+    .split("\n\n")
+    .flatMap((frame) => frame.split("\n"))
+    .filter((l) => l.startsWith("data: "))
+    .map((l) => l.slice(6))
+    .filter((d) => d !== '{"type":"ping"}')
+    .map((d) => JSON.parse(d));
 
 describe("anthropic-sse content block index clamping", () => {
   it("passes sequential indices through untouched", async () => {
@@ -161,5 +188,50 @@ describe("anthropic-sse content block index clamping", () => {
     // Sequential: exactly one block start, one stop, in order.
     expect(out.indexOf("content_block_start")).toBeLessThan(out.indexOf("text_delta"));
     expect(out.lastIndexOf("content_block_stop")).toBeGreaterThan(out.indexOf("text_delta"));
+  });
+});
+
+describe.each([
+  { reqN: "r10324", textFragment: "Search-4-LocalSearch", toolFragment: "check_twin_parity.py" },
+  { reqN: "r10416", textFragment: "QuantConnect", toolFragment: "config.json" },
+])("production fixture: MiniMax-M3 implicit signature block ($reqN)", ({ reqN, textFragment, toolFragment }) => {
+  it("renumbers the whole stream sequentially and drops the implicit signature block", async () => {
+    // Fixtures reconstructed from production captures (see the file header for
+    // the reconstruction proof): MiniMax emits a signature_delta + stop at
+    // index 0 with NO content_block_start (implicit block), then the text
+    // block at index 1 and the tool_use block at index 2.
+    const events = parseEmitted(await runFixture(`minimax-m3-anthropic-implicit-signature-${reqN}.sse`));
+
+    // The implicit signature block never existed client-side: dropped whole.
+    expect(events.filter((e) => e.type === "content_block_delta" && e.delta?.type === "signature_delta")).toHaveLength(0);
+
+    // Exactly two blocks are opened, renumbered sequentially: text at 0, tool_use at 1.
+    const starts = events.filter((e) => e.type === "content_block_start");
+    expect(starts.map((e) => [e.index, e.content_block.type])).toEqual([
+      [0, "text"],
+      [1, "tool_use"],
+    ]);
+
+    // Every text delta follows the remap: all at 0, none leaked at 1.
+    const textDeltas = events.filter((e) => e.delta?.type === "text_delta");
+    expect(textDeltas.length).toBeGreaterThan(5);
+    expect(new Set(textDeltas.map((e) => e.index))).toEqual(new Set([0]));
+    expect(textDeltas.map((e) => e.delta.text).join("")).toContain(textFragment);
+
+    // The tool call's input stream follows its own remap: all at 1, none at 2,
+    // and the concatenated partial_json reassembles into valid JSON.
+    const toolDeltas = events.filter((e) => e.delta?.type === "input_json_delta");
+    expect(toolDeltas.length).toBeGreaterThanOrEqual(1);
+    expect(new Set(toolDeltas.map((e) => e.index))).toEqual(new Set([1]));
+    const toolInput = JSON.parse(toolDeltas.map((e) => e.delta.partial_json).join(""));
+    expect(JSON.stringify(toolInput)).toContain(toolFragment);
+
+    // Blocks close in order, the terminal pair is present, and no index ever
+    // escapes the sequential range.
+    expect(events.filter((e) => e.type === "content_block_stop").map((e) => e.index)).toEqual([0, 1]);
+    expect(events.at(-1)?.type).toBe("message_stop");
+    const stopReason = events.find((e) => e.type === "message_delta")?.delta?.stop_reason;
+    expect(stopReason).toBe("tool_use");
+    expect(events.filter((e) => typeof e.index === "number" && e.index > 1)).toHaveLength(0);
   });
 });

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse-index-clamping.test.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse-index-clamping.test.ts
@@ -104,7 +104,10 @@ describe("anthropic-sse content block index clamping", () => {
     expect(out).toContain("second");
   });
 
-  it("clamps a delta whose index jumps past the last known block", async () => {
+  it("clamps an orphan delta to the last OPEN block, not the next slot", async () => {
+    // A delta can only reference a block the client has opened. Clamping it
+    // to highest + 1 would emit a delta for an unopened block — the same
+    // "Content block not found" this guard exists to prevent.
     const frames = [
       messageStart(),
       textBlockStart(0),
@@ -119,6 +122,7 @@ describe("anthropic-sse content block index clamping", () => {
 
     expect(out).toContain('"index":0');
     expect(out).not.toContain('"index":5');
+    expect(out).not.toContain('"index":1');
     expect(out).toContain("orphan");
   });
 });

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse-index-clamping.test.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse-index-clamping.test.ts
@@ -104,10 +104,10 @@ describe("anthropic-sse content block index clamping", () => {
     expect(out).toContain("second");
   });
 
-  it("clamps an orphan delta to the last OPEN block, not the next slot", async () => {
-    // A delta can only reference a block the client has opened. Clamping it
-    // to highest + 1 would emit a delta for an unopened block — the same
-    // "Content block not found" this guard exists to prevent.
+  it("drops an orphan delta instead of re-attaching it to another block", async () => {
+    // A delta can only reference a block the client has opened. One that
+    // references nothing is dropped: clamping it onto the last open block
+    // would corrupt that block's content.
     const frames = [
       messageStart(),
       textBlockStart(0),
@@ -123,6 +123,43 @@ describe("anthropic-sse content block index clamping", () => {
     expect(out).toContain('"index":0');
     expect(out).not.toContain('"index":5');
     expect(out).not.toContain('"index":1');
-    expect(out).toContain("orphan");
+    expect(out).not.toContain("orphan");
+  });
+
+  it("absorbs MiniMax's implicit signature block and keeps the stream sequential", async () => {
+    // Shape extracted from 7 production captures (MiniMax-M3, anthropic
+    // passthrough, 2026-07-19 → 2026-08-06): the upstream emits a
+    // signature_delta + stop at index 0 with NO content_block_start for it
+    // (the signature is the sha256 of the empty string — an implicit block),
+    // then the text block starts at index 1. The old stateless clamp remapped
+    // the start 1 → 0 but leaked every following text delta at the original
+    // index 1, producing "Content block not found" on the client.
+    const frames = [
+      messageStart(),
+      frame("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "signature_delta", signature: "EoMC" },
+      }),
+      frame("content_block_stop", { type: "content_block_stop", index: 0 }),
+      textBlockStart(1),
+      textDelta(1, "real content"),
+      blockStop(1),
+      messageDelta(),
+      messageStop(),
+    ];
+
+    const out = stripPingFrames(await run(frames));
+
+    // The implicit signature block never existed client-side: dropped whole.
+    expect(out).not.toContain("signature_delta");
+    // The text block is renumbered to 0 and its deltas FOLLOW the remap —
+    // no leak of the original index 1 anywhere.
+    expect(out).toContain('"index":0');
+    expect(out).not.toContain('"index":1');
+    expect(out).toContain("real content");
+    // Sequential: exactly one block start, one stop, in order.
+    expect(out.indexOf("content_block_start")).toBeLessThan(out.indexOf("text_delta"));
+    expect(out.lastIndexOf("content_block_stop")).toBeGreaterThan(out.indexOf("text_delta"));
   });
 });

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse-index-clamping.test.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse-index-clamping.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+
+import { createAnthropicPassthroughStream } from "./anthropic-sse.js";
+
+const ctx: any = {
+  body: (stream: any, init: any) => new Response(stream, init),
+  json: () => {
+    throw new Error("Unexpected no-body error path");
+  },
+};
+
+const sseResponse = (frames: string[]) =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const frame of frames) controller.enqueue(encoder.encode(frame));
+        controller.close();
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } }
+  );
+
+const frame = (event: string, data: unknown) =>
+  `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+
+const stripPingFrames = (wire: string): string =>
+  wire.replaceAll('event: ping\ndata: {"type":"ping"}\n\n', "");
+
+const run = (frames: string[]) =>
+  createAnthropicPassthroughStream(ctx, sseResponse(frames), {
+    modelName: "test-model",
+  }).text();
+
+const messageStart = () =>
+  frame("message_start", {
+    type: "message_start",
+    message: { id: "msg_1", usage: { input_tokens: 3, output_tokens: 0 } },
+  });
+
+const textBlockStart = (index: number) =>
+  frame("content_block_start", {
+    type: "content_block_start",
+    index,
+    content_block: { type: "text" },
+  });
+
+const textDelta = (index: number, text: string) =>
+  frame("content_block_delta", {
+    type: "content_block_delta",
+    index,
+    delta: { type: "text_delta", text },
+  });
+
+const blockStop = (index: number) =>
+  frame("content_block_stop", { type: "content_block_stop", index });
+
+const messageDelta = () =>
+  frame("message_delta", {
+    type: "message_delta",
+    delta: { stop_reason: "end_turn" },
+    usage: { output_tokens: 4 },
+  });
+
+const messageStop = () => frame("message_stop", { type: "message_stop" });
+
+describe("anthropic-sse content block index clamping", () => {
+  it("passes sequential indices through untouched", async () => {
+    const frames = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "hello"),
+      blockStop(0),
+      messageDelta(),
+      messageStop(),
+    ];
+
+    const out = stripPingFrames(await run(frames));
+
+    expect(out).toContain('"index":0');
+    expect(out).not.toContain('"index":1');
+    expect(out).toContain('"stop_reason":"end_turn"');
+  });
+
+  it("remaps a jumping content_block_start to the next sequential index", async () => {
+    // z.ai has been observed sending 0 → 2, skipping 1. The client fails
+    // with "Content block not found" unless the indices are remapped.
+    const frames = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "first"),
+      blockStop(0),
+      textBlockStart(2),
+      textDelta(2, "second"),
+      blockStop(2),
+      messageDelta(),
+      messageStop(),
+    ];
+
+    const out = stripPingFrames(await run(frames));
+
+    expect(out).toContain('"index":1');
+    expect(out).not.toContain('"index":2');
+    expect(out).toContain("second");
+  });
+
+  it("clamps a delta whose index jumps past the last known block", async () => {
+    const frames = [
+      messageStart(),
+      textBlockStart(0),
+      textDelta(0, "ok"),
+      textDelta(5, "orphan"),
+      blockStop(0),
+      messageDelta(),
+      messageStop(),
+    ];
+
+    const out = stripPingFrames(await run(frames));
+
+    expect(out).toContain('"index":0');
+    expect(out).not.toContain('"index":5');
+    expect(out).toContain("orphan");
+  });
+});

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -330,6 +330,31 @@ export function createAnthropicPassthroughStream(
           /** A frame was just dropped — swallow its trailing blank separator too. */
           let suppressedFrame = false;
 
+          // Content block index tracking — detect out-of-range indices
+          // that would cause "Content block not found" on the client side.
+          let highestSeenIndex = -1;
+          /**
+           * Original → remapped index for blocks whose content_block_start
+           * index jumped (e.g. z.ai 0 → 2). Every later frame of that block
+           * (deltas, stop) still carries the original index, so the remap
+           * must follow the block until it closes.
+           */
+          const remappedBlocks = new Map<number, number>();
+          const clampIndex = (idx: number, context: string): number => {
+            const remapped = remappedBlocks.get(idx);
+            if (remapped !== undefined) return remapped;
+            if (idx > highestSeenIndex + 1) {
+              log(
+                `[AnthropicSSE] Index jump detected: ${idx} but expected <=${highestSeenIndex + 1} (${context}) — clamping to ${highestSeenIndex + 1}`
+              );
+              return highestSeenIndex + 1;
+            }
+            return idx;
+          };
+          const trackIndex = (idx: number) => {
+            if (idx > highestSeenIndex) highestSeenIndex = idx;
+          };
+
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
@@ -407,7 +432,12 @@ export function createAnthropicPassthroughStream(
                   // Re-index non-thinking content blocks
                   // After suppressing N thinking blocks, subtract N from the index
                   if (typeof data.index === "number" && thinkingBlocksSuppressed > 0) {
-                    const reindexed = data.index - thinkingBlocksSuppressed;
+                    const clamped = clampIndex(
+                      data.index - thinkingBlocksSuppressed,
+                      `${data.type} (filtered, orig=${data.index})`
+                    );
+                    trackIndex(clamped);
+                    const reindexed = clamped;
                     const modifiedLine = `data: ${JSON.stringify({ ...data, index: reindexed })}`;
 
                     if (!isClosed) {
@@ -421,8 +451,22 @@ export function createAnthropicPassthroughStream(
 
                     // Still do usage tracking below with the ORIGINAL data
                   } else {
-                    // No filtering needed — pass through (via the tool interceptor,
-                    // which is a no-op unless a rule asked for this tool).
+                    // No filtering needed — track the index, clamp if it jumps,
+                    // and pass through via the tool interceptor (a no-op unless
+                    // a rule asked for this tool).
+                    if (
+                      typeof data.index === "number" &&
+                      data.type === "content_block_start"
+                    ) {
+                      trackIndex(data.index);
+                    } else if (typeof data.index === "number") {
+                      const clamped = clampIndex(data.index, `${data.type} (filtered stream)`);
+                      if (clamped !== data.index) {
+                        const modified = { ...data, index: clamped };
+                        enqueueData(controller, modified, `data: ${JSON.stringify(modified)}`);
+                        continue;
+                      }
+                    }
                     enqueueData(controller, data, line);
                   }
                 } catch {
@@ -462,9 +506,51 @@ export function createAnthropicPassthroughStream(
                       return; // stop processing further lines
                     }
 
-                    // No error — pass through (via the tool interceptor, which is
-                    // a no-op unless a rule asked for this tool).
-                    enqueueData(controller, data, line);
+                    // No error — check index bounds before passing through
+                    // (still via the tool interceptor, which is a no-op unless
+                    // a rule asked for this tool).
+                    if (typeof data.index === "number") {
+                      if (data.type === "content_block_start") {
+                        // z.ai sometimes sends content_block_start with an index
+                        // that jumps (e.g., 0 → 2, skipping 1). This causes
+                        // "Content block not found" on the client. Remap to
+                        // sequential indices and remember the mapping so the
+                        // block's later frames follow it.
+                        const expected = highestSeenIndex + 1;
+                        if (data.index !== expected) {
+                          log(
+                            `[AnthropicSSE] content_block_start index ${data.index} remapped to ${expected} (model=${opts.modelName})`
+                          );
+                          remappedBlocks.set(data.index, expected);
+                          const remapped = { ...data, index: expected };
+                          enqueueData(controller, remapped, `data: ${JSON.stringify(remapped)}`);
+                        } else {
+                          enqueueData(controller, data, line);
+                        }
+                        trackIndex(expected);
+                      } else if (data.type === "content_block_stop") {
+                        // delta / stop — follow an existing remap, clamp otherwise
+                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`);
+                        remappedBlocks.delete(data.index);
+                        if (clamped !== data.index) {
+                          const modified = { ...data, index: clamped };
+                          enqueueData(controller, modified, `data: ${JSON.stringify(modified)}`);
+                        } else {
+                          enqueueData(controller, data, line);
+                        }
+                      } else {
+                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`);
+                        if (clamped !== data.index) {
+                          const modified = { ...data, index: clamped };
+                          enqueueData(controller, modified, `data: ${JSON.stringify(modified)}`);
+                        } else {
+                          enqueueData(controller, data, line);
+                        }
+                      }
+                    } else {
+                      // No index field — pass through as-is
+                      enqueueData(controller, data, line);
+                    }
 
                     // Usage/debug tracking
                     if (data.message?.usage) {

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -356,7 +356,8 @@ export function createAnthropicPassthroughStream(
           ): number => {
             const remapped = remappedBlocks.get(idx);
             if (remapped !== undefined) return remapped;
-            const ceiling = kind === "start" ? highestSeenIndex + 1 : highestSeenIndex;
+            const ceiling =
+              kind === "start" ? highestSeenIndex + 1 : Math.max(highestSeenIndex, 0);
             if (idx > ceiling) {
               log(
                 `[AnthropicSSE] Index jump detected: ${idx} but expected <=${ceiling} (${context}) — clamping to ${ceiling}`
@@ -551,21 +552,27 @@ export function createAnthropicPassthroughStream(
                           enqueueData(controller, data, line);
                         }
                         trackIndex(expected);
-                      } else if (data.type === "content_block_stop") {
-                        // delta / stop — follow an existing remap, clamp otherwise
-                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`, "frame");
-                        remappedBlocks.delete(data.index);
-                        if (clamped !== data.index) {
-                          const modified = { ...data, index: clamped };
-                          enqueueData(controller, modified, `data: ${JSON.stringify(modified)}`);
-                        } else {
-                          enqueueData(controller, data, line);
-                        }
                       } else {
-                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`, "frame");
-                        if (clamped !== data.index) {
-                          const modified = { ...data, index: clamped };
+                        // delta / stop — follow an existing remap. An index
+                        // with no open block behind it (neither remapped nor
+                        // ≤ highest) is an orphan — e.g. MiniMax emits an
+                        // implicit signature block whose content_block_start
+                        // never arrives — and is DROPPED rather than clamped:
+                        // a delta can only point at a block the client has
+                        // opened, and re-attaching it to another block would
+                        // corrupt that block's content.
+                        const remapped = remappedBlocks.get(data.index);
+                        if (data.type === "content_block_stop") {
+                          remappedBlocks.delete(data.index);
+                        }
+                        if (remapped !== undefined) {
+                          const modified = { ...data, index: remapped };
                           enqueueData(controller, modified, `data: ${JSON.stringify(modified)}`);
+                        } else if (data.index > highestSeenIndex) {
+                          log(
+                            `[AnthropicSSE] Dropping orphan ${data.type} at index ${data.index} (no open block — model=${opts.modelName})`
+                          );
+                          pendingEventLine = null; // swallow the event: line too
                         } else {
                           enqueueData(controller, data, line);
                         }

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -340,14 +340,28 @@ export function createAnthropicPassthroughStream(
            * must follow the block until it closes.
            */
           const remappedBlocks = new Map<number, number>();
-          const clampIndex = (idx: number, context: string): number => {
+          /**
+           * Clamp an index to the valid range for its frame kind. A
+           * `content_block_start` may legitimately claim the NEXT sequential
+           * slot (highest + 1); a delta or stop can only reference a block
+           * the client has already opened, so their ceiling is `highest`.
+           * Without that distinction an orphan delta clamps to highest + 1 —
+           * an index the client never opened, which is the very
+           * "Content block not found" failure this guard exists to prevent.
+           */
+          const clampIndex = (
+            idx: number,
+            context: string,
+            kind: "start" | "frame"
+          ): number => {
             const remapped = remappedBlocks.get(idx);
             if (remapped !== undefined) return remapped;
-            if (idx > highestSeenIndex + 1) {
+            const ceiling = kind === "start" ? highestSeenIndex + 1 : highestSeenIndex;
+            if (idx > ceiling) {
               log(
-                `[AnthropicSSE] Index jump detected: ${idx} but expected <=${highestSeenIndex + 1} (${context}) — clamping to ${highestSeenIndex + 1}`
+                `[AnthropicSSE] Index jump detected: ${idx} but expected <=${ceiling} (${context}) — clamping to ${ceiling}`
               );
-              return highestSeenIndex + 1;
+              return ceiling;
             }
             return idx;
           };
@@ -434,7 +448,8 @@ export function createAnthropicPassthroughStream(
                   if (typeof data.index === "number" && thinkingBlocksSuppressed > 0) {
                     const clamped = clampIndex(
                       data.index - thinkingBlocksSuppressed,
-                      `${data.type} (filtered, orig=${data.index})`
+                      `${data.type} (filtered, orig=${data.index})`,
+                      data.type === "content_block_start" ? "start" : "frame"
                     );
                     trackIndex(clamped);
                     const reindexed = clamped;
@@ -453,21 +468,29 @@ export function createAnthropicPassthroughStream(
                   } else {
                     // No filtering needed — track the index, clamp if it jumps,
                     // and pass through via the tool interceptor (a no-op unless
-                    // a rule asked for this tool).
+                    // a rule asked for this tool). No `continue` here: frames
+                    // must fall through to the usage/text tracking below.
                     if (
                       typeof data.index === "number" &&
                       data.type === "content_block_start"
                     ) {
                       trackIndex(data.index);
+                      enqueueData(controller, data, line);
                     } else if (typeof data.index === "number") {
-                      const clamped = clampIndex(data.index, `${data.type} (filtered stream)`);
+                      const clamped = clampIndex(
+                        data.index,
+                        `${data.type} (filtered stream)`,
+                        "frame"
+                      );
                       if (clamped !== data.index) {
                         const modified = { ...data, index: clamped };
                         enqueueData(controller, modified, `data: ${JSON.stringify(modified)}`);
-                        continue;
+                      } else {
+                        enqueueData(controller, data, line);
                       }
+                    } else {
+                      enqueueData(controller, data, line);
                     }
-                    enqueueData(controller, data, line);
                   }
                 } catch {
                   // Unparseable — pass through
@@ -530,7 +553,7 @@ export function createAnthropicPassthroughStream(
                         trackIndex(expected);
                       } else if (data.type === "content_block_stop") {
                         // delta / stop — follow an existing remap, clamp otherwise
-                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`);
+                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`, "frame");
                         remappedBlocks.delete(data.index);
                         if (clamped !== data.index) {
                           const modified = { ...data, index: clamped };
@@ -539,7 +562,7 @@ export function createAnthropicPassthroughStream(
                           enqueueData(controller, data, line);
                         }
                       } else {
-                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`);
+                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`, "frame");
                         if (clamped !== data.index) {
                           const modified = { ...data, index: clamped };
                           enqueueData(controller, modified, `data: ${JSON.stringify(modified)}`);

--- a/packages/cli/src/test-fixtures/sse-responses/minimax-m3-anthropic-implicit-signature-r10324.sse
+++ b/packages/cli/src/test-fixtures/sse-responses/minimax-m3-anthropic-implicit-signature-r10324.sse
@@ -1,0 +1,200 @@
+# claudish response capture (reconstructed upstream stream)
+# source: production capture reqN=10324, MiniMax-M3 anthropic passthrough (2026-07)
+# The on-disk capture taped the OUTGOING stream (post-clamp): the old clamp
+# remapped content_block_start to sequential indices but let deltas/stops leak
+# at their upstream index. This fixture undoes the start remap (index+1 per start)
+# to restore the upstream stream the parser must absorb: implicit signature block
+# at 0 (signature_delta+stop, no start), text at 1, tool_use at 2.
+# verification: replaying the old clamp on this fixture reproduces the capture
+# event-for-event. Capture sha256=D891E76D4DFA41DA...
+# ==========================================================
+
+event: ping
+data: {"type":"ping"}
+
+event: message_start
+data: {"type":"message_start","message":{"id":"06c3b74282324cb3ce7ecd0ca42589bf","type":"message","role":"assistant","content":[],"model":"MiniMax-M3","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0,"service_tier":"standard"},"service_tier":"standard"}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" 155"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" OK"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" + 1 INT"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"RO (intro"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" introduced"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":")."}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" The DR"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"IFT is"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" the Search"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"-4-Local"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Search twin"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" pair,"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" which"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" `"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"local"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" --per-pair --"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"check` doesn't"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" flag the"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" same way"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" as CI —"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" CI"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" is"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" in"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" strict mode (SHA"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"-derived"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" per"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" #939"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"9 volet"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" b),"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" local"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" shows"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" INT"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"RO ("}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"newly"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" introduced asymmetry"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":").\n\n"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"Per"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" C9682"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"-L1 ★★"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":": per"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"-pair rebaseline"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" with"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" `--"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"update"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" --"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"pair \"<"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"name>\"`,"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" NEVER"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" `--yes"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"-all-pairs`."}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 2, "content_block": {"type": "tool_use", "id": "call_56991f122a7c48909aebfafa", "name": "Bash", "input": {}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"command\":\"cd \\\"d:/Dev/CoursIA-c9684-search-4-duree\\\" && python scripts/notebook_tools/check_twin_parity.py --update --pair \\\"Search-4-LocalSearch\\\" --by \\\"myia-po-2023:CoursIA-2\\\" 2>&1 | tail -20\",\"description\":\"Per-pair rebaseline of Search-4-LocalSearch with new SHAs\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":2}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":105264,"output_tokens":214,"service_tier":"standard"}}
+
+event: message_stop
+data: {"type":"message_stop"}
+

--- a/packages/cli/src/test-fixtures/sse-responses/minimax-m3-anthropic-implicit-signature-r10416.sse
+++ b/packages/cli/src/test-fixtures/sse-responses/minimax-m3-anthropic-implicit-signature-r10416.sse
@@ -1,0 +1,134 @@
+# claudish response capture (reconstructed upstream stream)
+# source: production capture reqN=10416, MiniMax-M3 anthropic passthrough (2026-07)
+# The on-disk capture taped the OUTGOING stream (post-clamp): the old clamp
+# remapped content_block_start to sequential indices but let deltas/stops leak
+# at their upstream index. This fixture undoes the start remap (index+1 per start)
+# to restore the upstream stream the parser must absorb: implicit signature block
+# at 0 (signature_delta+stop, no start), text at 1, tool_use at 2.
+# verification: replaying the old clamp on this fixture reproduces the capture
+# event-for-event. Capture sha256=87E1926B52BB7374...
+# ==========================================================
+
+event: ping
+data: {"type":"ping"}
+
+event: message_start
+data: {"type":"message_start","message":{"id":"06c3b9b250191b480da3570519225a87","type":"message","role":"assistant","content":[],"model":"MiniMax-M3","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0,"service_tier":"standard"},"service_tier":"standard"}}
+
+event: ping
+data: {"type":"ping"}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 1, "content_block": {"type": "text", "text": ""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" 8 open PRs touching QuantConnect. #6891 is the"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" **scope-defining issue** for 7 quantbooks"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" honesty. **No active PR on those 7 quantbook"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" paths** (the open PRs are timing drains"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" with .ipynb extension, not the project quant"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"books). Let me also check QC-Py-"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"40/41 PaperTrading status and verify which projects have"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":" config.json:"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 2, "content_block": {"type": "tool_use", "id": "call_991f0dd36bb64cab89b91c94", "name": "Bash", "input": {}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"{\"command\": \"cd \\\"d:/Dev/Cours"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"IA-2\\\" && ls -la MyIA.A"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"I.Notebooks/QuantConnect/projects/ 2>&1 |"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" head -3 && echo \\\"--- projects list ---"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\\\" && ls -1 MyIA.AI.Not"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"ebooks/QuantConnect/projects/ 2>&1 | grep -"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"E \\\"AllWeather|DualMomentum|EMA"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"-Cross-Alpha|FuturesTrend|MomentumStrategy|R"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"iskParity|SectorMomentum|TurnOfMonth\\\" |"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" head -10 && echo \\\"--- config.json check"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" ---\\\" && for p in AllWeather DualMomentum EMA"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"-Cross-Alpha FuturesTrend MomentumStrategy RiskParity Sector"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"Momentum TurnOfMonth; do\\n  if"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" [ -f \\\"MyIA.AI.Notebooks/"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"QuantConnect/projects/${p}/config.json\\\" ]; then"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\\n    echo \\\"${p}/config.json EXISTS\\\"\\n   "}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" cat \\\"MyIA.AI.Notebooks/QuantConnect"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"/projects/${p}/config.json\\\" 2>&1"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" | head -5\\n    echo \\\"\\\"\\n  fi"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":"\\ndone\", \"description\": \"Check"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" which 7 quantbooks have config.json (QC"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":2,"delta":{"type":"input_json_delta","partial_json":" Cloud presence)\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":2}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"input_tokens":150556,"output_tokens":339,"cache_read_input_tokens":2176,"service_tier":"standard"}}
+
+event: message_stop
+data: {"type":"message_stop"}
+


### PR DESCRIPTION
## Summary

- Add content block index tracking and clamping in the Anthropic SSE passthrough stream parser
- Prevents "Content block not found" errors when providers (z.ai, MiniMax) send non-sequential content block indices
- Handles both filtered (thinking block suppression) and unfiltered code paths

## Problem

Some Anthropic-compatible providers (z.ai, MiniMax, Kimi) occasionally send SSE events with content block indices that jump or are non-sequential (e.g., 0 → 2, skipping 1). Claude Code expects sequential indices (0, 1, 2, ...) and throws "Content block not found" when it encounters a gap.

Additionally, when `filterThinking` is enabled and thinking blocks are suppressed, the re-indexing logic now properly tracks and clamps indices to prevent the same issue.

## Changes

- **Index tracking**: `highestSeenIndex` tracks the highest content block index seen so far
- **`clampIndex()`**: If an incoming index exceeds `highestSeenIndex + 1`, it's clamped down to the expected sequential value
- **`trackIndex()`**: Updates `highestSeenIndex` on `content_block_start` events
- **Filtered path**: Re-indexed blocks (after thinking suppression) are also clamped
- **Unfiltered path**: Both `content_block_start` remapping and delta/stop clamping applied
- **Logging**: Diagnostic logs when index jumps are detected, useful for debugging provider quirks

## Test plan

- [ ] Verify existing format translation tests still pass: `bun test packages/cli/src/format-translation.test.ts`
- [ ] Manual: `claudish --model zai/claude-sonnet-4-20250514 "use webReader to fetch https://example.com"` — should complete without "Content block not found"
- [ ] Manual: test with a thinking-enabled model that uses `filterThinking` — verify re-indexing is correct
- [ ] Check debug logs for `[AnthropicSSE] Index jump detected` messages when using z.ai or MiniMax

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>