### PR TITLE
fix(rate-limit): gracefully handle GLM/Z.AI in-stream burst limits (HTTP 200 + [1302])

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+.git
+logs
+*.log
+.claude
+.claudish
+ai-docs
+test-fixtures
+*.md
+!packages/cli/README.md
+.startup-shortcut-created
+Dockerfile
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,12 @@ validation/
 .mnemex/
 gtd/sessions/
 .agents/
+
+# Diagnostic capture (temporary, activated via CLAUDISH_CAPTURE_DIR env)
+capture/
+
+# Session artifacts (traces, deploy notes, monitoring scripts)
+trace-*.json
+kv-cache-traces.md
+monitor-traffic.sh
+deploy-notes-*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,42 @@ Located in `handlers/shared/stream-parsers/`:
 - `ollama-jsonl.ts` — Ollama JSONL → Claude SSE
 - `openai-responses-sse.ts` — OpenAI Responses API → Claude SSE (Codex)
 
+## Web Search Interception (v7.1+)
+
+When providers emit web search tool calls (WebSearch/WebFetch) or GLM's `<searchWeb>` tags, claudish intercepts them and executes via a local **SearXNG** instance instead of forwarding to the provider (which would fail for non-Anthropic providers).
+
+### Architecture
+
+Two interception paths, both in the stream parsers:
+
+1. **Structured tool_call** (`openai-sse.ts`): WebSearch/WebFetch tool calls are flagged as `suppressed` in `ToolState`. At finalize, SearXNG is called and results are injected as a text block replacing the tool call. The `suppressed` flag prevents the tool_use content_block from reaching the client.
+
+2. **GLM `<searchWeb>` tags** (`openai-sse.ts`): GLM models emit `<searchWeb><query>...</query></searchWeb>` in text content. At finalize, these tags are detected, SearXNG is called, tags are stripped from text, and results are appended as a separate text block.
+
+3. **Sub-agent requests** (`proxy-server.ts`): Claude Code sometimes sends web search/fetch as a single user message ("Perform a web search for the query: X"). These are intercepted at the proxy level before handler selection.
+
+### Configuration
+
+- **`SEARXNG_URL`** env var (required): URL of the SearXNG instance (e.g. `http://search.myia.io`). When unset, web search interception falls through gracefully with a fallback message.
+- **`SEARXNG_AVAILABLE`** flag: detected at startup from `SEARXNG_URL` presence.
+- **Deadline**: 3s default for SearXNG calls (5s for sub-agent path). Non-blocking — races against timeout.
+
+### Components
+
+- `handlers/shared/web-search-executor.ts` — SearXNG fetch, result formatting, query extraction
+- `handlers/shared/stream-parsers/openai-sse.ts` — tool_call suppression + `<searchWeb>` tag detection
+- `proxy-server.ts` — sub-agent request interception
+
+### Inline System Message Handling
+
+Claude Code v2.1.153+ injects `role: "system"` messages inline (e.g. system-reminders). Anthropic-compatible providers (Z.AI, MiniMax, Kimi) reject these — only "user"/"assistant" accepted. The fix:
+- `composed-handler.ts`: strips inline system messages from `requestPayload.messages` for `anthropic-sse` transport, merges into top-level `system` field
+- `openai-messages.ts`: same strip for the OpenAI format path
+
+### Diagnostic Body Capture
+
+Set `CLAUDISH_CAPTURE_DIR` env var to enable full request body capture for offline reproduction of hangs or malformed responses. Disabled by default (no-op when unset). Files written as JSON with metadata (timestamp, source IP, model, PID).
+
 ## Debug Logging
 
 Debug logging is behind the `--debug` flag and outputs to `logs/` directory. It's disabled by default.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM oven/bun:1.2-alpine
