### PR TITLE
feat(web-search): intercept web search tool calls and execute via SearXNG

### DIFF
--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -16,6 +16,7 @@ import {
   type ToolSchema,
 } from "../tool-call-recovery.js";
 import { isWebSearchToolCall, warnWebSearchUnsupported } from "../web-search-detector.js";
+import { executeWebSearch, extractSearchQuery } from "../web-search-executor.js";
 
 export interface StreamingState {
   usage: any;
@@ -39,6 +40,7 @@ export interface ToolState {
   closed: boolean;
   arguments: string; // Accumulated JSON arguments string
   buffered: boolean; // Whether we're buffering args until tool call completes
+  suppressed?: boolean; // Whether this tool call was suppressed (e.g. web search intercepted)
 }
 
 /**
@@ -195,11 +197,76 @@ export function createStreamingResponseHandler(
             }
           }
 
+          // Detect GLM <searchWeb> tags in accumulated text and execute via SearXNG.
+          // GLM models emit <searchWeb>query</searchWeb> when they want to search.
+          const searchWebRegex = /<searchWeb>([\s\S]*?)<\/searchWeb>/g;
+          let searchMatch: RegExpExecArray | null;
+          const searchQueries: string[] = [];
+          let cleanText = state.accumulatedText;
+          while ((searchMatch = searchWebRegex.exec(state.accumulatedText)) !== null) {
+            searchQueries.push(searchMatch[1].trim());
+          }
+          if (searchQueries.length > 0) {
+            log(`[Streaming] Found ${searchQueries.length} <searchWeb> tag(s) in text`);
+            cleanText = state.accumulatedText.replace(searchWebRegex, "").trim();
+            // Strip the search tags from output if text block is still open
+            // Results will be appended after the search queries
+          }
+
           if (state.reasoningStarted) {
             send("content_block_stop", { type: "content_block_stop", index: state.reasoningIdx });
           }
           if (state.textStarted) {
             send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
+          }
+
+          // Handle suppressed web search tool calls — execute via SearXNG and inject results as text.
+          for (const t of Array.from(state.tools.values())) {
+            if (t.suppressed && !t.closed) {
+              const query = extractSearchQuery(t.arguments);
+              log(`[Streaming] Executing suppressed web search: "${query}"`);
+              const results = await executeWebSearch(query);
+              log(`[Streaming] Web search results: ${results.length} chars`);
+
+              // Inject results as a text block
+              if (!state.textStarted) {
+                state.textIdx = state.curIdx++;
+                send("content_block_start", {
+                  type: "content_block_start",
+                  index: state.textIdx,
+                  content_block: { type: "text", text: "" },
+                });
+                state.textStarted = true;
+              }
+              send("content_block_delta", {
+                type: "content_block_delta",
+                index: state.textIdx,
+                delta: { type: "text_delta", text: results },
+              });
+              t.closed = true;
+            }
+          }
+
+          // Execute <searchWeb> queries found in accumulated text
+          if (searchQueries.length > 0) {
+            for (const query of searchQueries) {
+              log(`[Streaming] Executing <searchWeb> query: "${query}"`);
+              const results = await executeWebSearch(query);
+              if (!state.textStarted) {
+                state.textIdx = state.curIdx++;
+                send("content_block_start", {
+                  type: "content_block_start",
+                  index: state.textIdx,
+                  content_block: { type: "text", text: "" },
+                });
+                state.textStarted = true;
+              }
+              send("content_block_delta", {
+                type: "content_block_delta",
+                index: state.textIdx,
+                delta: { type: "text_delta", text: results },
+              });
+            }
           }
 
           // Handle buffered-but-unsent structured tool calls.
@@ -277,6 +344,27 @@ export function createStreamingResponseHandler(
               send("content_block_stop", { type: "content_block_stop", index: t.blockIndex });
               t.closed = true;
             }
+          }
+
+          // Handle empty response — no text blocks and no tool calls were started.
+          // This can happen with some providers that return no content at all.
+          if (!state.textStarted && !Array.from(state.tools.values()).some((t) => t.started)) {
+            log(`[Streaming] Empty response — no text or tool blocks started, injecting error message`);
+            const emptyIdx = state.curIdx++;
+            send("content_block_start", {
+              type: "content_block_start",
+              index: emptyIdx,
+              content_block: { type: "text", text: "" },
+            });
+            send("content_block_delta", {
+              type: "content_block_delta",
+              index: emptyIdx,
+              delta: {
+                type: "text_delta",
+                text: "[Error: The model returned an empty response. Try compacting the conversation or reducing the context size.]",
+              },
+            });
+            send("content_block_stop", { type: "content_block_stop", index: emptyIdx });
           }
 
           if (middlewareManager) {
@@ -506,7 +594,9 @@ export function createStreamingResponseHandler(
                           };
                           state.tools.set(idx, t);
                           if (isWebSearchToolCall(restoredName)) {
-                            warnWebSearchUnsupported(restoredName, target);
+                            log(`[Streaming] Web search tool call '${restoredName}' detected — intercepting via SearXNG`);
+                            t.suppressed = true;
+                            t.buffered = true;
                           }
                         }
                         // Only send content_block_start immediately if NOT buffering

--- a/packages/cli/src/handlers/shared/web-search-executor.ts
+++ b/packages/cli/src/handlers/shared/web-search-executor.ts
@@ -1,0 +1,114 @@
+/**
+ * Web search executor — intercepts web_search tool calls from providers
+ * (z.ai, GLM) and executes them via SearXNG.
+ *
+ * When a provider model requests web_search, claudish:
+ * 1. Extracts the search query from tool arguments
+ * 2. Calls the local SearXNG instance
+ * 3. Returns formatted results as a text block in the stream
+ *
+ * IMPORTANT: executeWebSearchSync must not block the SSE stream.
+ * It races SearXNG against a 3-second deadline and returns a
+ * fallback message immediately if SearXNG is unreachable.
+ */
+
+import { log } from "../../logger.js";
+
+const SEARXNG_URL = process.env.SEARXNG_URL || "http://search.myia.io";
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/**
+ * Execute a web search via SearXNG. Non-throwing.
+ */
+async function fetchFromSearXNG(query: string, maxResults = 5): Promise<SearchResult[]> {
+  const url = `${SEARXNG_URL}/search?q=${encodeURIComponent(query)}&format=json&categories=general`;
+  log(`[WebSearch] Executing: "${query}" via ${SEARXNG_URL}`);
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(5000),
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    log(`[WebSearch] SearXNG returned HTTP ${response.status}`);
+    return [];
+  }
+
+  const data = (await response.json()) as any;
+  const results: SearchResult[] = (data.results || [])
+    .slice(0, maxResults)
+    .map((r: any) => ({
+      title: r.title || "",
+      url: r.url || "",
+      snippet: r.content || r.description || "",
+    }));
+
+  log(`[WebSearch] Got ${results.length} results for "${query}"`);
+  return results;
+}
+
+/**
+ * Stream-safe web search: races SearXNG against a short deadline.
+ * Returns formatted results text, never throws, never blocks > deadline.
+ */
+export async function executeWebSearch(query: string, deadlineMs = 3000): Promise<string> {
+  try {
+    const results = await Promise.race([
+      fetchFromSearXNG(query),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), deadlineMs)),
+    ]);
+
+    if (results === null) {
+      log(`[WebSearch] Timed out after ${deadlineMs}ms for "${query}"`);
+      return `[Web search for "${query}" timed out. SearXNG did not respond within ${deadlineMs / 1000}s.]`;
+    }
+
+    return formatSearchResults(query, results);
+  } catch (err: any) {
+    log(`[WebSearch] Error: ${err.message}`);
+    return `[Web search for "${query}" failed: ${err.message}]`;
+  }
+}
+
+/**
+ * Format search results as a text block for injection into the stream.
+ */
+export function formatSearchResults(query: string, results: SearchResult[]): string {
+  if (results.length === 0) {
+    return `[Web search for "${query}" returned no results. The search service may be unavailable.]`;
+  }
+
+  const lines = [`[Web search results for "${query}"]\n`];
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    lines.push(`${i + 1}. **${r.title}**`);
+    lines.push(`   ${r.url}`);
+    if (r.snippet) {
+      lines.push(`   ${r.snippet}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Extract the search query from a web_search tool call's arguments JSON.
+ */
+export function extractSearchQuery(argsJson: string): string {
+  try {
+    const args = JSON.parse(argsJson);
+    return args.query || args.q || args.search_query || args.keyword || "";
+  } catch {
+    // If args aren't valid JSON, try to extract from raw string
+    const match = argsJson.match(/"query"\s*:\s*"([^"]+)"/);
+    if (match) return match[1];
+    const match2 = argsJson.match(/"q"\s*:\s*"([^"]+)"/);
+    if (match2) return match2[1];
+    return "";
+  }
+}

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -35,6 +35,130 @@ import { route, loadRoutingRules } from "./providers/routing-rules.js";
 import { createHandlerForProvider } from "./providers/provider-profiles.js";
 import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
 import { getApiKey, loadConfig } from "./profile-config.js";
+import { executeWebSearch } from "./handlers/shared/web-search-executor.js";
+
+/**
+ * Intercept WebSearch/WebFetch tool calls and execute them via SearXNG instead
+ * of forwarding to the provider. Returns a streaming response with SearXNG results.
+ *
+ * Claude Code's WebSearch tool sends a sub-agent request with a single user message:
+ *   "Perform a web search for the query: <query>"
+ * We intercept this, execute SearXNG, and return the results as text.
+ */
+async function interceptWebTools(c: any, body: any): Promise<Response | null> {
+  const messages = body.messages || [];
+  const isStreaming = body.stream === true;
+
+  // Case 1: Sub-agent web search request (1 message, user role, starts with "Perform a web search")
+  if (messages.length === 1 && messages[0].role === "user") {
+    const text = typeof messages[0].content === "string"
+      ? messages[0].content
+      : Array.isArray(messages[0].content)
+        ? messages[0].content.map((b: any) => b.text || "").join("")
+        : "";
+
+    const searchMatch = text.match(/^Perform a web search for the query:\s*(.+)$/s);
+    if (searchMatch) {
+      const query = searchMatch[1].trim();
+      log(`[WebTools] Intercepted sub-agent web search: "${query}"`);
+      const results = await executeWebSearch(query, 5000);
+      return buildTextResponse(body.model || "unknown", results, isStreaming);
+    }
+
+    const fetchMatch = text.match(/^Perform a web fetch for the URL:\s*(.+)$/s);
+    if (fetchMatch) {
+      const url = fetchMatch[1].trim();
+      log(`[WebTools] Intercepted sub-agent web fetch: "${url}"`);
+      let resultText: string;
+      try {
+        const searxngUrl = `${process.env.SEARXNG_URL || "http://search.myia.io"}/search?q=${encodeURIComponent(url)}&format=json&categories=general`;
+        const resp = await fetch(searxngUrl, { signal: AbortSignal.timeout(5000) });
+        const data = await resp.json() as any;
+        const results = (data.results || []).slice(0, 3);
+        resultText = results.length > 0
+          ? results.map((r: any) => `**${r.title}**\n${r.url}\n${r.content || ""}`).join("\n\n")
+          : `[No results found for URL: ${url}]`;
+      } catch (err: any) {
+        resultText = `[Web fetch for "${url}" failed: ${err.message}]`;
+      }
+      return buildTextResponse(body.model || "unknown", resultText, isStreaming);
+    }
+  }
+
+  return null;
+}
+
+function buildTextResponse(model: string, text: string, streaming: boolean): Response {
+  const encoder = new TextEncoder();
+  const send = (event: string, data: any) =>
+    encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+
+  if (!streaming) {
+    return new Response(JSON.stringify({
+      id: `msg_webtools_${Date.now()}`,
+      type: "message",
+      role: "assistant",
+      model,
+      content: [{ type: "text", text }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }), {
+      headers: {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+      },
+    });
+  }
+
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(send("message_start", {
+        type: "message_start",
+        message: {
+          id: `msg_webtools_${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      }));
+      controller.enqueue(send("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }));
+      controller.enqueue(send("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text },
+      }));
+      controller.enqueue(send("content_block_stop", {
+        type: "content_block_stop",
+        index: 0,
+      }));
+      controller.enqueue(send("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { input_tokens: 0, output_tokens: 0 },
+      }));
+      controller.enqueue(send("message_stop", { type: "message_stop" }));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "anthropic-version": "2023-06-01",
+    },
+  });
+}
 
 export interface ProxyServerOptions {
   summarizeTools?: boolean; // Summarize tool descriptions for local models
@@ -569,6 +693,18 @@ export async function createProxyServer(
   app.post("/v1/messages", async (c) => {
     try {
       const body = await c.req.json();
+
+      // Intercept web search/fetch sub-agent requests before handler selection.
+      // When Claude Code's WebSearch tool fires a sub-agent, the request contains
+      // a single user message like "Perform a web search for the query: X".
+      // We intercept it and execute via SearXNG instead of forwarding to the model.
+      try {
+        const webToolResponse = await interceptWebTools(c, body);
+        if (webToolResponse) return webToolResponse;
+      } catch (e: any) {
+        log(`[WebTools] Intercept error (falling through to normal handler): ${e.message}`);
+      }
+
       const handler = await getHandlerForRequest(body.model);
 
       // Route


### PR DESCRIPTION
## Problem

When providers (Z.AI, GLM, OpenRouter models) emit WebSearch/WebFetch tool calls, they fail because the proxy doesn't implement server-side web search. GLM models also emit `<searchWeb>query</searchWeb>` tags in their text output, which go unhandled. Additionally, Claude Code's built-in WebSearch tool fires sub-agent requests that get forwarded to the model provider instead of being executed locally.

## Changes

### New file: `packages/cli/src/handlers/shared/web-search-executor.ts`

A stream-safe SearXNG client that:
- Queries a local SearXNG instance (`SEARXNG_URL` env var, defaults to `http://search.myia.io`)
- Races SearXNG against a configurable deadline (default 3s)
- Returns formatted results as text, never throws
- Extracts search queries from tool call arguments JSON

### `packages/cli/src/proxy-server.ts`

Add `interceptWebTools()` function that intercepts sub-agent web search/fetch requests BEFORE handler selection. Detects the standard Claude Code WebSearch sub-agent pattern ("Perform a web search for the query: X") and returns SearXNG results as a streaming or non-streaming Anthropic-format response.

### `packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts`

Three enhancements:

1. **WebSearch tool suppression** -- When a structured WebSearch/WebFetch tool call is detected, set `suppressed = true` and buffer arguments. At finalization, execute SearXNG and inject results as a text block.

2. **GLM `<searchWeb>` tag detection** -- Detect `<searchWeb>query</searchWeb>` tags in accumulated text and execute SearXNG for each query.

3. **Empty response handling** -- When no text or tool blocks were started, inject a synthetic error message so downstream doesn't hang.

## Providers affected

- Z.AI (GLM models)
- GLM direct
- OpenRouter models that emit web search tool calls
- Any provider where Claude Code's WebSearch sub-agent is routed through claudish

## How to test

1. **Sub-agent interception:**
   ```bash
   claudish --model zai@glm-4.7 "search the web for recent AI news"
   # Verify: SearXNG results appear in response instead of tool call error
   ```

2. **GLM <searchWeb> tags:**
   ```bash
   claudish --model glm-4.7 --debug "search for..."
   # Check debug log for [Streaming] Found N <searchWeb> tag(s) in text
   ```

3. **SearXNG URL configuration:**
   ```bash
   SEARXNG_URL=http://localhost:8080 claudish --model glm-4.7 "search for..."
   ```

## Notes

- SearXNG is expected to be running and accessible. If SearXNG is unavailable, a timeout/failure message is injected instead of crashing.
- The `SEARXNG_URL` env var should be documented in the main README as an optional configuration.