### PR TITLE
fix(anthropic-sse): suppress server_tool_use blocks and handle empty responses

### DIFF
--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -68,6 +68,9 @@ export function createAnthropicPassthroughStream(
           let textChunks = 0;
           let toolUseBlocks = 0;
           let stopReason: string | null = null;
+          let sawMessageStart = false;
+          let sawMessageStop = false;
+          let suppressedServerTools = 0;
 
           // Thinking-block filtering state
           let insideThinkingBlock = false;
@@ -137,6 +140,20 @@ export function createAnthropicPassthroughStream(
                     continue;
                   }
 
+                  // Suppress server_tool_use blocks (Z.AI built-in tools)
+                  if (
+                    data.type === "content_block_start" &&
+                    data.content_block?.type === "server_tool_use"
+                  ) {
+                    suppressedServerTools++;
+                    log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
+                    continue;
+                  }
+                  if (data.type === "content_block_stop" && suppressedServerTools > 0) {
+                    suppressedServerTools--;
+                    continue;
+                  }
+
                   // Re-index non-thinking content blocks
                   // After suppressing N thinking blocks, subtract N from the index
                   if (typeof data.index === "number" && thinkingBlocksSuppressed > 0) {
@@ -189,6 +206,20 @@ export function createAnthropicPassthroughStream(
                       return; // stop processing further lines
                     }
 
+                    // Suppress server_tool_use blocks (Z.AI built-in tools)
+                    if (
+                      data.type === "content_block_start" &&
+                      data.content_block?.type === "server_tool_use"
+                    ) {
+                      suppressedServerTools++;
+                      log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
+                      continue;
+                    }
+                    if (data.type === "content_block_stop" && suppressedServerTools > 0) {
+                      suppressedServerTools--;
+                      continue;
+                    }
+
                     // No error — pass through the line
                     if (!isClosed) {
                       controller.enqueue(encoder.encode(line + "\n"));
@@ -219,6 +250,12 @@ export function createAnthropicPassthroughStream(
                     }
                     if (data.type === "message_delta" && data.delta?.stop_reason) {
                       stopReason = data.delta.stop_reason;
+                    }
+                    if (data.type === "message_stop") {
+                      sawMessageStop = true;
+                    }
+                    if (data.type === "message_start") {
+                      sawMessageStart = true;
                     }
                   } catch {
                     // Unparseable data line — pass through
@@ -261,6 +298,12 @@ export function createAnthropicPassthroughStream(
                   if (data.type === "message_delta" && data.delta?.stop_reason) {
                     stopReason = data.delta.stop_reason;
                   }
+                  if (data.type === "message_stop") {
+                    sawMessageStop = true;
+                  }
+                  if (data.type === "message_start") {
+                    sawMessageStart = true;
+                  }
                 } catch {}
               }
             }
@@ -276,6 +319,41 @@ export function createAnthropicPassthroughStream(
           }
 
           if (!isClosed) {
+            // Handle empty responses — providers sometimes return no content blocks at all.
+            // Emit a synthetic message so downstream doesn't hang waiting for content.
+            if (!sawMessageStart) {
+              const synthId = `msg_${Date.now()}`;
+              log(`[AnthropicSSE] No message_start received — emitting synthetic empty response`);
+              controller.enqueue(encoder.encode(
+                "event: message_start\n" +
+                `data: {"type":"message_start","message":{"id":"${synthId}","type":"message","role":"assistant","model":"${opts.modelName}","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":${inputTokens},"output_tokens":${outputTokens}}}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_start\n" +
+                `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_delta\n" +
+                `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"[Error: The model returned an empty response. Try compacting the conversation or reducing the context size.]"}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_stop\n" +
+                `data: {"type":"content_block_stop","index":0}\n\n`
+              ));
+            }
+
+            // Emit synthetic message_stop if the provider omitted it
+            if (!sawMessageStop) {
+              controller.enqueue(encoder.encode(
+                "event: message_delta\n" +
+                `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":${outputTokens}}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: message_stop\n" +
+                `data: {"type":"message_stop"}\n\n`
+              ));
+            }
+
             isClosed = true;
             if (pingInterval) {
               clearInterval(pingInterval);


### PR DESCRIPTION
## Problem

Z.AI and GLM providers emit `server_tool_use` content blocks for their built-in tools (e.g., web search). These blocks confuse downstream consumers (Claude Code) that only expect `text`, `thinking`, and `tool_use` block types, causing parse errors or dropped content.

Additionally, some providers occasionally return completely empty responses (no `message_start` event at all), which causes the client to hang waiting for content.

## Changes

**File:** `packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts`

1. **Server tool suppression** -- Detect `content_block_start` with `type: "server_tool_use"` in both the filterThinking and non-filterThinking code paths and suppress them (skip the SSE event). A counter tracks nesting so `content_block_stop` events are properly matched.

2. **Message lifecycle tracking** -- Track `sawMessageStart` and `sawMessageStop` flags so the finalizer can detect when the provider omitted lifecycle events.

3. **Empty response handling** -- When no `message_start` was received, emit a synthetic message with a text block containing an actionable error message ("Try compacting the conversation or reducing the context size").

4. **Synthetic message_stop** -- When the provider omits `message_delta`+`message_stop`, emit them so the client stream terminates cleanly.

## Providers affected

- Z.AI (GLM models via Anthropic transport)
- GLM direct
- MiniMax, Kimi ( Anthropic transport, rare edge case)

## How to test

```bash
claudish --model zai@glm-4.7 --debug "search the web for Claude Code"
# Verify: no server_tool_use blocks in output, stream terminates normally

claudish --model zai@glm-4.7 --debug ""  # empty prompt, may trigger empty response
# Verify: synthetic error message appears, no hang
```