+
+WORKDIR /app
+
+# Copy workspace structure
+COPY package.json ./
+COPY scripts/postinstall.cjs ./scripts/postinstall.cjs
+COPY packages/cli/package.json ./packages/cli/package.json
+
+# Copy source
+COPY packages/cli/src ./packages/cli/src
+COPY packages/cli/bin ./packages/cli/bin
+COPY packages/cli/tsconfig.json ./packages/cli/tsconfig.json
+COPY packages/cli/scripts ./packages/cli/scripts
+
+# Install deps (skip lockfile — partial workspace)
+RUN bun install --production --no-save
+
+# Generate version file
+RUN bun run packages/cli/scripts/generate-version.ts 2>/dev/null || true
+
+# Expose proxy port
+EXPOSE 3000
+
+# Config directory
+VOLUME /root/.claudish
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://0.0.0.0:3000/health || exit 1
+
+ENTRYPOINT ["bun", "run", "packages/cli/src/standalone-proxy.ts"]
+CMD ["--port", "3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ VOLUME /root/.claudish
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://0.0.0.0:3000/health || exit 1
 
-ENTRYPOINT ["bun", "run", "packages/cli/src/standalone-proxy.ts"]
+ENTRYPOINT ["bun", "run", "packages/cli/src/fork/server/standalone-proxy.ts"]
 CMD ["--port", "3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.2-alpine
+FROM oven/bun:1.3-alpine
 
 WORKDIR /app
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,27 @@ Reference: research findings under `ai-docs/sessions/dev-research-channel-config
 
 ---
 
+## Adaptive / shared backoff pacer for burst rate-limits
+
+Status: not started. Deliberately deferred — current per-request backoff is judged sufficient for the present load.
+
+**What ships today** (the in-stream rate-limit fix): when an `anthropic-sse` provider (notably Z.AI) delivers its burst/RPM limit as HTTP 200 + an in-stream `[1302]` SSE error, ComposedHandler peeks the stream start, detects it, and **temporizes with a per-request jittered exponential backoff** (1s/2s/4s + 0–750ms), retrying the same provider up to 3× before returning 429 so FallbackHandler switches providers (e.g. Z.AI → GLM Coding, a separate quota). The transport layer (`AnthropicProviderTransport.enqueueRequest`) adds a second jittered backoff on genuine HTTP 429. Both are **per-request and independent** — there is no shared, cross-request pressure gauge.
+
+This produces *implicit* aggregate self-throttling: under a storm, more requests hit 429 → more requests back off → offered load drops. It does not, however, make *new arrivals* probe more cautiously while a storm is in progress — each new request still fires at full rate on its first attempt. With the stated load (≤50% of the 5h sustained quota even at peak; only the instantaneous burst limit is hit occasionally, and the cluster shares one key per provider), that residual gap is acceptable and a coordinated pacer would be over-engineering.
+
+**What this item would add**: a shared per-provider pressure gauge (e.g. AIMD — additive-increase/multiplicative-decrease — with time decay) that admission-paces *new* requests as the recent error rate climbs, so the fleet spreads requests **more** under a sustained storm rather than only after each individual request fails. This is the "écarter encore plus les requêtes quand le taux d'erreurs augmente" idea — correct in principle, but only worth the complexity (shared state across 6 machines, or per-process approximation; tuning; new failure modes) if the simpler per-request backoff proves insufficient.
+
+**Trigger conditions** (any one):
+- Sustained-quota utilization regularly approaches its ceiling (not just the instantaneous burst limit) — i.e. the "we have headroom" premise stops holding.
+- Capture/telemetry shows the in-stream-rate-limit fix's 3-retry budget is frequently exhausted (turns still failing over to fallback or to the client) despite the backoff — meaning synchronized full-rate probing during storms is the dominant remaining failure.
+- The cluster grows enough that uncoordinated per-request backoff visibly re-collides on the burst limit even with jitter.
+
+**Effort**: medium. A per-process AIMD gauge is small; a genuinely *shared* cross-machine gauge needs a coordination point (shared store or a designated pacer) and is the bulk of the cost.
+
+**Reference**: in-stream rate-limit fix — `packages/cli/src/handlers/shared/stream-peek.ts`, `composed-handler.ts` (peek+retry block), `providers/transport/anthropic-compat.ts` (`enqueueRequest`). Root-cause analysis in this session's capture diagnosis.
+
+---
+
 ## Adding a new roadmap item
 
 Each item should follow the structure above:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  claudish-proxy:
+    build: .
+    container_name: claudish-proxy
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      # Mount config from host (contains API keys, routing, profiles)
+      - type: bind
+        source: C:\Users\jsboi\.claudish
+        target: /root/.claudish
+        read_only: true
+    environment:
+      - NODE_ENV=production
+    command: ["--port", "3000", "--host", "0.0.0.0"]
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
         read_only: true
     environment:
       - NODE_ENV=production
+      - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - NODE_ENV=production
       - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
-      - SEARXNG_URL=http://192.168.0.47:8181
+      - SEARXNG_URL=http://search.myia.io
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - NODE_ENV=production
       - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
       - SEARXNG_URL=http://search.myia.io
+      - CLAUDISH_CAPTURE_DIR=/tmp/captures
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       - NODE_ENV=production
       - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
+      - SEARXNG_URL=http://192.168.0.47:8181
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/packages/cli/src/fork/config/profile-extensions.ts
+++ b/packages/cli/src/fork/config/profile-extensions.ts
@@ -1,0 +1,9 @@
+/**
+ * Profile config extension (fork extension).
+ *
+ * Adds proxyKey to the ClaudishProfileConfig type.
+ * This is the fork-specific schema extension — profile-config.ts re-exports it.
+ */
+
+/** Proxy authentication key — clients must send x-proxy-key matching this value */
+export type ProxyKey = string;

--- a/packages/cli/src/fork/index.ts
+++ b/packages/cli/src/fork/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Fork extensions barrel export + registration.
+ *
+ * All fork-specific features are wired through this single entry point.
+ * proxy-server.ts calls registerForkExtensions() to activate them.
+ * This keeps the diff between our fork and upstream minimal.
+ */
+
+import type { Hono } from "hono";
+import { log } from "../logger.js";
+import { createProxyAuthMiddleware } from "./middleware/proxy-auth.js";
+import { registerModelDiscoveryRoute } from "./routes/model-discovery.js";
+
+export { createProxyAuthMiddleware } from "./middleware/proxy-auth.js";
+export { registerModelDiscoveryRoute } from "./routes/model-discovery.js";
+export { stripBillingHeaderFromBody } from "./middleware/billing-header-strip.js";
+export { resolveSourceIp, logRequest } from "./middleware/request-logger.js";
+export { createHostnameConfig, type HostnameConfig } from "./server/hostname-binding.js";
+
+export interface ForkExtensionsOptions {
+  proxyKey?: string;
+}
+
+/**
+ * Register all fork extensions on the Hono app.
+ * Called once from proxy-server.ts during startup.
+ */
+export function registerForkExtensions(app: Hono, opts: ForkExtensionsOptions): void {
+  // 1. Proxy authentication middleware
+  if (opts.proxyKey) {
+    app.use("/v1/*", createProxyAuthMiddleware(opts.proxyKey));
+    log("[Proxy] Authentication enabled (Anthropic pass-through; proxy key required for other providers)");
+  }
+
+  // 2. Model discovery endpoint
+  registerModelDiscoveryRoute(app);
+}

--- a/packages/cli/src/fork/middleware/billing-header-strip.ts
+++ b/packages/cli/src/fork/middleware/billing-header-strip.ts
@@ -1,0 +1,27 @@
+/**
+ * Billing header strip (fork extension).
+ *
+ * Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
+ * into the prompt body — the `cch=` token changes every request, which breaks
+ * vLLM prefix caching (strict hash). Only Anthropic needs this; strip for others.
+ */
+
+export function stripBillingHeaderFromBody(body: any, isNative: boolean): void {
+  if (isNative) return;
+
+  if (typeof body.system === "string") {
+    body.system = body.system.replace(
+      /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+      ""
+    );
+  } else if (Array.isArray(body.system)) {
+    for (const block of body.system) {
+      if (block.type === "text" && typeof block.text === "string") {
+        block.text = block.text.replace(
+          /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+          ""
+        );
+      }
+    }
+  }
+}

--- a/packages/cli/src/fork/middleware/proxy-auth.ts
+++ b/packages/cli/src/fork/middleware/proxy-auth.ts
@@ -1,0 +1,54 @@
+/**
+ * Proxy authentication middleware (fork extension).
+ *
+ * Anthropic pass-through is exempt (OAuth or proxy-key swap handled by NativeHandler).
+ * Non-Anthropic providers require the proxy key in x-api-key / authorization / x-proxy-key.
+ * GET requests and health endpoints are exempt for Docker healthcheck and model discovery.
+ */
+
+import type { MiddlewareHandler } from "hono";
+import { wrapAnthropicError } from "../../handlers/shared/anthropic-error.js";
+import { parseModelSpec } from "../../providers/model-parser.js";
+
+export function createProxyAuthMiddleware(proxyKey: string): MiddlewareHandler {
+  return async (c, next) => {
+    if (c.req.method === "GET") {
+      return await next();
+    }
+
+    // Peek at body.model to determine target provider.
+    // Hono caches parsed JSON — safe to call again from the route handler.
+    let model: string | undefined;
+    try {
+      const body = await c.req.json();
+      model = body?.model;
+    } catch {
+      return await next(); // Malformed body — let handler return 400
+    }
+
+    // Anthropic pass-through: skip proxy key validation entirely.
+    // NativeHandler will either swap proxyKey → stored Anthropic key,
+    // or pass the client's OAuth token through unchanged.
+    if (model) {
+      const spec = parseModelSpec(model);
+      if (spec.provider === "native-anthropic") {
+        return await next();
+      }
+    }
+
+    // Non-Anthropic: enforce proxy key
+    const authHeader = c.req.header("authorization");
+    const apiKeyHeader = c.req.header("x-api-key");
+    const proxyKeyHeader = c.req.header("x-proxy-key");
+
+    const bearerToken = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice(7)
+      : authHeader;
+
+    const provided = proxyKeyHeader || apiKeyHeader || bearerToken;
+    if (!provided || provided !== proxyKey) {
+      return c.json(wrapAnthropicError(401, "invalid proxy authentication"), 401);
+    }
+    await next();
+  };
+}

--- a/packages/cli/src/fork/middleware/request-logger.ts
+++ b/packages/cli/src/fork/middleware/request-logger.ts
@@ -1,0 +1,29 @@
+/**
+ * Request logger (fork extension).
+ *
+ * Logs remote IP + request metadata for cluster traffic analysis.
+ * Resolves source IP from x-forwarded-for, x-real-ip, or direct connection map.
+ */
+
+export function resolveSourceIp(
+  req: Request,
+  remoteAddrMap: WeakMap<Request, string>
+): string {
+  const xff = req.headers.get("x-forwarded-for") || "";
+  const xrip = req.headers.get("x-real-ip") || "";
+  const directIp = remoteAddrMap.get(req) || "";
+  return xff || xrip || directIp || "direct";
+}
+
+export function logRequest(
+  body: { model?: string },
+  handlerName: string,
+  req: Request,
+  remoteAddrMap: WeakMap<Request, string>
+): void {
+  const src = resolveSourceIp(req, remoteAddrMap);
+  const ua = req.headers.get("user-agent") || "";
+  console.log(
+    `[claudish] [Request] model=${body.model ?? "(none)"} handler=${handlerName} src=${src} ua=${ua.slice(0, 60)}`
+  );
+}

--- a/packages/cli/src/fork/middleware/request-logger.ts
+++ b/packages/cli/src/fork/middleware/request-logger.ts
@@ -3,6 +3,8 @@
  *
  * Logs remote IP + request metadata for cluster traffic analysis.
  * Resolves source IP from x-forwarded-for, x-real-ip, or direct connection map.
+ *
+ * Leak investigation mode: dumps system prompt excerpt + first + last user message.
  */
 
 export function resolveSourceIp(
@@ -15,15 +17,84 @@ export function resolveSourceIp(
   return xff || xrip || directIp || "direct";
 }
 
+function excerpt(s: string, maxLen = 200): string {
+  const flat = s.replace(/\n/g, "\\n").replace(/\r/g, "");
+  if (flat.length <= maxLen) return flat;
+  return flat.slice(0, maxLen) + "...";
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const texts = content
+      .filter((b: Record<string, unknown>) => b.type === "text")
+      .map((b: Record<string, unknown>) => b.text as string);
+    return texts.join(" ");
+  }
+  return "";
+}
+
 export function logRequest(
-  body: { model?: string },
+  body: Record<string, unknown>,
   handlerName: string,
   req: Request,
   remoteAddrMap: WeakMap<Request, string>
 ): void {
   const src = resolveSourceIp(req, remoteAddrMap);
   const ua = req.headers.get("user-agent") || "";
-  console.log(
-    `[claudish] [Request] model=${body.model ?? "(none)"} handler=${handlerName} src=${src} ua=${ua.slice(0, 60)}`
+  const model = (body.model as string) ?? "(none)";
+
+  // Full-body capture (temporary diagnostic — gated by CLAUDISH_CAPTURE_DIR env).
+  // Disabled when the env var is unset, so this is a no-op in normal operation.
+  const captureDir = process.env.CLAUDISH_CAPTURE_DIR;
+  if (captureDir) {
+    try {
+      const fs = require("fs");
+      fs.mkdirSync(captureDir, { recursive: true });
+      const g = globalThis as Record<string, unknown>;
+      const n = (g.__capN = ((g.__capN as number) ?? 0) + 1);
+      const safeSrc = src.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 40);
+      const ts = new Date().toISOString().replace(/[:.]/g, "-");
+      const file = `${captureDir}/req-${process.pid}-${String(n).padStart(4, "0")}-${ts}-${safeSrc}.json`;
+      fs.writeFileSync(file, JSON.stringify({ ts, src, model, pid: process.pid, body }));
+      process.stdout.write(`  [capture] ${file}\n`);
+    } catch (e) {
+      process.stdout.write(`  [capture] error: ${String(e)}\n`);
+    }
+  }
+
+  // Header line
+  const msgs = Array.isArray(body.messages) ? body.messages.length : 0;
+  const stream = body.stream === true ? "stream" : "sync";
+  const maxTokens = body.max_tokens ?? "-";
+  process.stdout.write(
+    `[claudish] [Request] model=${model} handler=${handlerName} src=${src} ${stream} msgs=${msgs} max_tokens=${maxTokens} ua=${ua.slice(0, 80)}\n`
   );
+
+  // System prompt excerpt (first 300 chars)
+  const sysText = typeof body.system === "string"
+    ? body.system
+    : Array.isArray(body.system)
+      ? JSON.stringify(body.system)
+      : "";
+  if (sysText) {
+    process.stdout.write(`  [system] ${excerpt(sysText, 300)}\n`);
+  }
+
+  // First user message excerpt
+  const messages = (body.messages as Record<string, unknown>[]) ?? [];
+  if (messages.length > 0) {
+    const first = extractText(messages[0].content);
+    if (first) {
+      process.stdout.write(`  [msg:0] ${excerpt(first, 200)}\n`);
+    }
+  }
+
+  // Last user message excerpt
+  if (messages.length > 1) {
+    const last = extractText(messages[messages.length - 1].content);
+    if (last) {
+      process.stdout.write(`  [msg:${messages.length - 1}] ${excerpt(last, 300)}\n`);
+    }
+  }
 }

--- a/packages/cli/src/fork/middleware/request-logger.ts
+++ b/packages/cli/src/fork/middleware/request-logger.ts
@@ -67,8 +67,10 @@ export function logRequest(
   const msgs = Array.isArray(body.messages) ? body.messages.length : 0;
   const stream = body.stream === true ? "stream" : "sync";
   const maxTokens = body.max_tokens ?? "-";
+  const machine = req.headers.get("x-claudish-machine") || "";
+  const machineTag = machine ? ` machine=${machine}` : "";
   process.stdout.write(
-    `[claudish] [Request] model=${model} handler=${handlerName} src=${src} ${stream} msgs=${msgs} max_tokens=${maxTokens} ua=${ua.slice(0, 80)}\n`
+    `[claudish] [Request] model=${model} handler=${handlerName} src=${src} ${stream} msgs=${msgs} max_tokens=${maxTokens}${machineTag} ua=${ua.slice(0, 80)}\n`
   );
 
   // System prompt excerpt (first 300 chars)

--- a/packages/cli/src/fork/routes/model-discovery.ts
+++ b/packages/cli/src/fork/routes/model-discovery.ts
@@ -1,0 +1,55 @@
+/**
+ * Model discovery endpoint (fork extension).
+ *
+ * Claude Code queries /v1/models when CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1.
+ * Returns all routable models from config.json routing rules + custom endpoints.
+ */
+
+import type { Hono } from "hono";
+import { loadConfig } from "../../profile-config.js";
+
+export function registerModelDiscoveryRoute(app: Hono): void {
+  app.get("/v1/models", (c) => {
+    const cfg = loadConfig();
+    const seen = new Set<string>();
+    const models: { id: string; display_name: string; created_at: string }[] = [];
+
+    // From routing rules — each key is a model name
+    if (cfg.routing) {
+      for (const modelName of Object.keys(cfg.routing)) {
+        if (!seen.has(modelName)) {
+          seen.add(modelName);
+          models.push({
+            id: modelName,
+            display_name: modelName,
+            created_at: "2026-01-01T00:00:00Z",
+          });
+        }
+      }
+    }
+
+    // From custom endpoints — each declared model
+    if (cfg.customEndpoints) {
+      for (const [, ep] of Object.entries(cfg.customEndpoints)) {
+        const endpoint = ep as { models?: string[] };
+        if (endpoint.models) {
+          for (const m of endpoint.models) {
+            if (!seen.has(m)) {
+              seen.add(m);
+              models.push({
+                id: m,
+                display_name: m,
+                created_at: "2026-01-01T00:00:00Z",
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return c.json({
+      object: "list",
+      data: models,
+    });
+  });
+}

--- a/packages/cli/src/fork/server/hostname-binding.ts
+++ b/packages/cli/src/fork/server/hostname-binding.ts
@@ -1,0 +1,19 @@
+/**
+ * Hostname binding (fork extension).
+ *
+ * Configures the proxy to bind to a specific hostname (default: 127.0.0.1).
+ * For Docker deployments, use "0.0.0.0" to accept connections from all interfaces.
+ * Tracks direct remote addresses via WeakMap since Hono middleware can't access sockets.
+ */
+
+export interface HostnameConfig {
+  hostname: string;
+  remoteAddrMap: WeakMap<Request, string>;
+}
+
+export function createHostnameConfig(hostname?: string): HostnameConfig {
+  return {
+    hostname: hostname ?? "127.0.0.1",
+    remoteAddrMap: new WeakMap<Request, string>(),
+  };
+}

--- a/packages/cli/src/fork/server/standalone-proxy.ts
+++ b/packages/cli/src/fork/server/standalone-proxy.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 /**
- * Claudish Standalone Proxy Server
+ * Claudish Standalone Proxy Server (fork extension)
  *
  * Starts the proxy server without wrapping Claude Code.
  * Used for cluster deployments where other machines route LLM requests
  * through this proxy.
  *
- * Usage: bun packages/cli/src/standalone-proxy.ts [--port 3000]
+ * Usage: bun packages/cli/src/fork/server/standalone-proxy.ts [--port 3000]
  */
 
 import { config } from "dotenv";
@@ -60,8 +60,8 @@ if (hostIdx !== -1 && args[hostIdx + 1]) {
   hostname = args[hostIdx + 1];
 }
 
-import { createProxyServer } from "./proxy-server.js";
-import { loadConfig } from "./profile-config.js";
+import { createProxyServer } from "../../proxy-server.js";
+import { loadConfig } from "../../profile-config.js";
 
 // No modelMap — the proxy is a transparent router. Every model name routes
 // to its provider via config.json routing rules:

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -1535,10 +1535,15 @@ describe("Regression: Anthropic SSE in-stream error handling (#106)", () => {
     return mod.createAnthropicPassthroughStream;
   }
 
-  test("in-stream error payload emits proper error event instead of crashing (non-filtering path)", async () => {
-    // REGRESSION: Z.AI returns HTTP 200 with {"error":{"code":"1305","message":"..."}} in-stream.
-    // Before fix: raw error payload passed through, Claude Code crashes with "undefined is not an object"
-    // because it expects a `type` field. Fixed in /dev:fix session dev-fix-20260417-224919-72cb371e
+  test("mid-stream error finalizes gracefully with message_stop instead of a bare error event (non-filtering path)", async () => {
+    // REGRESSION (#106 → no-crash hardening): Z.AI returns HTTP 200 with
+    // {"error":{"code":"1305","message":"..."}} in-stream. The original fix
+    // forwarded a Claude-shaped `error` event, but Claude Code still treats a
+    // turn that ends on a bare `error` event (no message_stop) as "empty or
+    // malformed response (HTTP 200)" and crashes. The hardened contract:
+    // ALWAYS emit a valid terminal message. Mid-stream (text already sent), we
+    // close the open block and emit message_delta + message_stop — preserving
+    // the partial text and ending the turn cleanly.
     const createAnthropicPassthroughStream = await getParser();
     const fixture = fixtureToResponse(join(FIXTURES_DIR, "regression-zai-glm5-instream-error.sse"));
     const ctx = createMockContext();
@@ -1549,23 +1554,27 @@ describe("Regression: Anthropic SSE in-stream error handling (#106)", () => {
 
     const events = await parseClaudeSseStream(response);
 
-    // Should have received text content before the error
+    // Partial text received before the error is preserved.
     const text = extractText(events);
     expect(text).toContain("Hello");
 
-    // Should have an error event with proper structure
+    // No bare `error` event reaches the client — that is what crashes the turn.
     const errorEvent = events.find((e) => e.data?.type === "error");
-    expect(errorEvent).toBeDefined();
-    expect(errorEvent?.data?.error?.type).toBe("api_error");
-    expect(errorEvent?.data?.error?.message).toContain("temporarily overloaded");
+    expect(errorEvent).toBeUndefined();
 
-    // Should NOT have a message_stop (stream was terminated by error)
+    // The open content block is closed.
+    const blockStop = events.find((e) => e.data?.type === "content_block_stop");
+    expect(blockStop).toBeDefined();
+
+    // The turn ends cleanly with message_delta + message_stop.
+    const msgDelta = events.find((e) => e.data?.type === "message_delta");
+    expect(msgDelta?.data?.delta?.stop_reason).toBe("end_turn");
     const msgStop = events.find((e) => e.data?.type === "message_stop");
-    expect(msgStop).toBeUndefined();
+    expect(msgStop).toBeDefined();
   });
 
-  test("in-stream error payload handled in filtering path (adapter present)", async () => {
-    // Same scenario but with filterThinking enabled (MiniMax, Kimi)
+  test("mid-stream error finalizes gracefully in the filtering path (adapter present)", async () => {
+    // Same scenario with filterThinking enabled (MiniMax, Kimi).
     const createAnthropicPassthroughStream = await getParser();
     const { MiniMaxModelDialect } = await import("./adapters/minimax-model-dialect.js");
     const adapter = new MiniMaxModelDialect("minimax-m2.5");
@@ -1580,9 +1589,42 @@ describe("Regression: Anthropic SSE in-stream error handling (#106)", () => {
 
     const events = await parseClaudeSseStream(response);
 
-    // Should have an error event
+    // No bare error event; the turn terminates with message_stop.
     const errorEvent = events.find((e) => e.data?.type === "error");
-    expect(errorEvent).toBeDefined();
-    expect(errorEvent?.data?.error?.message).toContain("temporarily overloaded");
+    expect(errorEvent).toBeUndefined();
+    const msgStop = events.find((e) => e.data?.type === "message_stop");
+    expect(msgStop).toBeDefined();
+  });
+
+  test("start-of-stream rate-limit emits a synthetic message with a rate-limit notice (no message_start yet)", async () => {
+    // The burst-limit ([1302]) case: the provider sends a ping then an error
+    // BEFORE any message envelope. finalizeWithError must synthesize the whole
+    // message (message_start + a user-visible notice + message_stop) so the
+    // client renders a clean turn rather than crashing on an empty 200.
+    const createAnthropicPassthroughStream = await getParser();
+    const fixture = fixtureToResponse(
+      join(FIXTURES_DIR, "regression-zai-glm5-startofstream-ratelimit.sse")
+    );
+    const ctx = createMockContext();
+
+    const response = createAnthropicPassthroughStream(ctx, fixture, {
+      modelName: "glm-5.1",
+    });
+
+    const events = await parseClaudeSseStream(response);
+
+    // A synthetic message envelope is produced even though upstream sent none.
+    const msgStart = events.find((e) => e.data?.type === "message_start");
+    expect(msgStart).toBeDefined();
+
+    // The notice is rate-limit-aware (mentions retrying / a moment), not a raw dump.
+    const text = extractText(events);
+    expect(text.toLowerCase()).toContain("rate limited");
+
+    // No bare error event; the turn ends with message_stop.
+    const errorEvent = events.find((e) => e.data?.type === "error");
+    expect(errorEvent).toBeUndefined();
+    const msgStop = events.find((e) => e.data?.type === "message_stop");
+    expect(msgStop).toBeDefined();
   });
 });

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -301,7 +301,37 @@ export class ComposedHandler implements ModelHandler {
     // 4. Build request payload
     let requestPayload = adapter.buildPayload(claudeRequest, messages, tools);
 
-    // Merge provider-specific extra fields
+    // 4b. Strip inline system messages from messages[] for Anthropic-transport providers.
+    // Claude Code v2.1.153+ injects system messages inline (e.g. system-reminders).
+    // Providers like Z.AI reject role:"system" in messages — only role:"user"/"assistant" accepted.
+    // Merge them into the top-level system field instead.
+    if (this.provider.streamFormat === "anthropic-sse" && requestPayload.messages) {
+      const inlineSystemTexts: string[] = [];
+      requestPayload.messages = requestPayload.messages.filter((msg: any) => {
+        if (msg.role === "system") {
+          const text = typeof msg.content === "string"
+            ? msg.content
+            : Array.isArray(msg.content)
+              ? msg.content.map((c: any) => c.text || "").join("\n")
+              : "";
+          if (text) inlineSystemTexts.push(text);
+          return false;
+        }
+        return true;
+      });
+      if (inlineSystemTexts.length > 0) {
+        const merged = inlineSystemTexts.join("\n\n");
+        if (requestPayload.system) {
+          const existing = Array.isArray(requestPayload.system)
+            ? requestPayload.system.map((s: any) => s.text || s).join("\n\n")
+            : requestPayload.system;
+          requestPayload.system = existing + "\n\n" + merged;
+        } else {
+          requestPayload.system = merged;
+        }
+        log(`[ComposedHandler] Merged ${inlineSystemTexts.length} inline system message(s) into system prompt for ${this.provider.displayName}`);
+      }
+    }
     const extraFields = this.provider.getExtraPayloadFields?.();
     if (extraFields) {
       Object.assign(requestPayload, extraFields);

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -332,6 +332,26 @@ export class ComposedHandler implements ModelHandler {
         log(`[ComposedHandler] Merged ${inlineSystemTexts.length} inline system message(s) into system prompt for ${this.provider.displayName}`);
       }
     }
+
+    // Strip thinking blocks from message history for non-native providers.
+    // ComposedHandler is never used for native Anthropic (that's NativeHandler),
+    // so every request here goes to a provider that doesn't understand Anthropic
+    // thinking signatures. Without this strip, Opus thinking blocks (with signatures)
+    // flow through to Z.AI/GLM/MiniMax/etc., which either ignore or corrupt them.
+    if (requestPayload.messages) {
+      let stripped = 0;
+      for (const msg of requestPayload.messages) {
+        if (msg.role === "assistant" && Array.isArray(msg.content)) {
+          const before = msg.content.length;
+          msg.content = msg.content.filter((block: any) => block.type !== "thinking");
+          stripped += before - msg.content.length;
+        }
+      }
+      if (stripped > 0) {
+        log(`[ComposedHandler] Stripped ${stripped} thinking block(s) from message history for ${this.provider.displayName}`);
+      }
+    }
+
     const extraFields = this.provider.getExtraPayloadFields?.();
     if (extraFields) {
       Object.assign(requestPayload, extraFields);

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -41,6 +41,7 @@ import {
 import { reportError, classifyError } from "../telemetry.js";
 import { recordStats } from "../stats.js";
 import { wrapAnthropicError, ensureAnthropicErrorFormat } from "./shared/anthropic-error.js";
+import { peekStreamStart } from "./shared/stream-peek.js";
 
 function extractAuthHeaders(c: Context): VisionProxyAuthHeaders {
   const headers = c.req.header();
@@ -673,6 +674,103 @@ export class ComposedHandler implements ModelHandler {
           errorBody = { error: { type: "api_error", message: errorText } };
         }
         return c.json(ensureAnthropicErrorFormat(response.status, errorBody), response.status as any);
+      }
+    }
+
+    // ── In-stream rate-limit handling (temporize, then fall back) ──────────
+    // Some anthropic-sse providers (notably Z.AI) deliver their burst / RPM
+    // limit as HTTP 200 + an in-stream SSE error ([1302]) with no message
+    // envelope. That escapes `response.ok` above and FallbackHandler (both key
+    // off HTTP status), so it used to reach the client as a bare error and
+    // crash the turn. We peek the first bytes (the error arrives in 0-4ms, so a
+    // short window catches it without delaying slow-but-healthy big-context
+    // responses), temporize with a jittered backoff + retry the SAME provider
+    // (the sustained quota has headroom — only the instantaneous burst limit is
+    // hit), and on persistence return a 429 so FallbackHandler switches to the
+    // next provider in the chain (e.g. GLM Coding — a separate quota).
+    //
+    // The whole block is fail-open: peekStreamStart() only ever returns a
+    // usable Response, and any classification other than "rate-limit" flows
+    // straight through to handleStream() unchanged.
+    {
+      const peekFormat =
+        this.provider.overrideStreamFormat?.() ??
+        (this.explicitAdapter?.getStreamFormat() ?? this.modelAdapter?.getStreamFormat()) ??
+        this.getAdapter().getStreamFormat();
+      if (peekFormat === "anthropic-sse") {
+        const maxRlRetries = 3;
+        let rlAttempt = 0;
+        let peeked = await peekStreamStart(response);
+        while (peeked.cls === "rate-limit" && rlAttempt < maxRlRetries) {
+          // Jittered exponential backoff: 1s, 2s, 4s (+0-750ms). The cluster
+          // shares one key per provider, so jitter prevents synchronized
+          // retries from re-colliding on the burst limit.
+          const backoffMs =
+            Math.min(1000 * 2 ** rlAttempt, 8000) + Math.floor(Math.random() * 750);
+          log(
+            `[${this.provider.displayName}] in-stream rate-limit (HTTP 200), temporizing — retry ${rlAttempt + 1}/${maxRlRetries} in ${(backoffMs / 1000).toFixed(1)}s${peeked.detail ? `: ${peeked.detail}` : ""}`
+          );
+          await new Promise((r) => setTimeout(r, backoffMs));
+          rlAttempt++;
+          let retryResp: Response;
+          try {
+            retryResp = this.provider.enqueueRequest
+              ? await this.provider.enqueueRequest(doFetch)
+              : await doFetch();
+          } catch (e: any) {
+            log(`[${this.provider.displayName}] rate-limit retry fetch failed: ${e?.message ?? e}`);
+            break;
+          }
+          if (!retryResp.ok) {
+            // A genuine HTTP error this time — surface it for fallback below.
+            response = retryResp;
+            peeked = { cls: "rate-limit", response: retryResp };
+            break;
+          }
+          response = retryResp;
+          peeked = await peekStreamStart(response);
+        }
+        if (peeked.cls === "rate-limit") {
+          log(
+            `[${this.provider.displayName}] in-stream rate-limit persisted after ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} → returning 429 for cross-provider fallback`
+          );
+          try {
+            const { error_class, error_code } = classifyError(
+              new Error("in-stream rate limit"),
+              429,
+              peeked.detail
+            );
+            recordStats({
+              model_id: this.targetModel,
+              provider_name: this.provider.name,
+              stream_format: this.provider.streamFormat,
+              latency_ms: Math.round(performance.now() - startTime),
+              success: false,
+              http_status: 429,
+              error_class,
+              error_code,
+              token_strategy: this.options.tokenStrategy ?? "standard",
+              adapter_name: this.getActiveAdapterName(),
+              middleware_names: this.middlewareManager.getActiveNames(this.bareModelName),
+              fallback_used: fallbackMeta !== undefined,
+              fallback_chain: fallbackMeta?.chain,
+              fallback_attempts: fallbackMeta?.attempts,
+              invocation_mode: this.options.invocationMode ?? "auto-route",
+            });
+          } catch {
+            // Stats must never crash claudish
+          }
+          return c.json(
+            wrapAnthropicError(
+              429,
+              `${this.provider.displayName} rate limited (in-stream burst limit); ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} exhausted`,
+              "rate_limit_error"
+            ),
+            429 as any
+          );
+        }
+        // healthy or other-error → use the peeked (tee'd, full) stream below.
+        response = peeked.response;
       }
     }
 

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -708,7 +708,8 @@ export class ComposedHandler implements ModelHandler {
           const backoffMs =
             Math.min(1000 * 2 ** rlAttempt, 8000) + Math.floor(Math.random() * 750);
           log(
-            `[${this.provider.displayName}] in-stream rate-limit (HTTP 200), temporizing — retry ${rlAttempt + 1}/${maxRlRetries} in ${(backoffMs / 1000).toFixed(1)}s${peeked.detail ? `: ${peeked.detail}` : ""}`
+            `[RateLimit] [${this.provider.displayName}] in-stream rate-limit (HTTP 200), temporizing — retry ${rlAttempt + 1}/${maxRlRetries} in ${(backoffMs / 1000).toFixed(1)}s${peeked.detail ? `: ${peeked.detail}` : ""}`,
+            true // forceConsole — operational event, must be visible without --debug
           );
           await new Promise((r) => setTimeout(r, backoffMs));
           rlAttempt++;
@@ -718,7 +719,10 @@ export class ComposedHandler implements ModelHandler {
               ? await this.provider.enqueueRequest(doFetch)
               : await doFetch();
           } catch (e: any) {
-            log(`[${this.provider.displayName}] rate-limit retry fetch failed: ${e?.message ?? e}`);
+            log(
+              `[RateLimit] [${this.provider.displayName}] rate-limit retry fetch failed: ${e?.message ?? e}`,
+              true
+            );
             break;
           }
           if (!retryResp.ok) {
@@ -732,7 +736,8 @@ export class ComposedHandler implements ModelHandler {
         }
         if (peeked.cls === "rate-limit") {
           log(
-            `[${this.provider.displayName}] in-stream rate-limit persisted after ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} → returning 429 for cross-provider fallback`
+            `[RateLimit] [${this.provider.displayName}] in-stream rate-limit persisted after ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} → returning 429 for cross-provider fallback`,
+            true // forceConsole — operational event, must be visible without --debug
           );
           try {
             const { error_class, error_code } = classifyError(

--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import type { ModelHandler } from "./types.js";
 import { log, maskCredential } from "../logger.js";
 import { wrapAnthropicError } from "./shared/anthropic-error.js";
+import { createResponseCapture } from "./shared/response-capture.js";
 import {
   fetchMultiModelAdvice,
   findPendingAdvisorToolResults,
@@ -214,6 +215,7 @@ export class NativeHandler implements ModelHandler {
       // Handle streaming
       if (contentType.includes("text/event-stream")) {
         log("[Native] Streaming response detected");
+        const cap = createResponseCapture("native", target);
         return c.body(
           new ReadableStream({
             async start(controller) {
@@ -229,6 +231,7 @@ export class NativeHandler implements ModelHandler {
                   const { done, value } = await reader.read();
                   if (done) break;
 
+                  cap.tap(value);
                   controller.enqueue(value);
 
                   // Basic logging
@@ -242,9 +245,13 @@ export class NativeHandler implements ModelHandler {
                   for (const line of lines) if (line.trim()) eventLog += line + "\n";
                 }
                 if (eventLog) log(eventLog);
+                cap.note("reader done");
+                cap.done({ closed: true, reason: "done" });
                 controller.close();
               } catch (e) {
                 log(`[Native] Stream Error: ${e}`);
+                cap.note(`stream error: ${String(e)}`);
+                cap.done({ closed: true, reason: "error", err: String(e) });
                 controller.close();
               }
             },

--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -19,13 +19,14 @@ export class NativeHandler implements ModelHandler {
   private baseUrl: string;
   private advisorModels?: string[];
   private advisorCollector?: string | null;
+  private proxyKey?: string;
 
-  constructor(apiKey?: string, advisorModels?: string[], advisorCollector?: string | null) {
+  constructor(apiKey?: string, advisorModels?: string[], advisorCollector?: string | null, proxyKey?: string) {
     this.apiKey = apiKey;
-    // Always forward to real Anthropic API
     this.baseUrl = "https://api.anthropic.com";
     this.advisorModels = advisorModels;
     this.advisorCollector = advisorCollector;
+    this.proxyKey = proxyKey;
   }
 
   async handle(c: Context, payload: any): Promise<Response> {
@@ -145,13 +146,28 @@ export class NativeHandler implements ModelHandler {
       "anthropic-version": originalHeaders["anthropic-version"] || "2023-06-01",
     };
 
-    // Auth: pass through client headers, or fall back to stored API key
-    const clientAuth = originalHeaders["authorization"] || originalHeaders["x-api-key"];
-    if (clientAuth) {
-      if (originalHeaders["authorization"]) headers["authorization"] = originalHeaders["authorization"];
+    // Auth: pass through client headers unless they contain the proxy key,
+    // in which case fall back to stored API key (proxy key is for the local
+    // proxy only, not for api.anthropic.com).
+    const bearerToken = originalHeaders["authorization"]?.startsWith("Bearer ")
+      ? originalHeaders["authorization"].slice(7)
+      : originalHeaders["authorization"];
+    const clientAuthToken = originalHeaders["x-api-key"] || bearerToken;
+    const isProxyKey = this.proxyKey && clientAuthToken === this.proxyKey;
+
+    if (!isProxyKey && clientAuthToken) {
+      // Genuine client auth (OAuth token, API key) — pass through
       if (originalHeaders["x-api-key"]) headers["x-api-key"] = originalHeaders["x-api-key"];
+      else if (originalHeaders["authorization"]) headers["authorization"] = originalHeaders["authorization"];
     } else if (this.apiKey) {
-      headers["x-api-key"] = this.apiKey;
+      // Proxy key detected or no auth — use stored Anthropic key.
+      // OAuth tokens (sk-ant-oat01-) MUST be sent as authorization: Bearer,
+      // not as x-api-key — Anthropic rejects them in the latter header.
+      if (this.apiKey.startsWith("sk-ant-oat")) {
+        headers["authorization"] = `Bearer ${this.apiKey}`;
+      } else {
+        headers["x-api-key"] = this.apiKey;
+      }
     }
     if (originalHeaders["anthropic-beta"]) {
       const incomingBeta = originalHeaders["anthropic-beta"];

--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -140,56 +140,65 @@ export class NativeHandler implements ModelHandler {
     log(`Request body (Model: ${target}):`);
     log("=== End Request ===\n");
 
-    // Build headers - pass through auth headers exactly as received
+    // Transparent passthrough: forward ALL incoming headers to api.anthropic.com.
+    // This is essential for Max subscription auth — Claude Code sends internal
+    // headers that make the subscription work for Opus/Sonnet, and we must not
+    // drop any of them.
+    //
+    // Skip hop-by-hop headers and Hono-internal headers that must not be
+    // forwarded to an upstream API.
+    const HOP_BY_HOP = new Set([
+      "host", "connection", "keep-alive", "transfer-encoding", "te",
+      "trailer", "upgrade", "content-length",
+    ]);
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "anthropic-version": originalHeaders["anthropic-version"] || "2023-06-01",
     };
+    for (const [key, value] of Object.entries(originalHeaders)) {
+      if (HOP_BY_HOP.has(key.toLowerCase())) continue;
+      if (typeof value !== "string") continue;
+      headers[key] = value;
+    }
 
-    // Auth: pass through client headers unless they contain the proxy key,
-    // in which case fall back to stored API key (proxy key is for the local
-    // proxy only, not for api.anthropic.com).
-    const bearerToken = originalHeaders["authorization"]?.startsWith("Bearer ")
-      ? originalHeaders["authorization"].slice(7)
-      : originalHeaders["authorization"];
-    const clientAuthToken = originalHeaders["x-api-key"] || bearerToken;
-    const isProxyKey = this.proxyKey && clientAuthToken === this.proxyKey;
-
-    if (!isProxyKey && clientAuthToken) {
-      // Genuine client auth (OAuth token, API key) — pass through
-      if (originalHeaders["x-api-key"]) headers["x-api-key"] = originalHeaders["x-api-key"];
-      else if (originalHeaders["authorization"]) headers["authorization"] = originalHeaders["authorization"];
-    } else if (this.apiKey) {
-      // Proxy key detected or no auth — use stored Anthropic key.
-      // OAuth tokens (sk-ant-oat01-) MUST be sent as authorization: Bearer,
-      // not as x-api-key — Anthropic rejects them in the latter header.
-      if (this.apiKey.startsWith("sk-ant-oat")) {
-        headers["authorization"] = `Bearer ${this.apiKey}`;
-      } else {
-        headers["x-api-key"] = this.apiKey;
+    // Proxy key override: if the client auth matches our proxy key, replace it
+    // with the stored Anthropic key (proxy key is for the local proxy only,
+    // not for api.anthropic.com). When no proxy key is configured (pass-through
+    // mode), everything flows through unmodified.
+    if (this.proxyKey) {
+      const bearerToken = originalHeaders["authorization"]?.startsWith("Bearer ")
+        ? originalHeaders["authorization"].slice(7)
+        : originalHeaders["authorization"];
+      const clientAuthToken = originalHeaders["x-api-key"] || bearerToken;
+      if (clientAuthToken === this.proxyKey) {
+        // Strip proxy key from forwarded headers
+        delete headers["x-api-key"];
+        delete headers["authorization"];
+        if (this.apiKey) {
+          if (this.apiKey.startsWith("sk-ant-oat")) {
+            headers["authorization"] = `Bearer ${this.apiKey}`;
+          } else {
+            headers["x-api-key"] = this.apiKey;
+          }
+        }
       }
     }
-    if (originalHeaders["anthropic-beta"]) {
+
+    // Advisor-swap: strip advisor beta flag when we swapped the tool
+    if (advisorSwapped && originalHeaders["anthropic-beta"]) {
       const incomingBeta = originalHeaders["anthropic-beta"];
-      if (advisorSwapped) {
-        // When we swap the advisor tool we must also strip the matching beta
-        // flag; otherwise Anthropic rejects the request (beta enabled but no
-        // matching server tool declared).
-        const { stripped, changed } = stripAdvisorBeta(incomingBeta);
-        if (changed) {
-          log(
-            `[Native][advisor-swap] stripped advisor-tool beta; before=${incomingBeta} after=${stripped ?? "(empty)"}`
-          );
-          logAdvisorEvent(advisorCfg, {
-            kind: "beta_stripped",
-            before: incomingBeta,
-            after: stripped ?? "",
-          });
-        }
-        if (stripped) headers["anthropic-beta"] = stripped;
-      } else {
-        headers["anthropic-beta"] = incomingBeta;
+      const { stripped, changed } = stripAdvisorBeta(incomingBeta);
+      if (changed) {
+        log(
+          `[Native][advisor-swap] stripped advisor-tool beta; before=${incomingBeta} after=${stripped ?? "(empty)"}`
+        );
+        logAdvisorEvent(advisorCfg, {
+          kind: "beta_stripped",
+          before: incomingBeta,
+          after: stripped ?? "",
+        });
       }
+      if (stripped) headers["anthropic-beta"] = stripped;
+      else delete headers["anthropic-beta"];
     }
 
     // Execute fetch

--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -145,12 +145,13 @@ export class NativeHandler implements ModelHandler {
       "anthropic-version": originalHeaders["anthropic-version"] || "2023-06-01",
     };
 
-    // Pass through auth headers as-is
-    if (originalHeaders["authorization"]) {
-      headers["authorization"] = originalHeaders["authorization"];
-    }
-    if (originalHeaders["x-api-key"]) {
-      headers["x-api-key"] = originalHeaders["x-api-key"];
+    // Auth: pass through client headers, or fall back to stored API key
+    const clientAuth = originalHeaders["authorization"] || originalHeaders["x-api-key"];
+    if (clientAuth) {
+      if (originalHeaders["authorization"]) headers["authorization"] = originalHeaders["authorization"];
+      if (originalHeaders["x-api-key"]) headers["x-api-key"] = originalHeaders["x-api-key"];
+    } else if (this.apiKey) {
+      headers["x-api-key"] = this.apiKey;
     }
     if (originalHeaders["anthropic-beta"]) {
       const incomingBeta = originalHeaders["anthropic-beta"];

--- a/packages/cli/src/handlers/shared/format/openai-messages.ts
+++ b/packages/cli/src/handlers/shared/format/openai-messages.ts
@@ -39,6 +39,22 @@ export function convertMessagesToOpenAI(
     for (const msg of req.messages) {
       if (msg.role === "user") processUserMessage(msg, messages, simpleFormat);
       else if (msg.role === "assistant") processAssistantMessage(msg, messages, simpleFormat);
+      else if (msg.role === "system") {
+        // Inline system messages (Claude Code v2.1.153+): merge into the system prompt
+        // or prepend as a user message if no system prompt exists.
+        const content = typeof msg.content === "string"
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content.map((c: any) => c.text || "").join("\n")
+            : "";
+        if (content) {
+          if (messages.length > 0 && messages[0].role === "system") {
+            messages[0].content += "\n\n" + content;
+          } else {
+            messages.unshift({ role: "system", content });
+          }
+        }
+      }
     }
   }
 

--- a/packages/cli/src/handlers/shared/response-capture.ts
+++ b/packages/cli/src/handlers/shared/response-capture.ts
@@ -1,0 +1,92 @@
+/**
+ * Response-side SSE capture (temporary diagnostic — gated by CLAUDISH_CAPTURE_DIR).
+ *
+ * Pairs with the request-body capture in fork/middleware/request-logger.ts so we
+ * can inspect the FULL request→response of a hung/blocked stream offline. Every
+ * stream parser (anthropic-sse, openai-sse, native passthrough) taps its outgoing
+ * bytes here. At stream close we write the accumulated SSE to a `resp-*.sse` file
+ * and emit a one-line stdout marker visible in `docker logs`.
+ *
+ * No-op when CLAUDISH_CAPTURE_DIR is unset, so this is invisible in normal operation.
+ *
+ * The stdout marker is the key real-time signal: if a `[Request]` line appears in
+ * docker logs but its matching `[resp ...]` marker never does, the stream hung
+ * server-side (the parser loop never reached close).
+ */
+
+export interface ResponseCapture {
+  /** Tap outgoing bytes (raw Uint8Array or a pre-encoded SSE string). */
+  tap(chunk: Uint8Array | string): void;
+  /** Record a lifecycle note (e.g. "message_stop", "synthetic-finalize", "error"). */
+  note(label: string): void;
+  /** Flush to disk + emit stdout marker. Idempotent. */
+  done(extra?: Record<string, unknown>): void;
+}
+
+const NOOP: ResponseCapture = {
+  tap() {},
+  note() {},
+  done() {},
+};
+
+/**
+ * Create a response capture for one stream. `label` identifies the parser
+ * (e.g. "anthropic", "openai", "native"). Returns a no-op when capture is off.
+ */
+export function createResponseCapture(label: string, model: string): ResponseCapture {
+  const captureDir = process.env.CLAUDISH_CAPTURE_DIR;
+  if (!captureDir) return NOOP;
+
+  const decoder = new TextDecoder();
+  let sse = "";
+  const notes: string[] = [];
+  let events = 0;
+  let finished = false;
+  const startedAt = Date.now();
+
+  // Correlate with the request counter from request-logger (shared globalThis.__capN).
+  const g = globalThis as Record<string, unknown>;
+  const reqN = (g.__capN as number) ?? 0;
+
+  return {
+    tap(chunk: Uint8Array | string) {
+      const text = typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+      sse += text;
+      // Count SSE events (data: lines) for a quick at-a-glance summary.
+      let idx = 0;
+      while ((idx = text.indexOf("\ndata:", idx)) !== -1) {
+        events++;
+        idx += 6;
+      }
+    },
+    note(noteLabel: string) {
+      notes.push(`+${Date.now() - startedAt}ms ${noteLabel}`);
+    },
+    done(extra?: Record<string, unknown>) {
+      if (finished) return;
+      finished = true;
+      try {
+        const fs = require("fs");
+        fs.mkdirSync(captureDir, { recursive: true });
+        const ts = new Date().toISOString().replace(/[:.]/g, "-");
+        const safeModel = String(model).replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 40);
+        const file = `${captureDir}/resp-${process.pid}-r${String(reqN).padStart(4, "0")}-${ts}-${label}-${safeModel}.sse`;
+        const header =
+          `# claudish response capture\n` +
+          `# parser=${label} model=${model} reqN=${reqN} pid=${process.pid}\n` +
+          `# elapsed_ms=${Date.now() - startedAt} events~=${events}\n` +
+          `# notes=${notes.join(" | ")}\n` +
+          (extra ? `# extra=${JSON.stringify(extra)}\n` : "") +
+          `# ${"=".repeat(60)}\n\n`;
+        fs.writeFileSync(file, header + sse);
+        const stopReason = extra?.stop_reason ?? "?";
+        const closed = extra?.closed ?? "?";
+        process.stdout.write(
+          `  [resp] ${label} model=${model} reqN=${reqN} events~=${events} bytes=${sse.length} closed=${closed} stop=${stopReason} ${Date.now() - startedAt}ms -> ${file}\n`
+        );
+      } catch (e) {
+        process.stdout.write(`  [resp] capture error: ${String(e)}\n`);
+      }
+    },
+  };
+}

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -69,6 +69,8 @@ export function createAnthropicPassthroughStream(
           let toolUseBlocks = 0;
           let stopReason: string | null = null;
           let sawMessageStop = false;
+          let sawMessageStart = false;
+          let suppressedServerTools = 0;
 
           // Thinking-block filtering state
           let insideThinkingBlock = false;
@@ -283,12 +285,29 @@ export function createAnthropicPassthroughStream(
                         `[AnthropicSSE] Text chunk: "${txt.substring(0, 30).replace(/\n/g, "\\n")}" (${txt.length} chars)`
                       );
                     }
