### PR TITLE
fix(native-handler): strip unsigned thinking blocks to fix mixed-session 400

### DIFF
--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import type { ModelHandler } from "./types.js";
 import { log, maskCredential } from "../logger.js";
 import { wrapAnthropicError } from "./shared/anthropic-error.js";
+import { stripUnsignedThinkingBlocks } from "./shared/thinking-signature.js";
 import {
   fetchMultiModelAdvice,
   findPendingAdvisorToolResults,
@@ -127,6 +128,19 @@ export class NativeHandler implements ModelHandler {
           body: trimForLog(payload),
         });
       }
+    }
+
+    // Strip thinking blocks that arrived without a valid Anthropic signature.
+    // They originate from non-Anthropic providers (GLM/Kimi/DeepSeek reasoning
+    // surfaced as type:"thinking" with signature:"") and poison mixed-provider
+    // sessions: the Anthropic API rejects them with
+    // "messages.N.content.M: Invalid signature in thinking block" once a turn
+    // routes here. Genuine signed Anthropic thinking is preserved.
+    const strippedThinking = stripUnsignedThinkingBlocks(payload.messages);
+    if (strippedThinking > 0) {
+      log(
+        `[Native] Stripped ${strippedThinking} unsigned thinking block(s) (non-Anthropic origin) from message history for ${target}`
+      );
     }
 
     log("\n=== [NATIVE] Claude Code → Anthropic API Request ===");

--- a/packages/cli/src/handlers/shared/thinking-signature.test.ts
+++ b/packages/cli/src/handlers/shared/thinking-signature.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression tests for unsigned thinking-block stripping on the native path.
+ *
+ * Anchored to the real incident: a mixed-provider Claude Code session
+ * accumulated GLM reasoning surfaced as `{ type: "thinking", signature: "" }`
+ * blocks, then routed a turn to a native Anthropic model. The Anthropic API
+ * rejected the request with
+ * `messages.19.content.0: Invalid signature in thinking block` (400).
+ *
+ * stripUnsignedThinkingBlocks() must remove the unsigned (empty/missing
+ * signature) thinking blocks while preserving genuine signed Anthropic thinking
+ * and every other block type.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { stripUnsignedThinkingBlocks } from "./thinking-signature.js";
+
+describe("stripUnsignedThinkingBlocks", () => {
+  test("strips a thinking block with an empty-string signature (the GLM poison)", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "GLM reasoning", signature: "" },
+          { type: "text", text: "hello" },
+        ],
+      },
+    ];
+    const removed = stripUnsignedThinkingBlocks(messages);
+    expect(removed).toBe(1);
+    expect(messages[0].content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  test("strips a thinking block with no signature field at all", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "thinking", thinking: "no sig" }] },
+    ];
+    const removed = stripUnsignedThinkingBlocks(messages);
+    expect(removed).toBe(1);
+    expect(messages[0].content).toEqual([]);
+  });
+
+  test("preserves a genuine Anthropic thinking block with a non-empty signature", () => {
+    const signed = {
+      type: "thinking",
+      thinking: "real Opus reasoning",
+      signature: "ErcBCkgIBRABGAIiQ...valid-signature",
+    };
+    const messages = [{ role: "assistant", content: [signed, { type: "text", text: "ok" }] }];
+    const removed = stripUnsignedThinkingBlocks(messages);
+    expect(removed).toBe(0);
+    expect(messages[0].content).toContainEqual(signed);
+  });
+
+  test("reproduces the incident shape: content[0] unsigned thinking is removed", () => {
+    // messages.19.content.0 in the real 400. Index here is illustrative.
+    const messages = Array.from({ length: 20 }, (_, i) => ({
+      role: i % 2 === 0 ? "user" : "assistant",
+      content: [{ type: "text", text: `m${i}` }],
+    }));
+    messages[19] = {
+      role: "assistant",
+      content: [
+        { type: "thinking", thinking: "poisoned", signature: "" } as any,
+        { type: "text", text: "answer" },
+      ],
+    };
+    const removed = stripUnsignedThinkingBlocks(messages);
+    expect(removed).toBe(1);
+    expect(messages[19].content[0]).toEqual({ type: "text", text: "answer" });
+  });
+
+  test("leaves text, tool_use, tool_result and redacted_thinking blocks untouched", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "encrypted-blob" },
+          { type: "text", text: "hi" },
+          { type: "tool_use", id: "t1", name: "Bash", input: { cmd: "ls" } },
+        ],
+      },
+      { role: "user", content: [{ type: "tool_result", tool_use_id: "t1", content: "out" }] },
+    ];
+    const removed = stripUnsignedThinkingBlocks(messages);
+    expect(removed).toBe(0);
+    expect(messages[0].content).toHaveLength(3);
+  });
+
+  test("never touches user messages, even if they carry a thinking-shaped block", () => {
+    const messages = [
+      { role: "user", content: [{ type: "thinking", thinking: "x", signature: "" }] },
+    ];
+    const removed = stripUnsignedThinkingBlocks(messages);
+    expect(removed).toBe(0);
+    expect(messages[0].content).toHaveLength(1);
+  });
+
+  test("counts across multiple assistant turns and keeps signed ones", () => {
+    const messages = [
+      { role: "assistant", content: [{ type: "thinking", thinking: "a", signature: "" }] },
+      { role: "user", content: [{ type: "text", text: "u" }] },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "b", signature: "sig-ok" },
+          { type: "thinking", thinking: "c", signature: "" },
+        ],
+      },
+    ];
+    const removed = stripUnsignedThinkingBlocks(messages);
+    expect(removed).toBe(2);
+    expect(messages[2].content).toEqual([{ type: "thinking", thinking: "b", signature: "sig-ok" }]);
+  });
+
+  test("tolerates non-array / malformed inputs", () => {
+    expect(stripUnsignedThinkingBlocks(undefined)).toBe(0);
+    expect(stripUnsignedThinkingBlocks(null)).toBe(0);
+    expect(stripUnsignedThinkingBlocks("not-an-array" as any)).toBe(0);
+    expect(stripUnsignedThinkingBlocks([{ role: "assistant", content: "string-content" }])).toBe(0);
+  });
+});

