### PR TITLE
Fix OpenAI reasoning effort mapping

### DIFF
--- a/packages/cli/src/adapters/codex-api-format.ts
+++ b/packages/cli/src/adapters/codex-api-format.ts
@@ -11,8 +11,9 @@
  * This format handles Codex models only. All other OpenAI models use OpenAIAPIFormat.
  */
 
-import { BaseAPIFormat, type AdapterResult, matchesModelFamily } from "./base-api-format.js";
 import type { StreamFormat } from "../providers/transport/types.js";
+import { type AdapterResult, BaseAPIFormat, matchesModelFamily } from "./base-api-format.js";
+import { getCodexReasoningEffortFromClaudeRequest } from "./openai-reasoning-effort.js";
 
 /**
  * Normalize model name for ChatGPT backend API.
@@ -38,10 +39,6 @@ export function normalizeCodexModel(modelId: string | undefined): string {
 }
 
 export class CodexAPIFormat extends BaseAPIFormat {
-  constructor(modelId: string) {
-    super(modelId);
-  }
-
   processTextContent(textContent: string, _accumulatedText: string): AdapterResult {
     return {
       cleanedText: textContent,
@@ -51,7 +48,8 @@ export class CodexAPIFormat extends BaseAPIFormat {
   }
 
   shouldHandle(modelId: string): boolean {
-    return matchesModelFamily(modelId, "codex");
+    const model = normalizeCodexModel(modelId).toLowerCase();
+    return matchesModelFamily(modelId, "codex") || model.includes("codex");
   }
 
   getName(): string {
@@ -65,6 +63,7 @@ export class CodexAPIFormat extends BaseAPIFormat {
   override buildPayload(claudeRequest: any, messages: any[], tools: any[]): any {
     const convertedMessages = this.convertMessagesToResponsesAPI(messages);
     const normalizedModel = normalizeCodexModel(this.modelId);
+    const effort = getCodexReasoningEffortFromClaudeRequest(claudeRequest, normalizedModel);
 
     // Strip IDs from message items (stateless mode doesn't support server-side state)
     const strippedMessages = convertedMessages.map((item: any) => {
@@ -79,7 +78,7 @@ export class CodexAPIFormat extends BaseAPIFormat {
       store: false,
       include: ["reasoning.encrypted_content"],
       reasoning: {
-        effort: "medium",
+        effort,
         summary: "auto",
       },
       text: {

--- a/packages/cli/src/adapters/openai-api-format.ts
+++ b/packages/cli/src/adapters/openai-api-format.ts
@@ -3,7 +3,7 @@
  *
  * Handles:
  * - Context window detection for OpenAI models (gpt-*, o1, o3, codex)
- * - Mapping 'thinking.budget_tokens' to 'reasoning_effort' for o1/o3 models
+ * - Mapping Claude Code effort to OpenAI 'reasoning_effort' for reasoning models
  * - max_completion_tokens vs max_tokens for newer models
  * - Codex Responses API message conversion and payload building
  * - Tool choice mapping
@@ -11,15 +11,15 @@
  * Also serves as Layer 2 ModelDialect for OpenAI-native models (o1/o3 reasoning params).
  */
 
-import { BaseAPIFormat, type AdapterResult } from "./base-api-format.js";
 import { log } from "../logger.js";
 import type { StreamFormat } from "../providers/transport/types.js";