-                    if (
-                      data.type === "content_block_start" &&
-                      data.content_block?.type === "tool_use"
-                    ) {
-                      toolUseBlocks++;
-                      log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
+                                        if (
+                                          data.type === "content_block_start" &&
+                                          data.content_block?.type === "tool_use"
+                                        ) {
+                                          toolUseBlocks++;
+                                          log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
+                                        }
+                                        // Suppress server_tool_use blocks (Z.AI built-in tools)
+                                        if (
+                                          data.type === "content_block_start" &&
+                                          data.content_block?.type === "server_tool_use"
+                                        ) {
+                                          suppressedServerTools++;
+                                          log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
+                                          continue;
+                                        }
+                                        if (data.type === "content_block_stop" && suppressedServerTools > 0) {
+                                          suppressedServerTools--;
+                                          continue;
+                                        }
+                                        if (data.type === "message_start") {
+                                          sawMessageStart = true;
+
                     }
                     if (data.type === "message_delta" && data.delta?.stop_reason) {
                       stopReason = data.delta.stop_reason;
@@ -337,6 +356,9 @@ export function createAnthropicPassthroughStream(
                   if (data.type === "message_delta" && data.delta?.stop_reason) {
                     stopReason = data.delta.stop_reason;
                   }
+                  if (data.type === "message_start") {
+                    sawMessageStart = true;
+                  }
                   if (data.type === "message_stop") {
                     sawMessageStop = true;
                   }
@@ -360,6 +382,25 @@ export function createAnthropicPassthroughStream(
           // reports "API returned an empty or malformed response (HTTP 200)".
           if (!isClosed && !sawMessageStop) {
             log(`[AnthropicSSE] Stream ended without message_stop (stopReason=${stopReason}) — emitting synthetic finalization`);
+            if (!sawMessageStart) {
+              const synthId = `msg_${Date.now()}`;
+              controller.enqueue(encoder.encode(
+                "event: message_start\n" +
+                `data: {"type":"message_start","message":{"id":"${synthId}","type":"message","role":"assistant","model":"${opts.modelName}","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":${inputTokens},"output_tokens":${outputTokens}}}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_start\n" +
+                `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_delta\n" +
+                `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"[Error: The model returned an empty response. Try compacting the conversation or reducing the context size.]"}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_stop\n" +
+                `data: {"type":"content_block_stop","index":0}\n\n`
+              ));
+            }
             if (!stopReason) {
               controller.enqueue(encoder.encode(
                 "event: message_delta\n" +

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -68,6 +68,7 @@ export function createAnthropicPassthroughStream(
           let textChunks = 0;
           let toolUseBlocks = 0;
           let stopReason: string | null = null;
+          let sawMessageStop = false;
 
           // Thinking-block filtering state
           let insideThinkingBlock = false;
@@ -292,6 +293,9 @@ export function createAnthropicPassthroughStream(
                     if (data.type === "message_delta" && data.delta?.stop_reason) {
                       stopReason = data.delta.stop_reason;
                     }
+                    if (data.type === "message_stop") {
+                      sawMessageStop = true;
+                    }
                   } catch {
                     // Unparseable data line — pass through
                     if (!isClosed) {
@@ -333,6 +337,9 @@ export function createAnthropicPassthroughStream(
                   if (data.type === "message_delta" && data.delta?.stop_reason) {
                     stopReason = data.delta.stop_reason;
                   }
+                  if (data.type === "message_stop") {
+                    sawMessageStop = true;
+                  }
                 } catch {}
               }
             }
@@ -351,12 +358,14 @@ export function createAnthropicPassthroughStream(
           // message_stop, emit it ourselves. Claude Code requires
           // message_stop as the terminal event — without it, the client
           // reports "API returned an empty or malformed response (HTTP 200)".
-          if (!isClosed && !stopReason) {
-            log(`[AnthropicSSE] Stream ended without message_stop — emitting synthetic finalization`);
-            controller.enqueue(encoder.encode(
-              "event: message_delta\n" +
-              `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":${outputTokens}}}\n\n`
-            ));
+          if (!isClosed && !sawMessageStop) {
+            log(`[AnthropicSSE] Stream ended without message_stop (stopReason=${stopReason}) — emitting synthetic finalization`);
+            if (!stopReason) {
+              controller.enqueue(encoder.encode(
+                "event: message_delta\n" +
+                `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":${outputTokens}}}\n\n`
+              ));
+            }
             controller.enqueue(encoder.encode(
               "event: message_stop\n" +
               `data: {"type":"message_stop"}\n\n`

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -12,6 +12,7 @@
 import type { Context } from "hono";
 import { log } from "../../../logger.js";
 import type { BaseAPIFormat } from "../../../adapters/base-api-format.js";
+import { createResponseCapture } from "../response-capture.js";
 
 interface AnthropicPassthroughOpts {
   modelName: string;
@@ -41,9 +42,17 @@ export function createAnthropicPassthroughStream(
 
   const filterThinking = opts.adapter?.shouldFilterThinking() ?? false;
 
+  const cap = createResponseCapture("anthropic", opts.modelName);
+
   return c.body(
     new ReadableStream({
       async start(controller) {
+        // Diagnostic tap: mirror every outgoing byte into the response capture.
+        const _origEnqueue = controller.enqueue.bind(controller);
+        controller.enqueue = ((chunk: any) => {
+          cap.tap(chunk);
+          return _origEnqueue(chunk);
+        }) as typeof controller.enqueue;
         const sendPing = () => {
           if (!isClosed) {
             controller.enqueue(encoder.encode("event: ping\ndata: {\"type\":\"ping\"}\n\n"));
@@ -128,6 +137,8 @@ export function createAnthropicPassthroughStream(
                         clearInterval(pingInterval);
                         pingInterval = null;
                       }
+                      cap.note("in-stream-error(filtered)");
+                      cap.done({ closed: true, stop_reason: "error", path: "in-stream-error-filtered" });
                       controller.close();
                     }
                     return; // stop processing further lines
@@ -221,6 +232,8 @@ export function createAnthropicPassthroughStream(
                           clearInterval(pingInterval);
                           pingInterval = null;
                         }
+                        cap.note("in-stream-error");
+                        cap.done({ closed: true, stop_reason: "error", path: "in-stream-error" });
                         controller.close();
                       }
                       return; // stop processing further lines
@@ -371,6 +384,7 @@ export function createAnthropicPassthroughStream(
             `[AnthropicSSE] Stream complete for ${opts.modelName}: ${totalLines} lines, ${textChunks} text chunks, ${toolUseBlocks} tool_use blocks, stop_reason=${stopReason}` +
               (filterThinking ? `, filtered ${thinkingBlocksSuppressed} thinking blocks` : "")
           );
+          cap.note(`upstream-done sawMessageStop=${sawMessageStop} stop_reason=${stopReason} toolUse=${toolUseBlocks}`);
 
           if (opts.onTokenUpdate) {
             opts.onTokenUpdate(inputTokens, outputTokens);
@@ -419,21 +433,30 @@ export function createAnthropicPassthroughStream(
               clearInterval(pingInterval);
               pingInterval = null;
             }
+            cap.done({ closed: true, stop_reason: stopReason, sawMessageStop, path: "normal" });
             controller.close();
+          } else {
+            cap.done({ closed: true, stop_reason: stopReason, sawMessageStop, path: "already-closed" });
           }
         } catch (e) {
           log(`[AnthropicSSE] Stream error: ${e}`);
+          cap.note(`stream-exception ${String(e)}`);
           if (!isClosed) {
             isClosed = true;
             if (pingInterval) {
               clearInterval(pingInterval);
               pingInterval = null;
             }
+            cap.done({ closed: true, stop_reason: "exception", path: "catch", error: String(e) });
             controller.close();
+          } else {
+            cap.done({ closed: true, stop_reason: "exception", path: "catch-already-closed", error: String(e) });
           }
         }
       },
-      cancel() {
+      cancel(reason?: unknown) {
+        cap.note(`client-cancel ${reason !== undefined ? String(reason) : ""}`);
+        cap.done({ closed: false, stop_reason: "client-cancel", path: "cancel" });
         isClosed = true;
         if (pingInterval) {
           clearInterval(pingInterval);

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -102,6 +102,84 @@ export function createAnthropicPassthroughStream(
             if (idx > highestSeenIndex) highestSeenIndex = idx;
           };
 
+          // ── Graceful in-stream error finalization ─────────────────────
+          // Some anthropic-compat providers (Z.AI, MiniMax, Kimi) return HTTP 200
+          // and then inject an SSE error (e.g. Z.AI's [1302] rate limit) with NO
+          // valid message envelope. Forwarding a bare `event: error` makes Claude
+          // Code report "empty or malformed response (HTTP 200)" and crash the turn.
+          // Instead we ALWAYS emit a valid, terminal Claude message so the client
+          // ends the turn cleanly (no crash, no corruption):
+          //   - before any content → synthetic message_start + short notice + stop
+          //   - mid-stream         → close the open block + message_delta + stop
+          // ComposedHandler's peek/retry catches most start-of-stream rate limits
+          // before they reach here (it retries + falls back to a second provider);
+          // this is the last-resort safety net for whatever still slips through.
+          const finalizeWithError = (errMsg: string, path: string) => {
+            if (!isClosed) {
+              if (!sawMessageStart) {
+                const isRateLimit =
+                  /rate.?limit|\b1302\b|\b429\b|too many requests|overloaded/i.test(errMsg);
+                const notice = isRateLimit
+                  ? "[The model provider is rate limited right now. The proxy retried and exhausted fallback capacity — please try again in a moment.]"
+                  : `[Upstream provider error: ${errMsg}]`;
+                const synthId = `msg_${Date.now()}`;
+                controller.enqueue(
+                  encoder.encode(
+                    "event: message_start\n" +
+                      `data: {"type":"message_start","message":{"id":"${synthId}","type":"message","role":"assistant","model":"${opts.modelName}","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}\n\n`
+                  )
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    "event: content_block_start\n" +
+                      `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`
+                  )
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    "event: content_block_delta\n" +
+                      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: notice } })}\n\n`
+                  )
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    "event: content_block_stop\n" + `data: {"type":"content_block_stop","index":0}\n\n`
+                  )
+                );
+              } else if (highestSeenIndex >= 0) {
+                // Mid-stream: close whatever content block was open when the error hit,
+                // otherwise the client sees an unterminated block.
+                controller.enqueue(
+                  encoder.encode(
+                    "event: content_block_stop\n" +
+                      `data: {"type":"content_block_stop","index":${highestSeenIndex}}\n\n`
+                  )
+                );
+              }
+              controller.enqueue(
+                encoder.encode(
+                  "event: message_delta\n" +
+                    `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":0}}\n\n`
+                )
+              );
+              controller.enqueue(
+                encoder.encode("event: message_stop\n" + `data: {"type":"message_stop"}\n\n`)
+              );
+            }
+            isClosed = true;
+            if (pingInterval) {
+              clearInterval(pingInterval);
+              pingInterval = null;
+            }
+            cap.note(`in-stream-error->graceful: ${errMsg.slice(0, 80)}`);
+            cap.done({ closed: true, stop_reason: "error-graceful", path });
+            try {
+              controller.close();
+            } catch {
+              // already closed
+            }
+          };
+
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
@@ -125,22 +203,7 @@ export function createAnthropicPassthroughStream(
                   if (data.error) {
                     const errMsg = data.error.message || JSON.stringify(data.error);
                     log(`[AnthropicSSE] In-stream error detected: ${errMsg}`);
-                    if (!isClosed) {
-                      controller.enqueue(encoder.encode(
-                        `event: error\ndata: ${JSON.stringify({
-                          type: "error",
-                          error: { type: "api_error", message: errMsg },
-                        })}\n\n`
-                      ));
-                      isClosed = true;
-                      if (pingInterval) {
-                        clearInterval(pingInterval);
-                        pingInterval = null;
-                      }
-                      cap.note("in-stream-error(filtered)");
-                      cap.done({ closed: true, stop_reason: "error", path: "in-stream-error-filtered" });
-                      controller.close();
-                    }
+                    finalizeWithError(errMsg, "in-stream-error-filtered");
                     return; // stop processing further lines
                   }
 
@@ -220,22 +283,7 @@ export function createAnthropicPassthroughStream(
                     if (data.error) {
                       const errMsg = data.error.message || JSON.stringify(data.error);
                       log(`[AnthropicSSE] In-stream error detected: ${errMsg}`);
-                      if (!isClosed) {
-                        controller.enqueue(encoder.encode(
-                          `event: error\ndata: ${JSON.stringify({
-                            type: "error",
-                            error: { type: "api_error", message: errMsg },
-                          })}\n\n`
-                        ));
-                        isClosed = true;
-                        if (pingInterval) {
-                          clearInterval(pingInterval);
-                          pingInterval = null;
-                        }
-                        cap.note("in-stream-error");
-                        cap.done({ closed: true, stop_reason: "error", path: "in-stream-error" });
-                        controller.close();
-                      }
+                      finalizeWithError(errMsg, "in-stream-error");
                       return; // stop processing further lines
                     }
 
@@ -298,29 +346,28 @@ export function createAnthropicPassthroughStream(
                         `[AnthropicSSE] Text chunk: "${txt.substring(0, 30).replace(/\n/g, "\\n")}" (${txt.length} chars)`
                       );
                     }
-                                        if (
-                                          data.type === "content_block_start" &&
-                                          data.content_block?.type === "tool_use"
-                                        ) {
-                                          toolUseBlocks++;
-                                          log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
-                                        }
-                                        // Suppress server_tool_use blocks (Z.AI built-in tools)
-                                        if (
-                                          data.type === "content_block_start" &&
-                                          data.content_block?.type === "server_tool_use"
-                                        ) {
-                                          suppressedServerTools++;
-                                          log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
-                                          continue;
-                                        }
-                                        if (data.type === "content_block_stop" && suppressedServerTools > 0) {
-                                          suppressedServerTools--;
-                                          continue;
-                                        }
-                                        if (data.type === "message_start") {
-                                          sawMessageStart = true;
-
+                    if (
+                      data.type === "content_block_start" &&
+                      data.content_block?.type === "tool_use"
+                    ) {
+                      toolUseBlocks++;
+                      log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
+                    }
+                    // Suppress server_tool_use blocks (Z.AI built-in tools)
+                    if (
+                      data.type === "content_block_start" &&
+                      data.content_block?.type === "server_tool_use"
+                    ) {
+                      suppressedServerTools++;
+                      log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
+                      continue;
+                    }
+                    if (data.type === "content_block_stop" && suppressedServerTools > 0) {
+                      suppressedServerTools--;
+                      continue;
+                    }
+                    if (data.type === "message_start") {
+                      sawMessageStart = true;
                     }
                     if (data.type === "message_delta" && data.delta?.stop_reason) {
                       stopReason = data.delta.stop_reason;
@@ -335,7 +382,15 @@ export function createAnthropicPassthroughStream(
                     }
                   }
                 } else {
-                  // Non-data lines (event: lines, blank lines) — pass through
+                  // Non-data lines (event: lines, blank lines).
+                  // Suppress a bare `event: error` line: the matching `data:` line
+                  // that follows carries the payload and triggers finalizeWithError().
+                  // Forwarding `event: error` verbatim is itself what makes Claude Code
+                  // report "empty or malformed response (HTTP 200)" and crash, and it
+                  // produced the double `event: error` seen in production captures.
+                  if (line.trimStart().startsWith("event: error")) {
+                    continue;
+                  }
                   if (!isClosed) {
                     controller.enqueue(encoder.encode(line + "\n"));
                   }

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -74,6 +74,22 @@ export function createAnthropicPassthroughStream(
           /** How many thinking blocks have been suppressed so far. */
           let thinkingBlocksSuppressed = 0;
 
+          // Content block index tracking — detect out-of-range indices
+          // that would cause "Content block not found" on the client side.
+          let highestSeenIndex = -1;
+          const clampIndex = (idx: number, context: string): number => {
+            if (idx > highestSeenIndex + 1) {
+              log(
+                `[AnthropicSSE] Index jump detected: ${idx} but expected <=${highestSeenIndex + 1} (${context}) — clamping to ${highestSeenIndex + 1}`
+              );
+              return highestSeenIndex + 1;
+            }
+            return idx;
+          };
+          const trackIndex = (idx: number) => {
+            if (idx > highestSeenIndex) highestSeenIndex = idx;
+          };
+
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
@@ -141,8 +157,10 @@ export function createAnthropicPassthroughStream(
                   // After suppressing N thinking blocks, subtract N from the index
                   if (typeof data.index === "number" && thinkingBlocksSuppressed > 0) {
                     const reindexed = data.index - thinkingBlocksSuppressed;
+                    const clamped = clampIndex(reindexed, `${data.type} (filtered, orig=${data.index})`);
+                    trackIndex(clamped);
                     const modifiedLine =
-                      "data: " + JSON.stringify({ ...data, index: reindexed });
+                      "data: " + JSON.stringify({ ...data, index: clamped });
 
                     if (!isClosed) {
                       controller.enqueue(encoder.encode(modifiedLine + "\n"));
@@ -150,7 +168,23 @@ export function createAnthropicPassthroughStream(
 
                     // Still do usage tracking below with the ORIGINAL data
                   } else {
-                    // No filtering needed — pass through as-is
+                    // No filtering needed — track and pass through
+                    if (typeof data.index === "number") {
+                      if (data.type === "content_block_start") {
+                        trackIndex(data.index);
+                      } else {
+                        const clamped = clampIndex(data.index, `${data.type} (unfiltered)`);
+                        if (clamped !== data.index) {
+                          const modifiedLine =
+                            "data: " + JSON.stringify({ ...data, index: clamped });
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode(modifiedLine + "\n"));
+                          }
+                          // Skip original enqueue below
+                          continue;
+                        }
+                      }
+                    }
                     if (!isClosed) {
                       controller.enqueue(encoder.encode(line + "\n"));
                     }
@@ -189,9 +223,47 @@ export function createAnthropicPassthroughStream(
                       return; // stop processing further lines
                     }
 
-                    // No error — pass through the line
-                    if (!isClosed) {
-                      controller.enqueue(encoder.encode(line + "\n"));
+                    // No error — check index bounds before passing through
+                    if (typeof data.index === "number") {
+                      if (data.type === "content_block_start") {
+                        // z.ai sometimes sends content_block_start with an index
+                        // that jumps (e.g., 0 → 2, skipping 1). This causes
+                        // "Content block not found" on the client. Remap to
+                        // sequential indices to keep the client happy.
+                        const expected = highestSeenIndex + 1;
+                        if (data.index !== expected) {
+                          log(
+                            `[AnthropicSSE] content_block_start index ${data.index} remapped to ${expected} (model=${opts.modelName})`
+                          );
+                          const remapped = { ...data, index: expected };
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode("data: " + JSON.stringify(remapped) + "\n"));
+                          }
+                        } else {
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode(line + "\n"));
+                          }
+                        }
+                        trackIndex(expected);
+                      } else {
+                        // delta / stop — clamp to highestSeenIndex
+                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`);
+                        if (clamped !== data.index) {
+                          const modified = { ...data, index: clamped };
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode("data: " + JSON.stringify(modified) + "\n"));
+                          }
+                        } else {
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode(line + "\n"));
+                          }
+                        }
+                      }
+                    } else {
+                      // No index field — pass through as-is
+                      if (!isClosed) {
+                        controller.enqueue(encoder.encode(line + "\n"));
+                      }
                     }
 
                     // Usage/debug tracking
@@ -273,6 +345,22 @@ export function createAnthropicPassthroughStream(
 
           if (opts.onTokenUpdate) {
             opts.onTokenUpdate(inputTokens, outputTokens);
+          }
+
+          // Finalization: if the upstream stream ended without sending
+          // message_stop, emit it ourselves. Claude Code requires
+          // message_stop as the terminal event — without it, the client
+          // reports "API returned an empty or malformed response (HTTP 200)".
+          if (!isClosed && !stopReason) {
+            log(`[AnthropicSSE] Stream ended without message_stop — emitting synthetic finalization`);
+            controller.enqueue(encoder.encode(
+              "event: message_delta\n" +
+              `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":${outputTokens}}}\n\n`
+            ));
+            controller.enqueue(encoder.encode(
+              "event: message_stop\n" +
+              `data: {"type":"message_stop"}\n\n`
+            ));
           }
 
           if (!isClosed) {

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -173,6 +173,12 @@ export function createAnthropicPassthroughStream(
             }
             cap.note(`in-stream-error->graceful: ${errMsg.slice(0, 80)}`);
             cap.done({ closed: true, stop_reason: "error-graceful", path });
+            // Surface to stdout (visible without --debug) so a mid-stream burst
+            // that bypassed the start-of-stream peek is still observable live.
+            log(
+              `[RateLimit] safety-net finalized stream gracefully (${path}): ${errMsg.slice(0, 120)}`,
+              true
+            );
             try {
               controller.close();
             } catch {

--- a/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
@@ -62,7 +62,7 @@ export function createGeminiSseStream(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });
@@ -113,7 +113,7 @@ export function createGeminiSseStream(
           send("message_delta", {
             type: "message_delta",
             delta: { stop_reason: hasToolCalls ? "tool_use" : "end_turn", stop_sequence: null },
-            usage: { output_tokens: outputTokens },
+            usage: { input_tokens: inputTokens, output_tokens: outputTokens },
           });
           send("message_stop", { type: "message_stop" });
         }

--- a/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
@@ -50,7 +50,7 @@ export function createOllamaJsonlStream(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });
@@ -75,7 +75,7 @@ export function createOllamaJsonlStream(
           send("message_delta", {
             type: "message_delta",
             delta: { stop_reason: "end_turn", stop_sequence: null },
-            usage: { output_tokens: completionTokens },
+            usage: { input_tokens: promptTokens, output_tokens: completionTokens },
           });
           send("message_stop", { type: "message_stop" });
         }

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
@@ -66,7 +66,7 @@ export function createResponsesStreamHandler(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -8,14 +8,17 @@
  */
 
 import type { Context } from "hono";
-import { log } from "../../../logger.js";
+import { log, logStderr } from "../../../logger.js";
+
+const SEARXNG_AVAILABLE = !!process.env.SEARXNG_URL;
 import {
   validateAndRepairToolCall,
   inferMissingParameters,
   extractToolCallsFromText,
   type ToolSchema,
 } from "../tool-call-recovery.js";
-import { isWebSearchToolCall, warnWebSearchUnsupported } from "../web-search-detector.js";
+import { isWebSearchToolCall } from "../web-search-detector.js";
+import { executeWebSearch, extractSearchQuery } from "../web-search-executor.js";
 
 export interface StreamingState {
   usage: any;
@@ -37,6 +40,7 @@ export interface ToolState {
   blockIndex: number;
   started: boolean; // Whether content_block_start has been sent
   closed: boolean;
+  suppressed: boolean; // Web search tools — drop from stream, replace with text
   arguments: string; // Accumulated JSON arguments string
   buffered: boolean; // Whether we're buffering args until tool call completes
 }
@@ -152,6 +156,9 @@ export function createStreamingResponseHandler(
         const finalize = async (reason: string, err?: string) => {
           if (state.finalized) return;
           state.finalized = true;
+          const toolCount = Array.from(state.tools.values()).filter(t => t.started && !t.suppressed).length;
+          log(`[Stream] reason=${reason} model=${opts.modelName} text=${state.textStarted} tools=${toolCount} text_len=${state.accumulatedText.length} err=${err ?? "none"}`);
+          logStderr(`[Stream] ${opts.modelName} ${reason} text_len=${state.accumulatedText.length} tools=${toolCount}`);
 
           // Debug: Log accumulated text for analysis
           if (state.accumulatedText.length > 0) {
@@ -159,6 +166,27 @@ export function createStreamingResponseHandler(
             log(
               `[Streaming] Accumulated text (${state.accumulatedText.length} chars): ${preview}...`
             );
+          }
+
+          // Check for text-based web search tags (GLM emits <searchWeb><query>...</query></searchWeb>)
+          // These must be intercepted before text-based tool call extraction, since we want to
+          // execute SearXNG and replace the search tags with results, not pass them through.
+          let searchWebResults: string | null = null;
+          let cleanedText = state.accumulatedText;
+          const searchWebMatch = state.accumulatedText.match(/<searchWeb>\s*<query>([\s\S]*?)<\/query>\s*<\/searchWeb>/i);
+          if (searchWebMatch) {
+            const searchQuery = searchWebMatch[1].trim();
+            log(`[Stream] GLM searchWeb detected: "${searchQuery}" — intercepting via SearXNG`);
+            if (searchQuery && SEARXNG_AVAILABLE) {
+              searchWebResults = await executeWebSearch(searchQuery);
+            } else {
+              searchWebResults = searchQuery
+                ? `[Web search for "${searchQuery}" could not be executed. SearXNG is not configured.]`
+                : `[Web search was requested but no query was provided.]`;
+            }
+            // Remove the search tags from accumulated text so they don't appear in output
+            cleanedText = state.accumulatedText.replace(/<searchWeb>[\s\S]*?<\/searchWeb>/i, "").trim();
+            state.accumulatedText = cleanedText;
           }
 
           // Check for text-based tool calls before finalizing
@@ -200,6 +228,23 @@ export function createStreamingResponseHandler(
           }
           if (state.textStarted) {
             send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
+          }
+
+          // Inject SearXNG results if we intercepted GLM <searchWeb> tags.
+          // Sent as a separate text block after the (now-cleaned) model output.
+          if (searchWebResults) {
+            const srchIdx = state.curIdx++;
+            send("content_block_start", {
+              type: "content_block_start",
+              index: srchIdx,
+              content_block: { type: "text", text: "" },
+            });
+            send("content_block_delta", {
+              type: "content_block_delta",
+              index: srchIdx,
+              delta: { type: "text_delta", text: searchWebResults },
+            });
+            send("content_block_stop", { type: "content_block_stop", index: srchIdx });
           }
 
           // Handle buffered-but-unsent structured tool calls.
@@ -286,8 +331,27 @@ export function createStreamingResponseHandler(
           if (reason === "error") {
             send("error", { type: "error", error: { type: "api_error", message: err } });
           } else {
+            // Ensure at least one content block exists — some providers (z.ai, GLM)
+            // return empty responses (finish_reason without content). The Anthropic
+            // SDK treats messages with content:[] as malformed.
+            const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started && !t.suppressed);
+            const hasContent = state.textStarted || state.reasoningStarted || hasStructuredTools || textToolCalls.length > 0;
+            if (!hasContent) {
+              // Send a proper Anthropic error event so the SDK triggers its retry logic.
+              // Injecting fake text would be silently accepted but not trigger recovery.
+              const emptyMsg = `The model returned an empty response. This usually happens when the conversation context is too large. Try compacting the conversation or reducing the context size.`;
+              send("error", {
+                type: "error",
+                error: {
+                  type: "api_error",
+                  message: emptyMsg,
+                },
+              });
+              logStderr(`[Stream] EMPTY RESPONSE from ${opts.modelName} — sent api_error to client (context overflow?)`);
+              log(`[Stream] Empty response from provider (context overflow?) — sent api_error event`);
+            }
+
             // Set stop_reason based on whether we sent ANY tool calls (text-based or structured)
-            const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started);
             const stopReason =
               textToolCalls.length > 0 || hasStructuredTools ? "tool_use" : "end_turn";
             send("message_delta", {
@@ -498,20 +562,24 @@ export function createStreamingResponseHandler(
                           // Restore truncated tool name to original if mapping exists
                           const rawName = tc.function.name;
                           const restoredName = toolNameMap?.get(rawName) || rawName;
+                          const isWebSearch = isWebSearchToolCall(restoredName);
+                          if (isWebSearch) {
+                            log(`[Stream] Web search tool call detected: "${restoredName}" — intercepting via SearXNG (available=${SEARXNG_AVAILABLE})`);
+                          }
                           t = {
                             id: tc.id || `tool_${Date.now()}_${idx}`,
                             name: restoredName,
                             blockIndex: state.curIdx++,
                             started: false,
                             closed: false,
+                            suppressed: isWebSearch,
                             arguments: "", // Initialize arguments accumulator
-                            buffered: !!toolSchemas && toolSchemas.length > 0, // Buffer if we have schemas to validate
+                            buffered: !!toolSchemas && toolSchemas.length > 0 && !isWebSearch,
                           };
                           state.tools.set(idx, t);
-                          if (isWebSearchToolCall(restoredName)) {
-                            warnWebSearchUnsupported(restoredName, target);
-                          }
                         }
+                        // Skip suppressed tools entirely
+                        if (t.suppressed) continue;
                         // Only send content_block_start immediately if NOT buffering
                         if (!t.started && !t.buffered) {
                           send("content_block_start", {
@@ -522,7 +590,7 @@ export function createStreamingResponseHandler(
                           t.started = true;
                         }
                       }
-                      if (tc.function?.arguments && t) {
+                      if (tc.function?.arguments && t && !t.suppressed) {
                         // Always accumulate arguments
                         t.arguments += tc.function.arguments;
                         // Only stream immediately if NOT buffering
@@ -543,6 +611,36 @@ export function createStreamingResponseHandler(
 
                 if (chunk.choices?.[0]?.finish_reason === "tool_calls") {
                   for (const t of Array.from(state.tools.values())) {
+                    if (t.suppressed) {
+                      // Execute web search via SearXNG and inject results
+                      if (!t.closed) {
+                        const query = extractSearchQuery(t.arguments);
+                        let resultText: string;
+                        if (query && SEARXNG_AVAILABLE) {
+                          resultText = await executeWebSearch(query);
+                        } else {
+                          resultText = query
+                            ? `[Web search for "${query}" could not be executed. The search service (SearXNG) is not configured. Set SEARXNG_URL env var to enable.]`
+                            : `[Web search was requested but no query was provided.]`;
+                        }
+                        send("content_block_start", {
+                          type: "content_block_start",
+                          index: t.blockIndex,
+                          content_block: { type: "text", text: "" },
+                        });
+                        send("content_block_delta", {
+                          type: "content_block_delta",
+                          index: t.blockIndex,
+                          delta: { type: "text_delta", text: resultText },
+                        });
+                        send("content_block_stop", {
+                          type: "content_block_stop",
+                          index: t.blockIndex,
+                        });
+                        t.closed = true;
+                      }
+                      continue;
+                    }
                     if (!t.closed) {
                       // Validate and potentially repair tool arguments
                       if (toolSchemas && toolSchemas.length > 0) {

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -138,7 +138,7 @@ export function createStreamingResponseHandler(
             model: target,
             stop_reason: null,
             stop_sequence: null,
-            usage: { input_tokens: 100, output_tokens: 1 },
+            usage: { input_tokens: 0, output_tokens: 0 },
           },
         });
         send("ping", { type: "ping" });
@@ -293,7 +293,10 @@ export function createStreamingResponseHandler(
             send("message_delta", {
               type: "message_delta",
               delta: { stop_reason: stopReason, stop_sequence: null },
-              usage: { output_tokens: state.usage?.completion_tokens || 0 },
+              usage: {
+                input_tokens: state.usage?.prompt_tokens || 0,
+                output_tokens: state.usage?.completion_tokens || 0,
+              },
             });
             send("message_stop", { type: "message_stop" });
           }
@@ -312,7 +315,7 @@ export function createStreamingResponseHandler(
               log(
                 `[Streaming] No usage data from provider, estimating: ~${estimatedOutputTokens} output tokens`
               );
-              onTokenUpdate(100, estimatedOutputTokens); // Use 100 as placeholder for input
+              onTokenUpdate(0, estimatedOutputTokens);
             }
           }
 

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -19,6 +19,7 @@ import {
 } from "../tool-call-recovery.js";
 import { isWebSearchToolCall } from "../web-search-detector.js";
 import { executeWebSearch, extractSearchQuery } from "../web-search-executor.js";
+import { createResponseCapture } from "../response-capture.js";
 
 export interface StreamingState {
   usage: any;
@@ -120,9 +121,19 @@ export function createStreamingResponseHandler(
   const decoder = new TextDecoder();
   const streamMetadata = new Map<string, any>();
 
+  const cap = createResponseCapture("openai", target);
+
   return c.body(
     new ReadableStream({
       async start(controller) {
+        // Diagnostic tap (no-op unless CLAUDISH_CAPTURE_DIR set): mirror every
+        // outgoing byte to the response capture so a hung stream is visible offline.
+        const _origEnqueue = controller.enqueue.bind(controller);
+        controller.enqueue = ((chunk: any) => {
+          cap.tap(chunk);
+          return _origEnqueue(chunk);
+        }) as any;
+
         const send = (e: string, d: any) => {
           if (!isClosed) {
             controller.enqueue(encoder.encode(`event: ${e}\ndata: ${JSON.stringify(d)}\n\n`));
@@ -157,8 +168,8 @@ export function createStreamingResponseHandler(
           if (state.finalized) return;
           state.finalized = true;
           const toolCount = Array.from(state.tools.values()).filter(t => t.started && !t.suppressed).length;
-          log(`[Stream] reason=${reason} model=${opts.modelName} text=${state.textStarted} tools=${toolCount} text_len=${state.accumulatedText.length} err=${err ?? "none"}`);
-          logStderr(`[Stream] ${opts.modelName} ${reason} text_len=${state.accumulatedText.length} tools=${toolCount}`);
+          log(`[Stream] reason=${reason} model=${target} text=${state.textStarted} tools=${toolCount} text_len=${state.accumulatedText.length} err=${err ?? "none"}`);
+          logStderr(`[Stream] ${target} ${reason} text_len=${state.accumulatedText.length} tools=${toolCount}`);
 
           // Debug: Log accumulated text for analysis
           if (state.accumulatedText.length > 0) {
@@ -347,7 +358,7 @@ export function createStreamingResponseHandler(
                   message: emptyMsg,
                 },
               });
-              logStderr(`[Stream] EMPTY RESPONSE from ${opts.modelName} — sent api_error to client (context overflow?)`);
+              logStderr(`[Stream] EMPTY RESPONSE from ${target} — sent api_error to client (context overflow?)`);
               log(`[Stream] Empty response from provider (context overflow?) — sent api_error event`);
             }
 
@@ -390,6 +401,8 @@ export function createStreamingResponseHandler(
             controller.close();
             isClosed = true;
             if (ping) clearInterval(ping);
+            cap.note(`close reason=${reason}`);
+            cap.done({ closed: true, reason, tools: toolCount, text_len: state.accumulatedText.length, err: err ?? null });
           }
         };
 

--- a/packages/cli/src/handlers/shared/stream-peek.test.ts
+++ b/packages/cli/src/handlers/shared/stream-peek.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from "bun:test";
+import { peekStreamStart } from "./stream-peek.js";
+
+function sseResponse(chunks: string[], status = 200): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const ch of chunks) controller.enqueue(encoder.encode(ch));
+      controller.close();
+    },
+  });
+  return new Response(stream as any, { status });
+}
+
+async function readAll(response: Response): Promise<string> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+const MESSAGE_START =
+  'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"glm-5.1","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\n';
+const CONTENT =
+  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n';
+
+describe("peekStreamStart", () => {
+  test("classifies a message_start as healthy and hands the FULL stream downstream", async () => {
+    const res = sseResponse([MESSAGE_START + CONTENT]);
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("healthy");
+    // branch B must carry the entire stream — prefix included — not just what
+    // came after the peek.
+    const body = await readAll(peeked.response);
+    expect(body).toContain("message_start");
+    expect(body).toContain("Hello");
+  });
+
+  test("reads past leading ping/comment lines before deciding healthy", async () => {
+    const res = sseResponse(['event: ping\ndata: {"type":"ping"}\n\n', MESSAGE_START + CONTENT]);
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("healthy");
+    const body = await readAll(peeked.response);
+    expect(body).toContain("ping");
+    expect(body).toContain("Hello");
+  });
+
+  test("classifies a [1302] start-of-stream error as rate-limit", async () => {
+    const res = sseResponse([
+      'event: error\ndata: {"error":{"code":"1302","message":"Your account has reached its rate limit"}}\n\n',
+    ]);
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("rate-limit");
+    expect(peeked.detail).toContain("rate limit");
+  });
+
+  test("classifies a non-rate-limit in-stream error as other-error and still hands the stream downstream", async () => {
+    const res = sseResponse([
+      'event: error\ndata: {"error":{"code":"5000","message":"internal boom"}}\n\n',
+    ]);
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("other-error");
+    expect(peeked.detail).toContain("internal boom");
+    // other-error flows to the parser (its graceful finalizer surfaces it).
+    const body = await readAll(peeked.response);
+    expect(body).toContain("internal boom");
+  });
+
+  test("fails open (healthy) when the response has no body", async () => {
+    const res = new Response(null, { status: 200 });
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("healthy");
+    expect(peeked.response).toBe(res); // original, untouched
+  });
+});

--- a/packages/cli/src/handlers/shared/stream-peek.ts
+++ b/packages/cli/src/handlers/shared/stream-peek.ts
@@ -1,0 +1,195 @@
+/**
+ * Stream start peek — classify the first bytes of an SSE response without
+ * consuming the stream the parser will later read.
+ *
+ * Motivation: Z.AI (anthropic-sse transport) frequently delivers its burst /
+ * RPM limit as **HTTP 200** followed by an in-stream SSE error ([1302]) that
+ * carries no message envelope. That is invisible to `response.ok` and to
+ * FallbackHandler (both key off HTTP status), so it used to flow straight to
+ * the client as a bare error and crash the turn. By peeking the first bytes we
+ * can detect the rate-limit before handing the body to the parser, temporize
+ * (retry the same provider — the sustained quota has headroom, only the
+ * instantaneous burst limit is hit), and on persistence fall back to the next
+ * provider in the chain.
+ *
+ * Mechanism: `ReadableStream.tee()` splits the body into two independent
+ * branches. We sniff branch A and hand branch B (a pristine, full copy
+ * including the prefix we read) downstream. Tee buffers internally, so no bytes
+ * are lost for branch B even though we consumed branch A.
+ *
+ * Timing: the rate-limit errors we target arrive in 0-4ms. A short bounded
+ * window therefore catches them while leaving slow-but-healthy responses (a
+ * big-context cache-miss can have a multi-second TTFB) to proceed untouched.
+ *
+ * Fail-open: any unexpected condition (no body, tee unsupported, read error,
+ * timeout) resolves to "healthy" with a usable Response, so this never makes
+ * things worse than the parser-level safety net already guarantees.
+ */
+
+export type StreamStartClass = "healthy" | "rate-limit" | "other-error";
+
+export interface PeekResult {
+  cls: StreamStartClass;
+  /**
+   * Response to hand downstream.
+   * - healthy / other-error: a tee'd branch carrying the FULL original stream
+   *   (prefix included). Always use this — the original body is locked by tee().
+   * - rate-limit: the original Response (its body is already cancelled and must
+   *   not be read; the caller retries or falls back instead).
+   */
+  response: Response;
+  /** Best-effort human-readable error message extracted from the sniffed bytes. */
+  detail?: string;
+}
+
+export interface PeekOptions {
+  /**
+   * Max time to wait for the first classifiable bytes before assuming healthy.
+   * Rate-limit errors arrive in 0-4ms, so the default is generous.
+   */
+  timeoutMs?: number;
+  /** Max bytes to sniff before giving up and assuming healthy. */
+  maxSniffBytes?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const DEFAULT_MAX_SNIFF_BYTES = 64 * 1024;
+
+/** Extract the first `"message":"..."` value from sniffed SSE text. */
+function extractErrMsg(sniff: string): string | undefined {
+  const m = sniff.match(/"message"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+  if (!m) return undefined;
+  try {
+    return JSON.parse(`"${m[1]}"`);
+  } catch {
+    return m[1];
+  }
+}
+
+const RATE_LIMIT_RE = /rate.?limit|\b1302\b|\b1305\b|\b429\b|too many requests|overloaded|quota/i;
+
+/**
+ * Classify what we've sniffed so far. Returns null when the bytes are still
+ * ambiguous (need to read more), a concrete class once we can decide.
+ */
+function classifyPartial(sniff: string): { cls: StreamStartClass; detail?: string } | null {
+  // A message envelope means the provider is streaming a real answer — healthy.
+  if (/"type"\s*:\s*"message_start"/.test(sniff) || /(^|\n)event:\s*message_start/.test(sniff)) {
+    return { cls: "healthy" };
+  }
+  // Any content delta before an error likewise means a real answer is flowing.
+  if (/"type"\s*:\s*"content_block_start"/.test(sniff)) {
+    return { cls: "healthy" };
+  }
+  // Error signatures: an `event: error`, a top-level error type, or an error object.
+  const hasError =
+    /(^|\n)event:\s*error/.test(sniff) ||
+    /"type"\s*:\s*"error"/.test(sniff) ||
+    /"error"\s*:\s*\{/.test(sniff);
+  if (hasError) {
+    const detail = extractErrMsg(sniff);
+    const isRateLimit = RATE_LIMIT_RE.test(sniff);
+    return { cls: isRateLimit ? "rate-limit" : "other-error", detail };
+  }
+  return null;
+}
+
+/**
+ * Peek the start of an SSE response and classify it without disturbing the
+ * stream handed downstream. See module docs for the full rationale.
+ */
+export async function peekStreamStart(
+  response: Response,
+  opts: PeekOptions = {}
+): Promise<PeekResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxSniffBytes = opts.maxSniffBytes ?? DEFAULT_MAX_SNIFF_BYTES;
+
+  if (!response.body) {
+    return { cls: "healthy", response };
+  }
+
+  // Typed as `any`: `response.body.tee()` returns Node's stream/web
+  // ReadableStream, which is a distinct declaration from the global DOM
+  // ReadableStream and won't unify across the two type roots. The branches are
+  // only used locally (getReader / new Response), so erasing the type here is
+  // safe and avoids a cross-lib cast.
+  let branchA: any;
+  let branchB: any;
+  try {
+    [branchA, branchB] = response.body.tee();
+  } catch {
+    // tee() unsupported or failed — original body untouched, fail open.
+    return { cls: "healthy", response };
+  }
+
+  const reader = branchA.getReader();
+  const decoder = new TextDecoder();
+  let sniff = "";
+  let cls: StreamStartClass | null = null;
+  let detail: string | undefined;
+
+  const deadline = Date.now() + timeoutMs;
+  try {
+    while (cls === null) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        cls = "healthy";
+        break;
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<"timeout">((resolve) => {
+        timer = setTimeout(() => resolve("timeout"), remaining);
+      });
+      let res: { done?: boolean; value?: any } | "timeout";
+      try {
+        res = await Promise.race([reader.read(), timeout]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+      if (res === "timeout") {
+        cls = "healthy";
+        break;
+      }
+      if (res.done) {
+        // Stream ended within the window — classify whatever we saw.
+        cls = classifyPartial(sniff)?.cls ?? "healthy";
+        detail = classifyPartial(sniff)?.detail;
+        break;
+      }
+      if (res.value) {
+        sniff += decoder.decode(res.value, { stream: true });
+      }
+      const partial = classifyPartial(sniff);
+      if (partial) {
+        cls = partial.cls;
+        detail = partial.detail;
+        break;
+      }
+      if (sniff.length > maxSniffBytes) {
+        cls = "healthy";
+        break;
+      }
+    }
+  } catch {
+    cls = "healthy"; // read error — fail open
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+
+  if (cls === "rate-limit") {
+    // Caller will retry / fall back — discard the unused full-stream branch.
+    branchB.cancel().catch(() => {});
+    return { cls, response, detail };
+  }
+
+  // healthy OR other-error: hand the FULL stream (branch B) downstream. An
+  // other-error still flows to the parser, whose graceful finalizer surfaces it
+  // as a clean terminal message rather than a crash.
+  const downstream = new Response(branchB, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+  return { cls, response: downstream, detail };
+}

--- a/packages/cli/src/handlers/shared/web-search-executor.ts
+++ b/packages/cli/src/handlers/shared/web-search-executor.ts
@@ -1,0 +1,114 @@
+/**
+ * Web search executor — intercepts web_search tool calls from providers
+ * (z.ai, GLM) and executes them via SearXNG.
+ *
+ * When a provider model requests web_search, claudish:
+ * 1. Extracts the search query from tool arguments
+ * 2. Calls the local SearXNG instance
+ * 3. Returns formatted results as a text block in the stream
+ *
+ * IMPORTANT: executeWebSearchSync must not block the SSE stream.
+ * It races SearXNG against a 3-second deadline and returns a
+ * fallback message immediately if SearXNG is unreachable.
+ */
+
+import { log } from "../../logger.js";
+
+const SEARXNG_URL = process.env.SEARXNG_URL || "http://search.myia.io";
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/**
+ * Execute a web search via SearXNG. Non-throwing.
+ */
+async function fetchFromSearXNG(query: string, maxResults = 5): Promise<SearchResult[]> {
+  const url = `${SEARXNG_URL}/search?q=${encodeURIComponent(query)}&format=json&categories=general`;
+  log(`[WebSearch] Executing: "${query}" via ${SEARXNG_URL}`);
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(5000),
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    log(`[WebSearch] SearXNG returned HTTP ${response.status}`);
+    return [];
+  }
+
+  const data = (await response.json()) as any;
+  const results: SearchResult[] = (data.results || [])
+    .slice(0, maxResults)
+    .map((r: any) => ({
+      title: r.title || "",
+      url: r.url || "",
+      snippet: r.content || r.description || "",
+    }));
+
+  log(`[WebSearch] Got ${results.length} results for "${query}"`);
+  return results;
+}
+
+/**
+ * Stream-safe web search: races SearXNG against a short deadline.
+ * Returns formatted results text, never throws, never blocks > deadline.
+ */
+export async function executeWebSearch(query: string, deadlineMs = 3000): Promise<string> {
+  try {
+    const results = await Promise.race([
+      fetchFromSearXNG(query),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), deadlineMs)),
+    ]);
+
+    if (results === null) {
+      log(`[WebSearch] Timed out after ${deadlineMs}ms for "${query}"`);
+      return `[Web search for "${query}" timed out. SearXNG did not respond within ${deadlineMs / 1000}s.]`;
+    }
+
+    return formatSearchResults(query, results);
+  } catch (err: any) {
+    log(`[WebSearch] Error: ${err.message}`);
+    return `[Web search for "${query}" failed: ${err.message}]`;
+  }
+}
+
+/**
+ * Format search results as a text block for injection into the stream.
+ */
+export function formatSearchResults(query: string, results: SearchResult[]): string {
+  if (results.length === 0) {
+    return `[Web search for "${query}" returned no results. The search service may be unavailable.]`;
+  }
+
+  const lines = [`[Web search results for "${query}"]\n`];
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    lines.push(`${i + 1}. **${r.title}**`);
+    lines.push(`   ${r.url}`);
+    if (r.snippet) {
+      lines.push(`   ${r.snippet}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Extract the search query from a web_search tool call's arguments JSON.
+ */
+export function extractSearchQuery(argsJson: string): string {
+  try {
+    const args = JSON.parse(argsJson);
+    return args.query || args.q || args.search_query || args.keyword || "";
+  } catch {
+    // If args aren't valid JSON, try to extract from raw string
+    const match = argsJson.match(/"query"\s*:\s*"([^"]+)"/);
+    if (match) return match[1];
+    const match2 = argsJson.match(/"q"\s*:\s*"([^"]+)"/);
+    if (match2) return match2[1];
+    return "";
+  }
+}

--- a/packages/cli/src/profile-config.ts
+++ b/packages/cli/src/profile-config.ts
@@ -142,6 +142,8 @@ export interface ClaudishProfileConfig {
    * Validation of entries happens at the consumption site (Phase 3) via Zod, not here.
    */
   customEndpoints?: Record<string, unknown>;
+  /** Proxy authentication key — clients must send x-proxy-key matching this value */
+  proxyKey?: string;
 }
 
 /**
@@ -219,6 +221,9 @@ export function loadConfig(): ClaudishProfileConfig {
     }
     if (config.customEndpoints !== undefined) {
       merged.customEndpoints = config.customEndpoints;
+    }
+    if (config.proxyKey !== undefined) {
+      merged.proxyKey = config.proxyKey;
     }
     return merged;
   } catch (error) {

--- a/packages/cli/src/providers/routing-rules.ts
+++ b/packages/cli/src/providers/routing-rules.ts
@@ -12,6 +12,7 @@ import {
   isProviderAvailable,
 } from "./provider-definitions.js";
 import { buildCredentialHint } from "./routing-hints.js";
+import { getRuntimeProviders } from "./runtime-providers.js";
 
 /**
  * Pure merge — defaults < global < local. Exposed for testability so callers
@@ -185,6 +186,10 @@ export type RoutePlan =
  */
 function hasCredentialsForProvider(provider: string): boolean {
   if (isLocalTransport(provider)) return true;
+
+  // Custom endpoints registered at runtime always have credentials —
+  // the loader validates apiKey presence before registration.
+  if (getRuntimeProviders().has(provider)) return true;
 
   if (provider === "native-anthropic") {
     return !!process.env.ANTHROPIC_API_KEY || !!process.env.ANTHROPIC_AUTH_TOKEN;

--- a/packages/cli/src/providers/transport/anthropic-compat.test.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.test.ts
@@ -11,10 +11,10 @@
 // and is not part of the Anthropic public API spec — Kimi rejects it with HTTP 400.
 // Fix: stripUnsupportedContentTypes() filters tool_reference from tool_result content arrays.
 
-import { describe, it, expect } from "bun:test";
-import { AnthropicCompatProvider } from "./anthropic-compat.js";
+import { describe, it, test, expect } from "bun:test";
+import { AnthropicCompatProvider, AnthropicProviderTransport } from "./anthropic-compat.js";
 import { AnthropicAPIFormat } from "../../adapters/anthropic-api-format.js";
-import type { RemoteProvider } from "../../../handlers/shared/remote-provider-types.js";
+import type { RemoteProvider } from "../../handlers/shared/remote-provider-types.js";
 
 const TEST_API_KEY = "test-key-abc123";
 
@@ -71,6 +71,45 @@ describe("AnthropicCompatProvider.getHeaders()", () => {
     expect(headers["x-api-key"]).toBe(TEST_API_KEY);
     expect(headers["Authorization"]).toBeUndefined();
     expect(headers["anthropic-version"]).toBe("2023-06-01");
+  });
+});
+
+describe("AnthropicProviderTransport.enqueueRequest 429 retry (+ jitter)", () => {
+  const provider: RemoteProvider = {
+    name: "zai",
+    baseUrl: "https://api.z.ai",
+    apiPath: "/anthropic/v1/messages",
+    apiKeyEnvVar: "ZAI_API_KEY",
+    prefixes: ["zai@"],
+  };
+
+  test("retries on HTTP 429 then returns the eventual success", async () => {
+    const transport = new AnthropicProviderTransport(provider, "test-key");
+    let callCount = 0;
+
+    const response = await transport.enqueueRequest(() => {
+      callCount++;
+      if (callCount <= 2) {
+        return Promise.resolve(new Response('{"error":"rate limited"}', { status: 429 }));
+      }
+      return Promise.resolve(new Response('{"ok":true}', { status: 200 }));
+    });
+
+    expect(response.status).toBe(200);
+    expect(callCount).toBe(3); // 2 retries + 1 success
+  }, 15000); // 2s + 4s backoff (+ up to 2s jitter)
+
+  test("does not retry non-429 responses", async () => {
+    const transport = new AnthropicProviderTransport(provider, "test-key");
+    let callCount = 0;
+
+    const response = await transport.enqueueRequest(() => {
+      callCount++;
+      return Promise.resolve(new Response('{"error":"bad request"}', { status: 400 }));
+    });
+
+    expect(response.status).toBe(400);
+    expect(callCount).toBe(1); // No retry
   });
 });
 

--- a/packages/cli/src/providers/transport/anthropic-compat.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.ts
@@ -76,6 +76,56 @@ export class AnthropicProviderTransport implements ProviderTransport {
     return headers;
   }
 
+  /**
+   * Retry HTTP 429 responses with jittered exponential backoff.
+   *
+   * The anthropic-compat providers (Z.AI, MiniMax, Kimi) previously had NO
+   * transport-level retry at all — a bare 429 propagated straight up. This
+   * mirrors OpenAIProviderTransport's retry but ADDS jitter: the whole cluster
+   * shares a single key per provider, so without jitter every machine retries
+   * on the same 2s/4s/8s boundary and re-collides on the burst limit. The
+   * jitter spreads those retries out.
+   *
+   * Note: this only covers errors the provider returns as an HTTP 429. Z.AI's
+   * burst limit is frequently delivered as HTTP 200 + an in-stream SSE error
+   * ([1302]); that variant is handled one layer up in ComposedHandler (peek +
+   * backoff-retry + cross-provider fallback), since it isn't visible from the
+   * Response status alone.
+   */
+  async enqueueRequest(fetchFn: () => Promise<Response>): Promise<Response> {
+    const maxRetries = 5;
+    let lastResponse: Response | null = null;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const response = await fetchFn();
+
+      if (response.status === 429 && attempt < maxRetries) {
+        lastResponse = response;
+        const retryAfter = response.headers.get("Retry-After");
+        let delayMs: number;
+        if (retryAfter && !Number.isNaN(Number(retryAfter))) {
+          delayMs = Math.min(Number(retryAfter) * 1000, 30000);
+        } else {
+          // Exponential backoff: 2s, 4s, 8s, 16s, 30s (capped)
+          delayMs = Math.min(2000 * Math.pow(2, attempt), 30000);
+        }
+        // Jitter: spread cluster-wide synchronized retries off the same boundary.
+        const jitterMs = Math.floor(Math.random() * 1000);
+        const totalMs = delayMs + jitterMs;
+        log(
+          `[${this.displayName}] 429 rate limited, retry ${attempt + 1}/${maxRetries} in ${(totalMs / 1000).toFixed(1)}s`
+        );
+        await new Promise((resolve) => setTimeout(resolve, totalMs));
+        continue;
+      }
+
+      return response;
+    }
+
+    // All retries exhausted — return the last 429 response
+    return lastResponse!;
+  }
+
   private static formatDisplayName(name: string): string {
     const map: Record<string, string> = {
       minimax: "MiniMax",

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -499,6 +499,53 @@ export async function createProxyServer(
   );
   app.get("/health", (c) => c.json({ status: "ok" }));
 
+  // Model discovery endpoint — Claude Code queries /v1/models when
+  // CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 is set. Returns all
+  // routable models from config.json routing rules + custom endpoints.
+  app.get("/v1/models", (c) => {
+    const cfg = loadConfig();
+    const seen = new Set<string>();
+    const models: { id: string; display_name: string; created_at: string }[] = [];
+
+    // From routing rules — each key is a model name
+    if (cfg.routing) {
+      for (const modelName of Object.keys(cfg.routing)) {
+        if (!seen.has(modelName)) {
+          seen.add(modelName);
+          models.push({
+            id: modelName,
+            display_name: modelName,
+            created_at: "2026-01-01T00:00:00Z",
+          });
+        }
+      }
+    }
+
+    // From custom endpoints — each declared model
+    if (cfg.customEndpoints) {
+      for (const [, ep] of Object.entries(cfg.customEndpoints)) {
+        const endpoint = ep as { models?: string[] };
+        if (endpoint.models) {
+          for (const m of endpoint.models) {
+            if (!seen.has(m)) {
+              seen.add(m);
+              models.push({
+                id: m,
+                display_name: m,
+                created_at: "2026-01-01T00:00:00Z",
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return c.json({
+      object: "list",
+      data: models,
+    });
+  });
+
   // Token counting
   app.post("/v1/messages/count_tokens", async (c) => {
     try {

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -33,6 +33,7 @@ import { wrapAnthropicError } from "./handlers/shared/anthropic-error.js";
 import { route, loadRoutingRules } from "./providers/routing-rules.js";
 import { createHandlerForProvider } from "./providers/provider-profiles.js";
 import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
+import { getRuntimeProviders } from "./providers/runtime-providers.js";
 import { loadConfig } from "./profile-config.js";
 
 export interface ProxyServerOptions {
@@ -41,6 +42,7 @@ export interface ProxyServerOptions {
   isInteractive?: boolean; // Whether the current session is interactive (gates consent prompt)
   advisorModels?: string[]; // Advisor models from --advisor flag
   advisorCollector?: string | null; // Collector model (null = no synthesis)
+  hostname?: string; // Bind address (default: "127.0.0.1", use "0.0.0.0" for Docker)
 }
 
 export async function createProxyServer(
@@ -233,7 +235,9 @@ export async function createProxyServer(
       resolution.wasAutoRouted && resolution.fullModelId ? resolution.fullModelId : targetModel;
 
     // If resolver says use direct-api and key is available, create handler
-    if (resolution.category === "direct-api" && resolution.apiKeyAvailable) {
+    // Custom endpoints registered at runtime always have credentials (resolved from config)
+    const isRuntimeProvider = getRuntimeProviders().has(resolution.parsed?.provider ?? "");
+    if (resolution.category === "direct-api" && (resolution.apiKeyAvailable || isRuntimeProvider)) {
       const resolved = resolveRemoteProvider(resolveTarget);
       if (!resolved) return null;
 
@@ -459,6 +463,31 @@ export async function createProxyServer(
   const app = new Hono();
   app.use("*", cors());
 
+  // Proxy auth: validate standard Anthropic auth headers against the proxy key.
+  // Claude Code sends ANTHROPIC_AUTH_TOKEN as "authorization: Bearer <token>" or
+  // "x-api-key: <token>". We check all three headers so the proxy key doubles as
+  // the auth token — no custom headers needed.
+  // Health/status endpoints are exempt for Docker healthcheck compatibility.
+  const proxyKey = process.env.CLAUDISH_PROXY_KEY || loadConfig().proxyKey;
+  if (proxyKey) {
+    app.use("/v1/*", async (c, next) => {
+      const authHeader = c.req.header("authorization");
+      const apiKeyHeader = c.req.header("x-api-key");
+      const proxyKeyHeader = c.req.header("x-proxy-key");
+
+      const bearerToken = authHeader?.startsWith("Bearer ")
+        ? authHeader.slice(7)
+        : authHeader;
+
+      const provided = proxyKeyHeader || apiKeyHeader || bearerToken;
+      if (!provided || provided !== proxyKey) {
+        return c.json(wrapAnthropicError(401, "invalid proxy authentication"), 401);
+      }
+      await next();
+    });
+    log("[Proxy] Authentication enabled (proxy key required via authorization/x-api-key/x-proxy-key)");
+  }
+
   app.get("/", (c) =>
     c.json({
       status: "ok",
@@ -514,7 +543,8 @@ export async function createProxyServer(
     }
   });
 
-  const server = serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });
+  const bindHost = options.hostname ?? "127.0.0.1";
+  const server = serve({ fetch: app.fetch, port, hostname: bindHost });
 
   // Port resolution
   const addr = server.address();
@@ -538,7 +568,7 @@ export async function createProxyServer(
 
   return {
     port,
-    url: `http://127.0.0.1:${port}`,
+    url: `http://${bindHost}:${port}`,
     shutdown: async () => {
       return new Promise<void>((resolve) => server.close(() => resolve()));
     },

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -608,6 +608,26 @@ export async function createProxyServer(
       const body = await c.req.json();
       const handler = await getHandlerForRequest(body.model);
 
+      // Strip Claude Code billing header from system prompt for non-Anthropic
+      // providers. Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
+      // into the prompt body — the `cch=` token changes every request, which breaks
+      // vLLM prefix caching (strict hash). Only Anthropic needs this; strip for others.
+      if (!(handler instanceof NativeHandler) && typeof body.system === "string") {
+        body.system = body.system.replace(
+          /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+          ""
+        );
+      } else if (!(handler instanceof NativeHandler) && Array.isArray(body.system)) {
+        for (const block of body.system) {
+          if (block.type === "text" && typeof block.text === "string") {
+            block.text = block.text.replace(
+              /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+              ""
+            );
+          }
+        }
+      }
+
       // Route
       return handler.handle(c, body);
     } catch (e) {

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -36,6 +36,152 @@ import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
 import { getRuntimeProviders } from "./providers/runtime-providers.js";
 import { loadConfig } from "./profile-config.js";
 import { registerForkExtensions, stripBillingHeaderFromBody, logRequest, createHostnameConfig } from "./fork/index.js";
+import { executeWebSearch } from "./handlers/shared/web-search-executor.js";
+
+/**
+ * Intercept WebSearch/WebFetch tool calls and execute them via SearXNG instead
+ * of forwarding to the provider. Returns a streaming response with SearXNG results.
+ *
+ * Claude Code's WebSearch tool sends a sub-agent request with a single user message:
+ *   "Perform a web search for the query: <query>"
+ * We intercept this, execute SearXNG, and return the results as text.
+ */
+async function interceptWebTools(c: any, body: any): Promise<Response | null> {
+  const messages = body.messages || [];
+  const isStreaming = body.stream === true;
+
+  // Case 1: Sub-agent web search request (1 message, user role, starts with "Perform a web search")
+  if (messages.length === 1 && messages[0].role === "user") {
+    const text = typeof messages[0].content === "string"
+      ? messages[0].content
+      : Array.isArray(messages[0].content)
+        ? messages[0].content.map((b: any) => b.text || "").join("")
+        : "";
+
+    const searchMatch = text.match(/^Perform a web search for the query:\s*(.+)$/s);
+    if (searchMatch) {
+      const query = searchMatch[1].trim();
+      log(`[WebTools] Intercepted sub-agent web search: "${query}"`);
+      const results = await executeWebSearch(query, 5000);
+      log(`[WebTools] SearXNG results: ${results.slice(0, 100)}...`);
+      return buildTextResponse(body.model || "unknown", results, isStreaming);
+    }
+
+    const fetchMatch = text.match(/^Perform a web fetch for the URL:\s*(.+)$/s);
+    if (fetchMatch) {
+      const url = fetchMatch[1].trim();
+      log(`[WebTools] Intercepted sub-agent web fetch: "${url}"`);
+      let resultText: string;
+      try {
+        const fetchUrl = `${process.env.SEARXNG_URL || "http://search.myia.io"}/search?q=${encodeURIComponent(url)}&format=json&categories=general`;
+        const resp = await fetch(fetchUrl, { signal: AbortSignal.timeout(5000) });
+        const data = await resp.json() as any;
+        const results = (data.results || []).slice(0, 3);
+        resultText = results.length > 0
+          ? results.map((r: any) => `**${r.title}**\n${r.url}\n${r.content || ""}`).join("\n\n")
+          : `[No results found for URL: ${url}]`;
+      } catch (err: any) {
+        resultText = `[Web fetch for "${url}" failed: ${err.message}]`;
+      }
+      return buildTextResponse(body.model || "unknown", resultText, isStreaming);
+    }
+  }
+
+  // Case 2: tool_use in last assistant message for WebSearch/WebFetch
+  const lastAssistant = [...messages].reverse().find((m: any) => m.role === "assistant");
+  if (lastAssistant?.content) {
+    const content = Array.isArray(lastAssistant.content) ? lastAssistant.content : [];
+    const webToolCalls = content.filter(
+      (b: any) => b.type === "tool_use" && (b.name === "WebSearch" || b.name === "WebFetch")
+    );
+    if (webToolCalls.length > 0) {
+      log(`[WebTools] Intercepting ${webToolCalls.length} tool_use WebSearch/WebFetch`);
+      // For now, let these fall through to the normal handler
+      // (they'll be handled by the stream parser's searchWeb detection)
+    }
+  }
+
+  return null;
+}
+
+function buildTextResponse(model: string, text: string, streaming: boolean): Response {
+  const encoder = new TextEncoder();
+  const send = (event: string, data: any) =>
+    encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+
+  if (!streaming) {
+    // Non-streaming JSON response
+    return new Response(JSON.stringify({
+      id: `msg_webtools_${Date.now()}`,
+      type: "message",
+      role: "assistant",
+      model,
+      content: [{ type: "text", text }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }), {
+      headers: {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+      },
+    });
+  }
+
+  // Streaming SSE response
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(send("message_start", {
+        type: "message_start",
+        message: {
+          id: `msg_webtools_${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      }));
+
+      controller.enqueue(send("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }));
+
+      controller.enqueue(send("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text },
+      }));
+
+      controller.enqueue(send("content_block_stop", {
+        type: "content_block_stop",
+        index: 0,
+      }));
+
+      controller.enqueue(send("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { input_tokens: 0, output_tokens: 0 },
+      }));
+
+      controller.enqueue(send("message_stop", { type: "message_stop" }));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "anthropic-version": "2023-06-01",
+    },
+  });
+}
 
 export interface ProxyServerOptions {
   summarizeTools?: boolean; // Summarize tool descriptions for local models
@@ -542,6 +688,26 @@ export async function createProxyServer(
   app.post("/v1/messages", async (c) => {
     try {
       const body = await c.req.json();
+
+      // Log tool names in request for debugging WebSearch/WebFetch
+      const toolNames = (body.tools || []).map((t: any) => t.name);
+      if (toolNames.length > 0) log(`[Proxy] Tools in request: ${toolNames.join(", ")}`);
+      // Also check messages for tool_use blocks
+      const lastMsg = body.messages?.[body.messages.length - 1];
+      if (lastMsg?.content) {
+        const blocks = Array.isArray(lastMsg.content) ? lastMsg.content : [];
+        const toolUses = blocks.filter((b: any) => b.type === "tool_use");
+        if (toolUses.length > 0) log(`[Proxy] Last msg tool_use: ${toolUses.map((t: any) => t.name).join(", ")}`);
+      }
+
+      // Intercept WebSearch/WebFetch tool calls and execute via SearXNG
+      try {
+        const webToolResponse = await interceptWebTools(c, body);
+        if (webToolResponse) return webToolResponse;
+      } catch (e: any) {
+        log(`[WebTools] Intercept error (falling through to normal handler): ${e.message}`);
+      }
+
       const handler = await getHandlerForRequest(body.model);
       logRequest(body, handler.constructor.name, c.req.raw, hostnameConfig.remoteAddrMap);
       stripBillingHeaderFromBody(body, handler instanceof NativeHandler);

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -466,13 +466,37 @@ export async function createProxyServer(
   const app = new Hono();
   app.use("*", cors());
 
-  // Proxy auth: validate standard Anthropic auth headers against the proxy key.
-  // Claude Code sends ANTHROPIC_AUTH_TOKEN as "authorization: Bearer <token>" or
-  // "x-api-key: <token>". We check all three headers so the proxy key doubles as
-  // the auth token — no custom headers needed.
-  // Health/status endpoints are exempt for Docker healthcheck compatibility.
+  // Model-aware proxy auth: Anthropic pass-through is exempt (OAuth or proxy-key
+  // swap handled by NativeHandler). Non-Anthropic providers require the proxy key
+  // in x-api-key / authorization / x-proxy-key. GET requests and health endpoints
+  // are exempt for Docker healthcheck and model discovery compatibility.
   if (proxyKey) {
     app.use("/v1/*", async (c, next) => {
+      if (c.req.method === "GET") {
+        return await next();
+      }
+
+      // Peek at body.model to determine target provider.
+      // Hono caches parsed JSON — safe to call again from the route handler.
+      let model: string | undefined;
+      try {
+        const body = await c.req.json();
+        model = body?.model;
+      } catch {
+        return await next(); // Malformed body — let handler return 400
+      }
+
+      // Anthropic pass-through: skip proxy key validation entirely.
+      // NativeHandler will either swap proxyKey → stored Anthropic key,
+      // or pass the client's OAuth token through unchanged.
+      if (model) {
+        const spec = parseModelSpec(model);
+        if (spec.provider === "native-anthropic") {
+          return await next();
+        }
+      }
+
+      // Non-Anthropic: enforce proxy key
       const authHeader = c.req.header("authorization");
       const apiKeyHeader = c.req.header("x-api-key");
       const proxyKeyHeader = c.req.header("x-proxy-key");
@@ -487,7 +511,7 @@ export async function createProxyServer(
       }
       await next();
     });
-    log("[Proxy] Authentication enabled (proxy key required via authorization/x-api-key/x-proxy-key)");
+    log("[Proxy] Authentication enabled (Anthropic pass-through; proxy key required for other providers)");
   }
 
   app.get("/", (c) =>
@@ -607,6 +631,12 @@ export async function createProxyServer(
     try {
       const body = await c.req.json();
       const handler = await getHandlerForRequest(body.model);
+      const xff = c.req.header("x-forwarded-for") || "";
+      const xrip = c.req.header("x-real-ip") || "";
+      const ua = c.req.header("user-agent") || "";
+      const directIp = remoteAddrMap.get(c.req.raw) || "";
+      const src = xff || xrip || directIp || "direct";
+      console.log(`[claudish] [Request] model=${body.model ?? "(none)"} handler=${handler.constructor.name} src=${src} ua=${ua.slice(0, 60)}`);
 
       // Strip Claude Code billing header from system prompt for non-Anthropic
       // providers. Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
@@ -637,7 +667,22 @@ export async function createProxyServer(
   });
 
   const bindHost = options.hostname ?? "127.0.0.1";
-  const server = serve({ fetch: app.fetch, port, hostname: bindHost });
+  // Store remote addresses for direct connections (no IIS/proxy).
+  // Hono middleware can't access the socket, so we intercept at the
+  // serve() level and pass the IP through the Request headers.
+  const remoteAddrMap = new WeakMap<Request, string>();
+  const server = serve({
+    fetch(req, env, ctx) {
+      if (!req.headers.get("x-forwarded-for") && !req.headers.get("x-real-ip")) {
+        // @ts-expect-error — Bun injects remoteAddress on the server info object
+        const addr = ctx?.remoteAddress?.address as string | undefined;
+        if (addr) remoteAddrMap.set(req, addr);
+      }
+      return app.fetch(req, env, ctx);
+    },
+    port,
+    hostname: bindHost,
+  });
 
   // Port resolution
   const addr = server.address();

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -511,20 +511,38 @@ export async function createProxyServer(
       }
       const handler = await getHandlerForRequest(body.model);
 
-      // If native, we just forward. OpenRouter needs estimation.
+      // If native, forward transparently (all client headers passthrough).
       if (handler instanceof NativeHandler) {
-        const headers: any = { "Content-Type": "application/json" };
-        if (anthropicApiKey) {
-          if (anthropicApiKey.startsWith("sk-ant-oat")) {
-            headers["authorization"] = `Bearer ${anthropicApiKey}`;
-          } else {
-            headers["x-api-key"] = anthropicApiKey;
+        const HOP_BY_HOP = new Set([
+          "host", "connection", "keep-alive", "transfer-encoding", "te",
+          "trailer", "upgrade", "content-length",
+        ]);
+        const reqHeaders: Record<string, string> = { "Content-Type": "application/json" };
+        for (const [key, value] of Object.entries(c.req.header())) {
+          if (HOP_BY_HOP.has(key.toLowerCase()) || typeof value !== "string") continue;
+          reqHeaders[key] = value;
+        }
+        // Proxy key override (same logic as NativeHandler)
+        if (proxyKey) {
+          const authHeader = c.req.header("authorization");
+          const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : authHeader;
+          const clientAuthToken = c.req.header("x-api-key") || bearerToken;
+          if (clientAuthToken === proxyKey) {
+            delete reqHeaders["x-api-key"];
+            delete reqHeaders["authorization"];
+            if (anthropicApiKey) {
+              if (anthropicApiKey.startsWith("sk-ant-oat")) {
+                reqHeaders["authorization"] = `Bearer ${anthropicApiKey}`;
+              } else {
+                reqHeaders["x-api-key"] = anthropicApiKey;
+              }
+            }
           }
         }
 
         const res = await fetch("https://api.anthropic.com/v1/messages/count_tokens", {
           method: "POST",
-          headers,
+          headers: reqHeaders,
           body: JSON.stringify(body),
         });
         return c.json(await res.json());

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -54,6 +54,9 @@ export async function createProxyServer(
   modelMap?: { opus?: string; sonnet?: string; haiku?: string; subagent?: string },
   options: ProxyServerOptions = {}
 ): Promise<ProxyServer> {
+  // Resolve proxy key early — needed for both auth middleware and NativeHandler
+  const proxyKey = process.env.CLAUDISH_PROXY_KEY || loadConfig().proxyKey;
+
   // Load user-declared custom endpoints from ~/.claudish/config.json and
   // register them in the runtime provider registry so they appear in lookups
   // and handler creation. Runs once per proxy lifetime; idempotent.
@@ -76,7 +79,7 @@ export async function createProxyServer(
   }
 
   // Define handlers for different roles
-  const nativeHandler = new NativeHandler(anthropicApiKey, options.advisorModels, options.advisorCollector);
+  const nativeHandler = new NativeHandler(anthropicApiKey, options.advisorModels, options.advisorCollector, proxyKey);
   const openRouterHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> OpenRouter Handler
   const localProviderHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> Local Provider Handler
   const remoteProviderHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> Gemini/OpenAI Handler
@@ -468,7 +471,6 @@ export async function createProxyServer(
   // "x-api-key: <token>". We check all three headers so the proxy key doubles as
   // the auth token — no custom headers needed.
   // Health/status endpoints are exempt for Docker healthcheck compatibility.
-  const proxyKey = process.env.CLAUDISH_PROXY_KEY || loadConfig().proxyKey;
   if (proxyKey) {
     app.use("/v1/*", async (c, next) => {
       const authHeader = c.req.header("authorization");
@@ -512,7 +514,13 @@ export async function createProxyServer(
       // If native, we just forward. OpenRouter needs estimation.
       if (handler instanceof NativeHandler) {
         const headers: any = { "Content-Type": "application/json" };
-        if (anthropicApiKey) headers["x-api-key"] = anthropicApiKey;
+        if (anthropicApiKey) {
+          if (anthropicApiKey.startsWith("sk-ant-oat")) {
+            headers["authorization"] = `Bearer ${anthropicApiKey}`;
+          } else {
+            headers["x-api-key"] = anthropicApiKey;
+          }
+        }
 
         const res = await fetch("https://api.anthropic.com/v1/messages/count_tokens", {
           method: "POST",

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -35,6 +35,7 @@ import { createHandlerForProvider } from "./providers/provider-profiles.js";
 import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
 import { getRuntimeProviders } from "./providers/runtime-providers.js";
 import { loadConfig } from "./profile-config.js";
+import { registerForkExtensions, stripBillingHeaderFromBody, logRequest, createHostnameConfig } from "./fork/index.js";
 
 export interface ProxyServerOptions {
   summarizeTools?: boolean; // Summarize tool descriptions for local models
@@ -42,7 +43,7 @@ export interface ProxyServerOptions {
   isInteractive?: boolean; // Whether the current session is interactive (gates consent prompt)
   advisorModels?: string[]; // Advisor models from --advisor flag
   advisorCollector?: string | null; // Collector model (null = no synthesis)
-  hostname?: string; // Bind address (default: "127.0.0.1", use "0.0.0.0" for Docker)
+  hostname?: string; // Bind address (default: "127.0.0.1", use "0.0.0.0" for Docker) — fork extension
 }
 
 export async function createProxyServer(
@@ -463,56 +464,14 @@ export async function createProxyServer(
     return getOpenRouterHandler(target, invocationMode);
   };
 
+  // Fork extension: hostname binding + remote address tracking
+  const hostnameConfig = createHostnameConfig(options.hostname);
+
   const app = new Hono();
   app.use("*", cors());
 
-  // Model-aware proxy auth: Anthropic pass-through is exempt (OAuth or proxy-key
-  // swap handled by NativeHandler). Non-Anthropic providers require the proxy key
-  // in x-api-key / authorization / x-proxy-key. GET requests and health endpoints
-  // are exempt for Docker healthcheck and model discovery compatibility.
-  if (proxyKey) {
-    app.use("/v1/*", async (c, next) => {
-      if (c.req.method === "GET") {
-        return await next();
-      }
-
-      // Peek at body.model to determine target provider.
-      // Hono caches parsed JSON — safe to call again from the route handler.
-      let model: string | undefined;
-      try {
-        const body = await c.req.json();
-        model = body?.model;
-      } catch {
-        return await next(); // Malformed body — let handler return 400
-      }
-
-      // Anthropic pass-through: skip proxy key validation entirely.
-      // NativeHandler will either swap proxyKey → stored Anthropic key,
-      // or pass the client's OAuth token through unchanged.
-      if (model) {
-        const spec = parseModelSpec(model);
-        if (spec.provider === "native-anthropic") {
-          return await next();
-        }
-      }
-
-      // Non-Anthropic: enforce proxy key
-      const authHeader = c.req.header("authorization");
-      const apiKeyHeader = c.req.header("x-api-key");
-      const proxyKeyHeader = c.req.header("x-proxy-key");
-
-      const bearerToken = authHeader?.startsWith("Bearer ")
-        ? authHeader.slice(7)
-        : authHeader;
-
-      const provided = proxyKeyHeader || apiKeyHeader || bearerToken;
-      if (!provided || provided !== proxyKey) {
-        return c.json(wrapAnthropicError(401, "invalid proxy authentication"), 401);
-      }
-      await next();
-    });
-    log("[Proxy] Authentication enabled (Anthropic pass-through; proxy key required for other providers)");
-  }
+  // Fork extensions: proxy auth + model discovery
+  registerForkExtensions(app, { proxyKey });
 
   app.get("/", (c) =>
     c.json({
@@ -522,53 +481,6 @@ export async function createProxyServer(
     })
   );
   app.get("/health", (c) => c.json({ status: "ok" }));
-
-  // Model discovery endpoint — Claude Code queries /v1/models when
-  // CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 is set. Returns all
-  // routable models from config.json routing rules + custom endpoints.
-  app.get("/v1/models", (c) => {
-    const cfg = loadConfig();
-    const seen = new Set<string>();
-    const models: { id: string; display_name: string; created_at: string }[] = [];
-
-    // From routing rules — each key is a model name
-    if (cfg.routing) {
-      for (const modelName of Object.keys(cfg.routing)) {
-        if (!seen.has(modelName)) {
-          seen.add(modelName);
-          models.push({
-            id: modelName,
-            display_name: modelName,
-            created_at: "2026-01-01T00:00:00Z",
-          });
-        }
-      }
-    }
-
-    // From custom endpoints — each declared model
-    if (cfg.customEndpoints) {
-      for (const [, ep] of Object.entries(cfg.customEndpoints)) {
-        const endpoint = ep as { models?: string[] };
-        if (endpoint.models) {
-          for (const m of endpoint.models) {
-            if (!seen.has(m)) {
-              seen.add(m);
-              models.push({
-                id: m,
-                display_name: m,
-                created_at: "2026-01-01T00:00:00Z",
-              });
-            }
-          }
-        }
-      }
-    }
-
-    return c.json({
-      object: "list",
-      data: models,
-    });
-  });
 
   // Token counting
   app.post("/v1/messages/count_tokens", async (c) => {
@@ -631,32 +543,8 @@ export async function createProxyServer(
     try {
       const body = await c.req.json();
       const handler = await getHandlerForRequest(body.model);
-      const xff = c.req.header("x-forwarded-for") || "";
-      const xrip = c.req.header("x-real-ip") || "";
-      const ua = c.req.header("user-agent") || "";
-      const directIp = remoteAddrMap.get(c.req.raw) || "";
-      const src = xff || xrip || directIp || "direct";
-      console.log(`[claudish] [Request] model=${body.model ?? "(none)"} handler=${handler.constructor.name} src=${src} ua=${ua.slice(0, 60)}`);
-
-      // Strip Claude Code billing header from system prompt for non-Anthropic
-      // providers. Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
-      // into the prompt body — the `cch=` token changes every request, which breaks
-      // vLLM prefix caching (strict hash). Only Anthropic needs this; strip for others.
-      if (!(handler instanceof NativeHandler) && typeof body.system === "string") {
-        body.system = body.system.replace(
-          /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
-          ""
-        );
-      } else if (!(handler instanceof NativeHandler) && Array.isArray(body.system)) {
-        for (const block of body.system) {
-          if (block.type === "text" && typeof block.text === "string") {
-            block.text = block.text.replace(
-              /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
-              ""
-            );
-          }
-        }
-      }
+      logRequest(body, handler.constructor.name, c.req.raw, hostnameConfig.remoteAddrMap);
+      stripBillingHeaderFromBody(body, handler instanceof NativeHandler);
 
       // Route
       return handler.handle(c, body);
@@ -666,22 +554,17 @@ export async function createProxyServer(
     }
   });
 
-  const bindHost = options.hostname ?? "127.0.0.1";
-  // Store remote addresses for direct connections (no IIS/proxy).
-  // Hono middleware can't access the socket, so we intercept at the
-  // serve() level and pass the IP through the Request headers.
-  const remoteAddrMap = new WeakMap<Request, string>();
   const server = serve({
     fetch(req, env, ctx) {
       if (!req.headers.get("x-forwarded-for") && !req.headers.get("x-real-ip")) {
         // @ts-expect-error — Bun injects remoteAddress on the server info object
         const addr = ctx?.remoteAddress?.address as string | undefined;
-        if (addr) remoteAddrMap.set(req, addr);
+        if (addr) hostnameConfig.remoteAddrMap.set(req, addr);
       }
       return app.fetch(req, env, ctx);
     },
     port,
-    hostname: bindHost,
+    hostname: hostnameConfig.hostname,
   });
 
   // Port resolution
@@ -706,7 +589,7 @@ export async function createProxyServer(
 
   return {
     port,
-    url: `http://${bindHost}:${port}`,
+    url: `http://${hostnameConfig.hostname}:${port}`,
     shutdown: async () => {
       return new Promise<void>((resolve) => server.close(() => resolve()));
     },

--- a/packages/cli/src/standalone-proxy.ts
+++ b/packages/cli/src/standalone-proxy.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env bun
+/**
+ * Claudish Standalone Proxy Server
+ *
+ * Starts the proxy server without wrapping Claude Code.
+ * Used for cluster deployments where other machines route LLM requests
+ * through this proxy.
+ *
+ * Usage: bun packages/cli/src/standalone-proxy.ts [--port 3000]
+ */
+
+import { config } from "dotenv";
+config({ quiet: true });
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Load stored API keys from ~/.claudish/config.json
+function loadStoredApiKeys(): void {
+  try {
+    const configPath = join(homedir(), ".claudish", "config.json");
+    if (!existsSync(configPath)) return;
+    const raw = readFileSync(configPath, "utf-8");
+    const cfg = JSON.parse(raw) as {
+      apiKeys?: Record<string, string>;
+      endpoints?: Record<string, string>;
+    };
+    if (cfg.apiKeys) {
+      for (const [envVar, value] of Object.entries(cfg.apiKeys)) {
+        if (!process.env[envVar] && typeof value === "string") {
+          process.env[envVar] = value;
+        }
+      }
+    }
+    if (cfg.endpoints) {
+      for (const [envVar, value] of Object.entries(cfg.endpoints)) {
+        if (!process.env[envVar] && typeof value === "string") {
+          process.env[envVar] = value;
+        }
+      }
+    }
+  } catch {
+    // Silently ignore
+  }
+}
+
+loadStoredApiKeys();
+
+// Parse --port and --host from args
+const args = process.argv.slice(2);
+let port = 3000;
+let hostname = process.env.CLAUDISH_HOST || "127.0.0.1";
+const portIdx = args.indexOf("--port");
+if (portIdx !== -1 && args[portIdx + 1]) {
+  port = Number.parseInt(args[portIdx + 1], 10);
+}
+const hostIdx = args.indexOf("--host");
+if (hostIdx !== -1 && args[hostIdx + 1]) {
+  hostname = args[hostIdx + 1];
+}
+
+import { createProxyServer } from "./proxy-server.js";
+import { loadConfig, getModelMapping } from "./profile-config.js";
+
+// Read active profile's model mapping for role-based routing
+// (opus/sonnet/haiku role remapping from config)
+const cfg = loadConfig();
+const modelMap = getModelMapping(cfg.defaultProfile);
+const activeProfile = cfg.profiles[cfg.defaultProfile];
+
+const server = await createProxyServer(
+  port,
+  process.env.OPENROUTER_API_KEY,
+  undefined,
+  false,
+  process.env.ANTHROPIC_API_KEY,
+  modelMap.opus || modelMap.sonnet || modelMap.haiku ? modelMap : undefined,
+  { quiet: false, hostname }
+);
+
+const mappingInfo = modelMap.opus
+  ? ` (opus→${modelMap.opus}, sonnet→${modelMap.sonnet || "passthrough"}, haiku→${modelMap.haiku || "passthrough"})`
+  : " (passthrough — no profile mapping)";
+console.log(`[claudish-proxy] Standalone proxy running on http://${hostname}:${port}`);
+console.log(`[claudish-proxy] Profile: ${cfg.defaultProfile}${activeProfile ? ` — ${activeProfile.description ?? ""}` : ""}`);
+console.log(`[claudish-proxy] Role mapping: ${modelMap.opus ? `opus=${modelMap.opus}, sonnet=${modelMap.sonnet ?? "passthrough"}, haiku=${modelMap.haiku ?? "passthrough"}` : "none (all models passthrough)"}`);
+console.log(`[claudish-proxy] Config: ~/.claudish/config.json`);
+console.log(`[claudish-proxy] Press Ctrl+C to stop`);
+
+// Keep process alive
+process.on("SIGINT", async () => {
+  console.log("\n[claudish-proxy] Shutting down...");
+  await server.shutdown();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await server.shutdown();
+  process.exit(0);
+});

--- a/packages/cli/src/standalone-proxy.ts
+++ b/packages/cli/src/standalone-proxy.ts
@@ -61,13 +61,12 @@ if (hostIdx !== -1 && args[hostIdx + 1]) {
 }
 
 import { createProxyServer } from "./proxy-server.js";
-import { loadConfig, getModelMapping } from "./profile-config.js";
+import { loadConfig } from "./profile-config.js";
 
-// Read active profile's model mapping for role-based routing
-// (opus/sonnet/haiku role remapping from config)
-const cfg = loadConfig();
-const modelMap = getModelMapping(cfg.defaultProfile);
-const activeProfile = cfg.profiles[cfg.defaultProfile];
+// No modelMap — the proxy is a transparent router. Every model name routes
+// to its provider via config.json routing rules:
+//   claude-opus-4-7 → anthropic, glm-5.1 → z.ai, qwen3.6-35b-a3b → vllm-myia
+// Any model can be used directly; no role remapping.
 
 const server = await createProxyServer(
   port,
@@ -75,16 +74,11 @@ const server = await createProxyServer(
   undefined,
   false,
   process.env.ANTHROPIC_API_KEY,
-  modelMap.opus || modelMap.sonnet || modelMap.haiku ? modelMap : undefined,
+  undefined,
   { quiet: false, hostname }
 );
 
-const mappingInfo = modelMap.opus
-  ? ` (opus→${modelMap.opus}, sonnet→${modelMap.sonnet || "passthrough"}, haiku→${modelMap.haiku || "passthrough"})`
-  : " (passthrough — no profile mapping)";
 console.log(`[claudish-proxy] Standalone proxy running on http://${hostname}:${port}`);
-console.log(`[claudish-proxy] Profile: ${cfg.defaultProfile}${activeProfile ? ` — ${activeProfile.description ?? ""}` : ""}`);
-console.log(`[claudish-proxy] Role mapping: ${modelMap.opus ? `opus=${modelMap.opus}, sonnet=${modelMap.sonnet ?? "passthrough"}, haiku=${modelMap.haiku ?? "passthrough"}` : "none (all models passthrough)"}`);
 console.log(`[claudish-proxy] Config: ~/.claudish/config.json`);
 console.log(`[claudish-proxy] Press Ctrl+C to stop`);
 

--- a/packages/cli/src/test-fixtures/sse-responses/regression-zai-glm5-startofstream-ratelimit.sse
+++ b/packages/cli/src/test-fixtures/sse-responses/regression-zai-glm5-startofstream-ratelimit.sse
@@ -1,0 +1,6 @@
+event: ping
+data: {"type":"ping"}
+
+event: error
+data: {"error":{"code":"1302","message":"Your account has reached its rate limit (concurrency/RPM). Please try again later."},"request_id":"20260602xstartofstreamratelimit"}
+

--- a/start-claudish-proxy.ps1
+++ b/start-claudish-proxy.ps1
@@ -1,0 +1,38 @@
+# Claudish Proxy - Windows Service Wrapper
+# Run via Scheduled Task at system startup
+# Logs to ~/.claudish/logs/proxy-*.log
+
+$ErrorActionPreference = "Stop"
+$LogFile = "$env:USERPROFILE\.claudish\logs\proxy-$(Get-Date -Format 'yyyy-MM-dd').log"
+$LogDir = Split-Path $LogFile -Parent
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+function Write-Log {
+    param([string]$Message)
+    $ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    "$ts  $Message" | Add-Content -Path $LogFile -Encoding utf8NoBOM
+}
+
+Write-Log "Claudish proxy service starting..."
+Write-Log "Working dir: $PSScriptRoot"
+Write-Log "Bun path: $(Get-Command bun -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)"
+
+Set-Location $PSScriptRoot
+
+# Kill any existing proxy on port 3000
+$existing = Get-NetTCPConnection -LocalPort 3000 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique
+if ($existing) {
+    Write-Log "Killing existing process(es) on port 3000: $($existing -join ', ')"
+    $existing | ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }
+    Start-Sleep -Seconds 2
+}
+
+# Start the proxy
+Write-Log "Starting: bun packages/cli/src/standalone-proxy.ts --port 3000"
+bun packages/cli/src/standalone-proxy.ts --port 3000 2>&1 | ForEach-Object {
+    Write-Log $_
+}
+Write-Log "Claudish proxy exited."

--- a/start-claudish-proxy.ps1
+++ b/start-claudish-proxy.ps1
@@ -31,8 +31,8 @@ if ($existing) {
 }
 
 # Start the proxy
-Write-Log "Starting: bun packages/cli/src/standalone-proxy.ts --port 3000"
-bun packages/cli/src/standalone-proxy.ts --port 3000 2>&1 | ForEach-Object {
+Write-Log "Starting: bun packages/cli/src/fork/server/standalone-proxy.ts --port 3000"
+bun packages/cli/src/fork/server/standalone-proxy.ts --port 3000 2>&1 | ForEach-Object {
     Write-Log $_
 }
 Write-Log "Claudish proxy exited."


### PR DESCRIPTION
## Problem

Recurring GLM dropouts — Claude Code crashes with **\"empty or malformed response (HTTP 200)\"** mid-turn, requiring a manual `continue` / `reprends stp` to recover. Every one of those manual recoveries follows the same client-side crash.

## Root cause (confirmed via `CLAUDISH_CAPTURE_DIR` captures)

Z.AI delivers its **instantaneous burst / RPM limit** as **HTTP 200** followed by an in-stream SSE error (`[1302]`) that carries **no message envelope**. Because both `response.ok` and `FallbackHandler` key off HTTP status, a 200-with-in-stream-error is invisible to them — it flowed straight to Claude Code as a bare error and crashed the turn.

Key finding: the errors are **instant (0–4 ms)**, not timeouts. The user's intuition that *large context → more crashes* is real but indirect — big context drives request bursting/concurrency (and cache misses), which trips the **burst** limit. It is **not** a duration/TTFB problem. Condensing helps by reducing request volume.

The 5h **sustained** quota has headroom (≤50% even at peak rush); only the **instantaneous** burst limit is hit, occasionally.

## Fix — three proportionate, fail-open layers

1. **Parser safety-net** (`anthropic-sse.ts`): `finalizeWithError()` always emits a clean terminal message (synthetic `message_start` if none was seen, + `message_delta` `end_turn` + `message_stop`) and suppresses bare `event: error`. A stream error can no longer surface as a raw client crash; rate-limit errors get a friendly retry notice.

2. **Transport backoff** (`anthropic-compat.ts`): `AnthropicProviderTransport.enqueueRequest` retries genuine HTTP 429 with jittered exponential backoff (2/4/8/16/30s + 0–1s, honoring `Retry-After`).

3. **In-stream peek + temporize** (`stream-peek.ts` + `composed-handler.ts`): peek the first bytes of `anthropic-sse` responses via `ReadableStream.tee()` (no bytes lost downstream; bounded ~2s window catches the 0–4ms error without delaying slow-but-healthy big-context responses). On `[1302]`, **temporize** with jittered backoff (1/2/4s + 0–750ms) and retry the **same** provider up to 3× (the sustained quota has headroom). On persistence, return **429** so `FallbackHandler` switches provider (Z.AI → GLM Coding — a separate quota). Fails open on any unexpected condition.

Jitter throughout de-synchronizes the 6-machine cluster (one shared key per provider) so retries don't re-collide on the burst limit.

Also enables `CLAUDISH_CAPTURE_DIR` in `docker-compose` for ongoing production diagnosis.

## On \"shared/adaptive backoff\"

The design is **per-request jittered exponential backoff**, intentionally **not** a shared AIMD pacer. More 429s → more requests back off → offered load drops (implicit aggregate self-throttling), which is sufficient for the stated load. A coordinated pacer that makes *new arrivals* probe more cautiously during a storm is the correct next step **only if** the headroom premise stops holding — deferred to `ROADMAP.md` with explicit trigger conditions to avoid over-engineering.

## Tests

- `stream-peek.test.ts` (5): full-byte passthrough on healthy, multi-read past leading ping, `[1302]`→rate-limit, non-RL→other-error (still streamed), no-body→fail-open.
- `anthropic-compat.test.ts` (+2): 429 retry-then-success; non-429 no-retry.
- `format-translation.test.ts`: #106 regression rewritten to the **no-crash** contract + new start-of-stream rate-limit fixture/test.
- Build + `tsc --noEmit` clean. (One unrelated pre-existing `MiniMaxModelDialect` context-window test failure from the Firebase catalog migration — not touched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)