### PR TITLE
fix(cli): detect Bun on Windows in launcher (which → where)

### DIFF
--- a/packages/cli/bin/claudish.cjs
+++ b/packages/cli/bin/claudish.cjs
@@ -8,17 +8,27 @@ const { execFileSync, execSync } = require("child_process");
 const { resolve } = require("path");
 
 function findBun() {
+  const isWin = process.platform === "win32";
+  // PATH lookup — "which" is POSIX-only; Windows uses "where".
   try {
-    const path = execSync("which bun", { encoding: "utf-8" }).trim();
-    if (path) return path;
+    const out = execSync(isWin ? "where bun" : "which bun", { encoding: "utf-8" }).trim();
+    const first = out.split(/\r?\n/).map((l) => l.trim()).find(Boolean);
+    if (first) return first;
   } catch {}
   // Common install locations
-  const candidates = [
-    process.env.HOME + "/.bun/bin/bun",
-    "/usr/local/bin/bun",
-    "/opt/homebrew/bin/bun",
-  ];
+  const home = process.env.HOME || process.env.USERPROFILE;
+  const candidates = isWin
+    ? [
+        home && resolve(home, ".bun", "bin", "bun.exe"),
+        home && resolve(home, ".bun", "bin", "bun"),
+      ]
+    : [
+        home && home + "/.bun/bin/bun",
+        "/usr/local/bin/bun",
+        "/opt/homebrew/bin/bun",
+      ];
   for (const c of candidates) {
+    if (!c) continue;
     try {
       execFileSync(c, ["--version"], { stdio: "ignore" });
       return c;
@@ -29,10 +39,14 @@ function findBun() {
 
 const bun = findBun();
 if (!bun) {
+  const installCmd =
+    process.platform === "win32"
+      ? 'powershell -c "irm bun.sh/install.ps1 | iex"'
+      : "curl -fsSL https://bun.sh/install | bash";
   console.error(`claudish requires the Bun runtime but it was not found.
 
 Install Bun (one command):
-  curl -fsSL https://bun.sh/install | bash
+  ${installCmd}
 
 Then retry:
   claudish --version


### PR DESCRIPTION
## Problem

On Windows, `claudish` fails to launch even when Bun is installed and on `PATH`:

```
'which' is not recognized as an internal or external command,
operable program or batch file.
claudish requires the Bun runtime but it was not found.
```

`bin/claudish.cjs` `findBun()` is POSIX-only:

1. `execSync("which bun")` — `which` doesn't exist in cmd/PowerShell, so the lookup throws.
2. The fallback candidates are all Unix paths (`$HOME/.bun/bin/bun`, `/usr/local/bin/bun`, `/opt/homebrew/bin/bun`) — none match the Windows install location `%USERPROFILE%\.bun\bin\bun.exe`.
3. `process.env.HOME` is typically unset on Windows (it's `USERPROFILE`), so even the first candidate resolves to `undefined/.bun/bin/bun`.

Net effect: a correctly installed Bun is reported as missing on every Windows machine.

## Fix

- Use `where bun` on `win32`, `which bun` elsewhere; take the first returned line.
- Add Windows fallback candidates `%USERPROFILE%\.bun\bin\bun.exe` (and extensionless), using `HOME || USERPROFILE`.
- Make the "install Bun" hint platform-aware — Windows users get the PowerShell one-liner (`irm bun.sh/install.ps1 | iex`) instead of `curl … | bash`.

No behavior change on macOS/Linux (same `which` path and same Unix candidates).

## Testing

- Windows 11 + Bun 1.3.13 on PATH: `claudish --version` → `claudish version 7.1.2` (was failing before).
- `node --check bin/claudish.cjs` passes.