+import { type AdapterResult, BaseAPIFormat } from "./base-api-format.js";
+import {
+  getOpenAIReasoningEffortFromClaudeRequest,
+  isOpenAIReasoningModel,
+} from "./openai-reasoning-effort.js";
 
 export class OpenAIAPIFormat extends BaseAPIFormat {
-  constructor(modelId: string) {
-    super(modelId);
-  }
-
   processTextContent(textContent: string, accumulatedText: string): AdapterResult {
     return {
       cleanedText: textContent,
@@ -36,17 +36,13 @@ export class OpenAIAPIFormat extends BaseAPIFormat {
    * Handle request preparation — reasoning parameters and tool name truncation
    */
   override prepareRequest(request: any, originalRequest: any): any {
-    // Map thinking.budget_tokens -> reasoning_effort for o1/o3 models
-    if (originalRequest.thinking && this.isReasoningModel()) {
-      const { budget_tokens } = originalRequest.thinking;
-      let effort = "medium";
-      if (budget_tokens < 4000) effort = "minimal";
-      else if (budget_tokens < 16000) effort = "low";
-      else if (budget_tokens >= 32000) effort = "high";
-
-      request.reasoning_effort = effort;
-      delete request.thinking;
-      log(`[OpenAIAPIFormat] Mapped budget ${budget_tokens} -> reasoning_effort: ${effort}`);
+    if (this.isReasoningModel() && this.isChatCompletionsPayload(request)) {
+      const effort = getOpenAIReasoningEffortFromClaudeRequest(originalRequest, this.modelId);
+      if (effort) {
+        request.reasoning_effort = effort;
+        log(`[OpenAIAPIFormat] Mapped Claude effort -> reasoning_effort: ${effort}`);
+      }
+      request.thinking = undefined;
     }
 
     // Truncate tool names if model has a limit
@@ -59,7 +55,7 @@ export class OpenAIAPIFormat extends BaseAPIFormat {
   }
 
   shouldHandle(modelId: string): boolean {
-    return modelId.startsWith("oai/") || modelId.includes("o1") || modelId.includes("o3");
+    return modelId.toLowerCase().startsWith("oai/") || isOpenAIReasoningModel(modelId);
   }
 
   getName(): string {
@@ -75,8 +71,11 @@ export class OpenAIAPIFormat extends BaseAPIFormat {
   // ─── Private helpers ───────────────────────────────────────────────
 
   private isReasoningModel(): boolean {
-    const model = this.modelId.toLowerCase();
-    return model.includes("o1") || model.includes("o3");
+    return isOpenAIReasoningModel(this.modelId);
+  }
+
+  private isChatCompletionsPayload(request: any): boolean {
+    return Array.isArray(request?.messages);
   }
 
   private usesMaxCompletionTokens(): boolean {
@@ -117,17 +116,13 @@ export class OpenAIAPIFormat extends BaseAPIFormat {
       }
     }
 
-    // Reasoning params handled in prepareRequest instead
-    if (claudeRequest.thinking && this.isReasoningModel()) {
-      const { budget_tokens } = claudeRequest.thinking;
-      let effort = "medium";
-      if (budget_tokens < 4000) effort = "minimal";
-      else if (budget_tokens < 16000) effort = "low";
-      else if (budget_tokens >= 32000) effort = "high";
-      payload.reasoning_effort = effort;
-      log(
-        `[OpenAIAPIFormat] Mapped thinking.budget_tokens ${budget_tokens} -> reasoning_effort: ${effort}`
-      );
+    // Reasoning params are also handled in prepareRequest; set them here for direct buildPayload users.
+    if (this.isReasoningModel()) {
+      const effort = getOpenAIReasoningEffortFromClaudeRequest(claudeRequest, this.modelId);
+      if (effort) {
+        payload.reasoning_effort = effort;
+        log(`[OpenAIAPIFormat] Mapped Claude effort -> reasoning_effort: ${effort}`);
+      }
     }
 
     return payload;

--- a/packages/cli/src/adapters/openai-reasoning-effort.ts
+++ b/packages/cli/src/adapters/openai-reasoning-effort.ts
@@ -1,0 +1,150 @@
+export type ClaudeCodeEffort = "low" | "medium" | "high" | "xhigh" | "max";
+export type OpenAIReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
+export type CodexReasoningEffort = "low" | "medium" | "high" | "xhigh";
+
+const GPT5_XHIGH_SUPPORTED_MINORS = new Set([2, 4, 5]);
+const GPT5_NEWER_MINOR_XHIGH_FLOOR = 6;
+const GPT5_CODEX_XHIGH_SUPPORTED_MINORS = new Set([2, 3]);
+const GPT5_CODEX_NEWER_MINOR_XHIGH_FLOOR = 4;
+
+export function getClaudeCodeEffort(claudeRequest: any): ClaudeCodeEffort | undefined {
+  return normalizeClaudeCodeEffort(claudeRequest?.output_config?.effort);
+}
+
+export function getOpenAIReasoningEffortFromClaudeRequest(
+  claudeRequest: any,
+  modelId: string
+): OpenAIReasoningEffort | undefined {
+  const effort = getClaudeCodeEffort(claudeRequest);
+  if (effort) return mapClaudeCodeEffortToOpenAIReasoningEffort(effort, modelId);
+
+  const budgetTokens = claudeRequest?.thinking?.budget_tokens;
+  if (budgetTokens !== undefined) {
+    return mapThinkingBudgetToOpenAIReasoningEffort(budgetTokens, modelId);
+  }
+
+  return undefined;
+}
+
+export function getCodexReasoningEffortFromClaudeRequest(
+  claudeRequest: any,
+  modelId: string
+): CodexReasoningEffort {
+  const effort = getClaudeCodeEffort(claudeRequest);
+  if (effort) return mapClaudeCodeEffortToCodexReasoningEffort(effort, modelId);
+
+  const budgetTokens = claudeRequest?.thinking?.budget_tokens;
+  if (budgetTokens !== undefined) {
+    return mapThinkingBudgetToCodexReasoningEffort(budgetTokens, modelId);
+  }
+
+  return "medium";
+}
+
+export function isOpenAIReasoningModel(modelId: string): boolean {
+  const model = stripProviderPrefix(modelId);
+  if (model.includes("chat-latest")) return false;
+  return (
+    model.startsWith("o1") ||
+    model.startsWith("o3") ||
+    model.startsWith("o4") ||
+    model.startsWith("gpt-5")
+  );
+}
+
+function mapClaudeCodeEffortToOpenAIReasoningEffort(
+  effort: ClaudeCodeEffort,
+  modelId: string
+): OpenAIReasoningEffort {
+  if (effort === "max") {
+    return supportsXHighReasoningEffort(modelId) ? "xhigh" : "high";
+  }
+  if (effort === "xhigh" && !supportsXHighReasoningEffort(modelId)) {
+    return "high";
+  }
+  return effort;
+}
+
+function mapClaudeCodeEffortToCodexReasoningEffort(
+  effort: ClaudeCodeEffort,
+  modelId: string
+): CodexReasoningEffort {
+  if (effort === "max") {
+    return supportsXHighReasoningEffort(modelId) ? "xhigh" : "high";
+  }
+  if (effort === "xhigh" && !supportsXHighReasoningEffort(modelId)) {
+    return "high";
+  }
+  return effort;
+}
+
+function supportsXHighReasoningEffort(modelId: string): boolean {
+  const model = stripProviderPrefix(modelId);
+  if (model.startsWith("gpt-5.1-codex-max")) return true;
+
+  const codexMatch = model.match(/^gpt-5\.(\d+)-codex(?:-|$)/);
+  if (codexMatch) {
+    const minor = Number(codexMatch[1]);
+    return (
+      GPT5_CODEX_XHIGH_SUPPORTED_MINORS.has(minor) ||
+      minor >= GPT5_CODEX_NEWER_MINOR_XHIGH_FLOOR
+    );
+  }
+
+  const gpt5Match = model.match(/^gpt-5\.(\d+)(?:-|$)/);
+  if (!gpt5Match) return false;
+
+  const minor = Number(gpt5Match[1]);
+  return GPT5_XHIGH_SUPPORTED_MINORS.has(minor) || minor >= GPT5_NEWER_MINOR_XHIGH_FLOOR;
+}
+
+function supportsMinimalReasoningEffort(modelId: string | undefined): boolean {
+  if (!modelId) return true;
+
+  const model = stripProviderPrefix(modelId);
+  const gpt5Match = model.match(/^gpt-5(?:\.(\d+))?(?:-|$)/);
+  return !gpt5Match?.[1];
+}
+
+function normalizeClaudeCodeEffort(value: unknown): ClaudeCodeEffort | undefined {
+  if (typeof value !== "string") return undefined;
+  const effort = value.toLowerCase().replace(/[-_\s]/g, "");
+  if (
+    effort === "low" ||
+    effort === "medium" ||
+    effort === "high" ||
+    effort === "xhigh" ||
+    effort === "max"
+  ) {
+    return effort;
+  }
+  return undefined;
+}
+
+function stripProviderPrefix(modelId: string): string {
+  const lower = modelId.toLowerCase();
+  if (lower.includes("@")) return lower.split("@").pop()!.trim();
+  if (lower.includes("/")) return lower.split("/").pop()!.trim();
+  return lower.trim();
+}
+
+export function mapThinkingBudgetToOpenAIReasoningEffort(
+  budgetTokens: unknown,
+  modelId?: string
+): OpenAIReasoningEffort {
+  const budget = Number(budgetTokens);
+  if (!Number.isFinite(budget)) return "medium";
+
+  if (budget < 4000) return supportsMinimalReasoningEffort(modelId) ? "minimal" : "low";
+  if (budget < 16000) return "low";
+  if (budget >= 32000) return "high";
+  return "medium";
+}
+
+export function mapThinkingBudgetToCodexReasoningEffort(
+  budgetTokens: unknown,
+  modelId?: string
+): CodexReasoningEffort {
+  const effort = mapThinkingBudgetToOpenAIReasoningEffort(budgetTokens, modelId);
+  return effort === "minimal" ? "low" : effort;
+}

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -551,10 +551,10 @@ describe("Model Adapter Quirks", () => {
     expect(request.temperature).toBe(0.7);
   });
 
-  test("MiniMaxModelDialect: unknown minimax model → context window 0", async () => {
+  test("MiniMaxModelDialect: known minimax model → catalog context window", async () => {
     const { MiniMaxModelDialect } = await import("./adapters/minimax-model-dialect.js");
     const adapter = new MiniMaxModelDialect("minimax-m2.5");
-    expect(adapter.getContextWindow()).toBe(0);
+    expect(adapter.getContextWindow()).toBe(204800);
   });
 
   test("MiniMaxModelDialect: supportsVision returns false", async () => {
@@ -573,6 +573,215 @@ describe("Model Adapter Quirks", () => {
     adapter.prepareRequest(request, original);
     expect(request.reasoning_effort).toBe("high");
     expect(request.thinking).toBeUndefined();
+  });
+
+  test("OpenAIAPIFormat: output_config.effort → reasoning_effort for GPT-5 reasoning models", async () => {
+    const { OpenAIAPIFormat } = await import("./adapters/openai-api-format.js");
+    const adapter = new OpenAIAPIFormat("gpt-5.2");
+
+    const request: any = { model: "gpt-5.2", messages: [], thinking: { type: "adaptive" } };
+    const original = { thinking: { type: "adaptive" }, output_config: { effort: "xhigh" } };
+
+    adapter.prepareRequest(request, original);
+    expect(request.reasoning_effort).toBe("xhigh");
+    expect(request.thinking).toBeUndefined();
+  });
+
+  test("OpenAIAPIFormat: max Claude effort caps to high for GPT-5 models without xhigh", async () => {
+    const { OpenAIAPIFormat } = await import("./adapters/openai-api-format.js");
+
+    for (const model of ["gpt-5", "gpt-5.1", "gpt-5.3"]) {
+      const adapter = new OpenAIAPIFormat(model);
+      const request: any = { model, messages: [], thinking: { type: "adaptive" } };
+      const original = { thinking: { type: "adaptive" }, output_config: { effort: "max" } };
+
+      adapter.prepareRequest(request, original);
+      expect(request.reasoning_effort).toBe("high");
+      expect(request.thinking).toBeUndefined();
+    }
+  });
+
+  test("OpenAIAPIFormat: max Claude effort maps to xhigh for supported and newer GPT-5 models", async () => {
+    const { OpenAIAPIFormat } = await import("./adapters/openai-api-format.js");
+
+    for (const model of ["gpt-5.2", "gpt-5.4", "gpt-5.5", "gpt-5.6"]) {
+      const adapter = new OpenAIAPIFormat(model);
+      const request: any = { model, messages: [], thinking: { type: "adaptive" } };
+      const original = { thinking: { type: "adaptive" }, output_config: { effort: "max" } };
+
+      adapter.prepareRequest(request, original);
+      expect(request.reasoning_effort).toBe("xhigh");
+      expect(request.thinking).toBeUndefined();
+    }
+  });
+
+  test("OpenAIAPIFormat: legacy thinking budget does not emit minimal for GPT-5.2", async () => {
+    const { OpenAIAPIFormat } = await import("./adapters/openai-api-format.js");
+    const adapter = new OpenAIAPIFormat("gpt-5.2");
+
+    const request: any = { model: "gpt-5.2", messages: [], thinking: { budget_tokens: 1000 } };
+    const original = { thinking: { budget_tokens: 1000 } };
+
+    adapter.prepareRequest(request, original);
+    expect(request.reasoning_effort).toBe("low");
+    expect(request.thinking).toBeUndefined();
+  });
+
+  test("CodexAPIFormat: output_config.effort controls Responses API reasoning effort", async () => {
+    const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
+    const adapter = new CodexAPIFormat("gpt-5-codex");
+
+    const payload = adapter.buildPayload(
+      {
+        system: "system",
+        max_tokens: 1024,
+        thinking: { type: "adaptive" },
+        output_config: { effort: "high" },
+      },
+      [{ role: "user", content: "hello" }],
+      []
+    );
+
+    expect(payload.reasoning).toEqual({ effort: "high", summary: "auto" });
+  });
+
+  test("CodexAPIFormat: max Claude effort caps to high for GPT-5 Codex models without xhigh", async () => {
+    const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
+
+    for (const model of [
+      "gpt-5-codex",
+      "gpt-5.1-codex",
+      "gpt-5.1-codex-mini",
+    ]) {
+      const adapter = new CodexAPIFormat(model);
+      const payload = adapter.buildPayload(
+        {
+          system: "system",
+          max_tokens: 1024,
+          thinking: { type: "adaptive" },
+          output_config: { effort: "max" },
+        },
+        [{ role: "user", content: "hello" }],
+        []
+      );
+
+      expect(payload.reasoning).toEqual({ effort: "high", summary: "auto" });
+    }
+  });
+
+  test("CodexAPIFormat: max Claude effort caps to high for GPT-5.1", async () => {
+    const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
+    const adapter = new CodexAPIFormat("gpt-5.1");
+
+    const payload = adapter.buildPayload(
+      {
+        system: "system",
+        max_tokens: 1024,
+        thinking: { type: "adaptive" },
+        output_config: { effort: "max" },
+      },
+      [{ role: "user", content: "hello" }],
+      []
+    );
+
+    expect(payload.reasoning).toEqual({ effort: "high", summary: "auto" });
+  });
+
+  test("CodexAPIFormat: max Claude effort maps to xhigh for GPT-5.2 and GPT-5.5", async () => {
+    const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
+
+    for (const model of ["gpt-5.2", "gpt-5.5"]) {
+      const adapter = new CodexAPIFormat(model);
+      const payload = adapter.buildPayload(
+        {
+          system: "system",
+          max_tokens: 1024,
+          thinking: { type: "adaptive" },
+          output_config: { effort: "max" },
+        },
+        [{ role: "user", content: "hello" }],
+        []
+      );
+
+      expect(payload.reasoning).toEqual({ effort: "xhigh", summary: "auto" });
+    }
+  });
+
+  test("CodexAPIFormat: max Claude effort maps to xhigh for supported Codex model IDs", async () => {
+    const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
+
+    for (const model of [
+      "gpt-5.1-codex-max",
+      "gpt-5.2-codex",
+      "gpt-5.3-codex",
+      "gpt-5.3-codex-spark",
+      "gpt-5.4-codex",
+      "gpt-5.6-codex",
+    ]) {
+      const adapter = new CodexAPIFormat(model);
+      const payload = adapter.buildPayload(
+        {
+          system: "system",
+          max_tokens: 1024,
+          thinking: { type: "adaptive" },
+          output_config: { effort: "max" },
+        },
+        [{ role: "user", content: "hello" }],
+        []
+      );
+
+      expect(payload.reasoning).toEqual({ effort: "xhigh", summary: "auto" });
+    }
+  });
+
+  test("CodexAPIFormat: low Claude effort maps to Codex-supported low effort", async () => {
+    const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
+    const adapter = new CodexAPIFormat("gpt-5-codex");
+
+    const payload = adapter.buildPayload(
+      {
+        system: "system",
+        max_tokens: 1024,
+        thinking: { type: "adaptive" },
+        output_config: { effort: "low" },
+      },
+      [{ role: "user", content: "hello" }],
+      []
+    );
+
+    expect(payload.reasoning).toEqual({ effort: "low", summary: "auto" });
+  });
+
+  test("CodexAPIFormat: defaults to medium reasoning effort without thinking budget", async () => {
+    const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
+    const adapter = new CodexAPIFormat("gpt-5-codex");
+
+    const payload = adapter.buildPayload(
+      { system: "system", max_tokens: 1024 },
+      [{ role: "user", content: "hello" }],
+      []
+    );
+
+    expect(payload.reasoning).toEqual({ effort: "medium", summary: "auto" });
+  });
+
+  test("OpenAIAPIFormat dialect does not add reasoning_effort to Codex Responses payloads", async () => {
+    const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
+    const { OpenAIAPIFormat } = await import("./adapters/openai-api-format.js");
+    const codexAdapter = new CodexAPIFormat("gpt-5.5");
+    const openAIDialect = new OpenAIAPIFormat("gpt-5.5");
+    const original = {
+      system: "system",
+      max_tokens: 1024,
+      thinking: { type: "adaptive" },
+      output_config: { effort: "xhigh" },
+    };
+
+    const payload = codexAdapter.buildPayload(original, [{ role: "user", content: "hello" }], []);
+    openAIDialect.prepareRequest(payload, original);
+
+    expect(payload.reasoning).toEqual({ effort: "xhigh", summary: "auto" });
+    expect(payload.reasoning_effort).toBeUndefined();
   });
 
   test("GLMAdapter: strips thinking params", async () => {
@@ -642,6 +851,7 @@ describe("CodexAdapter", () => {
     const { CodexAPIFormat } = await import("./adapters/codex-api-format.js");
     expect(new CodexAPIFormat("codex-mini").shouldHandle("codex-mini")).toBe(true);
     expect(new CodexAPIFormat("codex-mini").shouldHandle("codex-davinci-002")).toBe(true);
+    expect(new CodexAPIFormat("gpt-5-codex").shouldHandle("gpt-5-codex")).toBe(true);
   });
 
   test("shouldHandle returns false for non-codex models", async () => {
@@ -663,6 +873,7 @@ describe("CodexAdapter", () => {
   test("AdapterManager selects CodexAPIFormat for codex-mini", async () => {
     const { DialectManager } = await import("./adapters/dialect-manager.js");
     expect(new DialectManager("codex-mini").getAdapter().getName()).toBe("CodexAPIFormat");
+    expect(new DialectManager("gpt-5-codex").getAdapter().getName()).toBe("CodexAPIFormat");
   });
 });
 

--- a/packages/cli/src/providers/provider-profiles.ts
+++ b/packages/cli/src/providers/provider-profiles.ts
@@ -116,7 +116,10 @@ const geminiCodeAssistProfile: ProviderProfile = {
 const openaiProfile: ProviderProfile = {
   createHandler(ctx) {
     const transport = new OpenAIProviderTransport(ctx.provider, ctx.modelName, ctx.apiKey);
-    const adapter = new OpenAIAPIFormat(ctx.modelName);
+    const isCodexModel = ctx.modelName.toLowerCase().includes("codex");
+    const adapter = isCodexModel
+      ? new CodexAPIFormat(ctx.modelName)
+      : new OpenAIAPIFormat(ctx.modelName);
     const handler = new ComposedHandler(transport, ctx.targetModel, ctx.modelName, ctx.port, {
       adapter,
       tokenStrategy: "delta-aware",

--- a/packages/cli/src/providers/provider-routing.test.ts
+++ b/packages/cli/src/providers/provider-routing.test.ts
@@ -467,3 +467,22 @@ describe("OpenCode Zen — model routing", () => {
     expect(adapter.getStreamFormat()).toBe("openai-responses-sse");
   });
 });
+
+describe("OpenAI profile — Codex model routing", () => {
+  const openAIBaseProvider = BUILTIN_PROVIDERS.find((p) => p.name === "openai")!;
+  const sharedCtx = {
+    provider: openAIBaseProvider as any,
+    apiKey: "test-key",
+    targetModel: "oai@gpt-5-codex",
+    port: 4000,
+    sharedOpts: { isInteractive: false as const, invocationMode: "explicit-model" as const },
+  };
+
+  test("direct OpenAI Codex models use CodexAPIFormat", () => {
+    const profile = PROVIDER_PROFILES["openai"];
+    const handler = profile.createHandler({ ...sharedCtx, modelName: "gpt-5-codex" }) as any;
+
+    expect(handler).not.toBeNull();
+    expect(handler.explicitAdapter).toBeInstanceOf(CodexAPIFormat);
+  });
+});


### PR DESCRIPTION
## Problem

Claude Code now sends the selected thinking effort in `output_config.effort` while keeping `thinking: { type: "adaptive" }`. Claudish was still primarily deriving OpenAI reasoning effort from legacy `thinking.budget_tokens`.

For direct OpenAI Codex routes, the Responses payload could also pass through the OpenAI Chat Completions dialect and get an unsupported top-level `reasoning_effort`, causing 400 errors like:

`Unsupported parameter: reasoning_effort`

## Summary

Fixes Claude Code thinking effort propagation for OpenAI and Codex upstream providers.

- Read Claude Code's current `output_config.effort` values: `low`, `medium`, `high`, `xhigh`, `max`.
- Map OpenAI Chat Completions requests to `reasoning_effort` only when the payload is actually chat-completions shaped.
- Map Codex/Responses requests to `reasoning.effort`.
- Cap `xhigh` / `max` to `high` for older GPT-5 and Codex model IDs that do not support `xhigh`.
- Route direct OpenAI Codex model names through `CodexAPIFormat`.
- Add coverage for `gpt-5.3-codex-spark`, current `xhigh`-capable models, older capped models, and future GPT-5 minor IDs.
- Update the stale MiniMax context-window assertion so the full format-translation suite is green.

## Validation

- `bun test packages/cli/src/format-translation.test.ts`
- `bun test packages/cli/src/providers/provider-routing.test.ts`