--- a/packages/cli/src/handlers/shared/thinking-signature.ts
+++ b/packages/cli/src/handlers/shared/thinking-signature.ts
@@ -1,0 +1,46 @@
+/**
+ * Thinking-block signature hygiene for the native Anthropic path.
+ *
+ * Non-Anthropic providers (GLM, Kimi, DeepSeek, …) emit reasoning that the
+ * openai-sse / gemini-sse parsers surface to the client as Anthropic
+ * `{ type: "thinking" }` content blocks — but with NO signature (the client
+ * stores them as `signature: ""`). These blocks are harmless while the session
+ * stays on a non-native provider (ComposedHandler strips all thinking blocks
+ * before forwarding). They become toxic in a MIXED session: once a turn routes
+ * to a real Anthropic model, NativeHandler forwards the history verbatim and
+ * the Anthropic API rejects the unsigned block with
+ * `messages.N.content.M: Invalid signature in thinking block` (400).
+ *
+ * This helper removes ONLY thinking blocks whose signature is missing or empty.
+ * Genuine Anthropic thinking blocks carry a real signature and are preserved —
+ * they are required for interleaved-thinking / tool-use continuity. Other block
+ * types (text, tool_use, tool_result, redacted_thinking, …) are untouched.
+ */
+
+/** A thinking block is "unsigned" when its signature is absent or empty. */
+function isUnsignedThinkingBlock(block: any): boolean {
+  return (
+    !!block &&
+    block.type === "thinking" &&
+    (typeof block.signature !== "string" || block.signature.length === 0)
+  );
+}
+
+/**
+ * Strip unsigned thinking blocks from assistant messages in place.
+ *
+ * @param messages The Anthropic-format `messages` array (mutated in place).
+ * @returns The number of thinking blocks removed.
+ */
+export function stripUnsignedThinkingBlocks(messages: any): number {
+  if (!Array.isArray(messages)) return 0;
+
+  let stripped = 0;
+  for (const msg of messages) {
+    if (!msg || msg.role !== "assistant" || !Array.isArray(msg.content)) continue;
+    const before = msg.content.length;
+    msg.content = msg.content.filter((block: any) => !isUnsignedThinkingBlock(block));
+    stripped += before - msg.content.length;
+  }
+  return stripped;
+}


### PR DESCRIPTION
## Summary

Fixes a `400 messages.N.content.M: Invalid signature in thinking block` error that hits **mixed-provider** Claude Code sessions when a turn routes back to a real Anthropic model.

### The bug

Non-Anthropic providers (GLM/Z.AI, Kimi, DeepSeek) emit reasoning that the `openai-sse` / `gemini-sse` stream parsers surface to the client as Anthropic `{ type: "thinking" }` content blocks — but **with no signature** (Claude Code stores them as `signature: ""`).

While the session stays on a non-native provider this is harmless: `ComposedHandler` already strips all thinking blocks before forwarding (see #137, the *forward* direction). The blocks become toxic in a **mixed** session — once a turn routes to a native Anthropic model, `NativeHandler` is a transparent passthrough and forwards the accumulated history verbatim to `api.anthropic.com`. The unsigned blocks are then rejected:

```
API Error: 400 messages.19.content.0: Invalid signature in thinking block
```

(An empty signature is "present but invalid", which is why this surfaces as *invalid* rather than *missing*.)

### The fix

A small pure helper, `stripUnsignedThinkingBlocks()`, removes **only** thinking blocks whose signature is missing or empty, called in `NativeHandler` just before the upstream fetch.

- **Genuine Anthropic thinking is preserved** — it carries a real signature and is required for interleaved-thinking / tool-use continuity.
- Other block types (`text`, `tool_use`, `tool_result`, `redacted_thinking`) are untouched.
- User messages are never modified.
- No-op for pure-native sessions (nothing to strip).

This is the **reverse-direction counterpart** to #137: that PR strips signed Opus thinking on the way *out* to non-Anthropic providers (`ComposedHandler`); this strips unsigned provider thinking on the way *back* to Anthropic (`NativeHandler`).

## Files

- `packages/cli/src/handlers/shared/thinking-signature.ts` — new pure helper (dependency-free, easy to unit-test).
- `packages/cli/src/handlers/native-handler.ts` — import + 1 call before the fetch, with a `log()` line when blocks are stripped.
- `packages/cli/src/handlers/shared/thinking-signature.test.ts` — regression tests.

## Testing

```
bun test packages/cli/src/handlers/shared/thinking-signature.test.ts
# 8 pass, 0 fail
bun run build   # clean
```

Tests cover: empty-signature strip, missing-signature strip, signed-thinking preservation, `redacted_thinking`/`text`/`tool_use` preservation, multi-turn counting, user-message immunity, malformed input, and the exact incident shape (`messages[].content[0]` unsigned thinking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
