### PR TITLE
fix: stream robustness, web search interception, non-streaming /compact, empty-response false-positive

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+node_modules
+dist
+.git
+logs
+*.log
+.claude
+.claudish
+ai-docs
+test-fixtures
+*.md
+!packages/cli/README.md
+.startup-shortcut-created
+Dockerfile
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,12 @@ validation/
 .mnemex/
 gtd/sessions/
 .agents/
+
+# Diagnostic capture (temporary, activated via CLAUDISH_CAPTURE_DIR env)
+capture/
+
+# Session artifacts (traces, deploy notes, monitoring scripts)
+trace-*.json
+kv-cache-traces.md
+monitor-traffic.sh
+deploy-notes-*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,24 @@ Claude Code v2.1.153+ injects `role: "system"` messages inline (e.g. system-remi
 
 Set `CLAUDISH_CAPTURE_DIR` env var to enable full request body capture for offline reproduction of hangs or malformed responses. Disabled by default (no-op when unset). Files written as JSON with metadata (timestamp, source IP, model, PID).
 
+### Opus Leak Diagnostics
+
+When VS Code displays "sonnet" or "glm" but the proxy shows `claude-opus-4-8` requests from that machine, the cause is almost always **sub-agents**, not the main session. The Agent tool spawns sub-agents that default to Opus.
+
+**Quick check:**
+```bash
+# Are there Opus requests from a specific machine?
+docker logs claudish-proxy --since 1h 2>&1 | grep "machine=HOST.*claude-opus" | head -5
+
+# Is it sub-agents? Check billing header in captures:
+docker exec -i claudish-proxy sh -c "head -c 500 /captures/req-1-NNNN-*.json"
+# Look for: cc_is_subagent=true
+```
+
+**Root cause:** Claude Code's Agent tool selects the "best available model" for sub-agents. On Anthropic direct, that's Opus. This is client-side behavior — not fixable in the proxy.
+
+**Fix:** Add a global rule in `~/.claude/rules/` instructing the model to always specify `model: "sonnet"` (or equivalent) when spawning sub-agents, and reserve Opus for genuinely complex tasks.
+
 ## Debug Logging
 
 Debug logging is behind the `--debug` flag and outputs to `logs/` directory. It's disabled by default.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,28 +215,44 @@ Located in `handlers/shared/stream-parsers/`:
 
 ## Web Search Interception (v7.1+)
 
-When providers emit web search tool calls (WebSearch/WebFetch) or GLM's `<searchWeb>` tags, claudish intercepts them and executes via a local **SearXNG** instance instead of forwarding to the provider (which would fail for non-Anthropic providers).
+When providers emit web search tool calls (`web_search`, `brave_web_search`, `tavily_search`) or GLM's `<searchWeb>` tags, claudish intercepts them instead of forwarding to the provider (which would fail for non-Anthropic providers).
+
+**HARD constraint**: a failed search/fetch must NEVER stop the agent. Every path degrades gracefully to well-formed text — no throws, no hung streams.
 
 ### Architecture
 
-Two interception paths, both in the stream parsers:
+Three interception paths:
 
-1. **Structured tool_call** (`openai-sse.ts`): WebSearch/WebFetch tool calls are flagged as `suppressed` in `ToolState`. At finalize, SearXNG is called and results are injected as a text block replacing the tool call. The `suppressed` flag prevents the tool_use content_block from reaching the client.
+1. **Structured tool_call** (`openai-sse.ts`): provider web search tool calls are detected via `web-search-detector.ts`. **If the client declared a `WebSearch` tool in the request** (checked against `toolSchemas`), the call is **remapped** to a synthetic `WebSearch` tool_use block with `stop_reason: "tool_use"` — Claude Code then executes its own WebSearch (which arrives as a sub-agent request, path 3) and the agentic loop continues. If WebSearch is NOT declared (e.g. sub-agents without web tools), the call is `suppressed` and results are injected as a text block with `end_turn` (legitimate there).
 
-2. **GLM `<searchWeb>` tags** (`openai-sse.ts`): GLM models emit `<searchWeb><query>...</query></searchWeb>` in text content. At finalize, these tags are detected, SearXNG is called, tags are stripped from text, and results are appended as a separate text block.
+2. **GLM `<searchWeb>` tags** (`openai-sse.ts`): GLM models emit `<searchWeb><query>...</query></searchWeb>` in text content. At finalize, same remap logic: WebSearch declared → synthetic tool_use; otherwise SearXNG is called and results are appended as a text block.
 
-3. **Sub-agent requests** (`proxy-server.ts`): Claude Code sometimes sends web search/fetch as a single user message ("Perform a web search for the query: X"). These are intercepted at the proxy level before handler selection.
+3. **Sub-agent requests** (`proxy-server.ts`): Claude Code's own WebSearch/WebFetch tools send a single user message ("Perform a web search for the query: X" / "Perform a web fetch for the URL: X"). Intercepted at the proxy level before handler selection; results returned as text with `end_turn` (correct — the sub-agent's job is to return text).
+
+**Why the remap matters (CoursIA incident 2026-06-10)**: suppress + inject-text + `end_turn` ends the assistant turn on raw search results — the agent stalls instead of using them. Remapping to the client's WebSearch keeps `stop_reason: "tool_use"`, so results come back as a tool_result and the loop continues. Regression tests: `format-translation.test.ts` ("web search remap").
+
+### Execution backends (fallback chains)
+
+`web-search-executor.ts` resolves each search/fetch through a chain; the first usable result wins:
+
+- **Search**: MCP `searxng_web_search` (if `SEARXNG_MCP_URL` set, 5s deadline) → direct HTTP `{SEARXNG_URL}/search?format=json` (3s) → error text.
+- **Fetch**: MCP `web_url_read` (12s, real fetch + markdown) → MCP `web_url_read` with `https://r.jina.ai/<url>` prefix (bypasses 403 on bot-hostile hosts, e.g. npmjs) → direct streaming HTTP with 500KB byte cap → error text.
+
+The MCP client (`handlers/shared/mcp-searxng-client.ts`) is a minimal JSON-RPC streamable-http client (no SDK, no stdio): handles both `application/json` and `text/event-stream` response formats, lazy `initialize` handshake with `mcp-session-id` caching when the server demands a session, strict `AbortSignal.timeout` deadlines, and a non-throwing `{ ok, text|error }` contract. Per-call duration is logged as `[MCP-SearXNG] tools/call <name> <ms>ms ok=<bool>` for overhead measurement vs direct HTTP.
 
 ### Configuration
 
-- **`SEARXNG_URL`** env var (required): URL of the SearXNG instance (e.g. `http://search.myia.io`). When unset, web search interception falls through gracefully with a fallback message.
-- **`SEARXNG_AVAILABLE`** flag: detected at startup from `SEARXNG_URL` presence.
-- **Deadline**: 3s default for SearXNG calls (5s for sub-agent path). Non-blocking — races against timeout.
+- **`SEARXNG_MCP_URL`** env var (optional): URL of the MCP searxng endpoint (e.g. `https://mcp-tools.myia.io/searxng/mcp`). When unset, the MCP layer is skipped entirely — zero behavior change for existing deployments.
+- **`MCP_AUTH`** or **`SEARXNG_MCP_TOKEN`** env var: bearer token for the MCP endpoint. Never hardcode; provisioned via RooSync.
+- **`SEARXNG_URL`** env var: URL of the SearXNG instance (e.g. `http://search.myia.io`) for the direct HTTP fallback. When unset, interception falls through gracefully with a fallback message.
+- **Deadlines**: MCP search 5s, MCP fetch 12s, direct HTTP search 3s (5s sub-agent path), direct fetch 10s. Non-blocking — every call races a timeout.
 
 ### Components
 
-- `handlers/shared/web-search-executor.ts` — SearXNG fetch, result formatting, query extraction
-- `handlers/shared/stream-parsers/openai-sse.ts` — tool_call suppression + `<searchWeb>` tag detection
+- `handlers/shared/mcp-searxng-client.ts` — MCP streamable-http JSON-RPC client (non-throwing)
+- `handlers/shared/web-search-executor.ts` — fallback chains, result formatting, query extraction
+- `handlers/shared/web-search-detector.ts` — provider web-search tool name detection
+- `handlers/shared/stream-parsers/openai-sse.ts` — remap/suppression + `<searchWeb>` tag detection
 - `proxy-server.ts` — sub-agent request interception
 
 ### Inline System Message Handling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,17 @@ Located in `handlers/shared/stream-parsers/`:
 - `ollama-jsonl.ts` — Ollama JSONL → Claude SSE
 - `openai-responses-sse.ts` — OpenAI Responses API → Claude SSE (Codex)
 
+### Non-Streaming (`stream: false`) Support
+
+Claude Code's agentic loop always sends `stream: true`, but **`/compact` (context condensation) and any non-streaming Anthropic API caller send `stream: false`** and expect a single JSON `message` body (`Content-Type: application/json`), NOT SSE. Returning SSE to such a client surfaces as `"API Error: API returned an empty or malformed response (HTTP 200) — check for a proxy or gateway intercepting the request"` and **blocks the affected operation** (a session that can't compact eventually overflows and the agent stalls — a never-hang-priority violation).
+
+Every adapter's `buildPayload` hardcodes `stream: true` (the proxy always drives the upstream provider in streaming mode), and the whole translation pipeline emits Claude SSE. To serve non-streaming clients, `ComposedHandler.handle()` buffers the already-translated SSE back into one Anthropic message via `collectAnthropicSseToMessage()` (`handlers/shared/collect-sse-message.ts`):
+
+- The trigger mirrors `request-logger.ts`'s `stream` definition exactly: `wantsStreaming = payload?.stream === true`. Anything else → buffer to JSON.
+- `NativeHandler` (Anthropic-direct/Opus) already honored `stream: false` natively — that is why `/compact` worked on Opus but failed on every proxied/composed model. This closes the same gap for ComposedHandler (and therefore FallbackHandler, which delegates to it).
+- The collector **never throws** (never-hang-priority): a broken/empty stream degrades to a well-formed message with an empty text block. It reuses the full pipeline (all stream formats, web-tool interception, empty-response classification) verbatim — it just collapses the SSE into a message at the end.
+- Regression tests: `handlers/shared/collect-sse-message.test.ts` (text, tool_use, mixed thinking/text order, empty body, malformed lines, unparseable tool JSON).
+
 ## Web Search Interception (v7.1+)
 
 When providers emit web search tool calls (`web_search`, `brave_web_search`, `tavily_search`) or GLM's `<searchWeb>` tags, claudish intercepts them instead of forwarding to the provider (which would fail for non-Anthropic providers).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,25 +274,81 @@ Claude Code v2.1.153+ injects `role: "system"` messages inline (e.g. system-remi
 
 ### Diagnostic Body Capture
 
-Set `CLAUDISH_CAPTURE_DIR` env var to enable full request body capture for offline reproduction of hangs or malformed responses. Disabled by default (no-op when unset). Files written as JSON with metadata (timestamp, source IP, model, PID).
+Set `CLAUDISH_CAPTURE_DIR` env var to enable full request body capture for offline reproduction of hangs or malformed responses. Disabled by default (no-op when unset). Files written as JSON with metadata (timestamp, source IP, model, PID, machine header).
 
-### Opus Leak Diagnostics
+In the Docker deployment, `CLAUDISH_CAPTURE_DIR=/captures` is bind-mounted to `D:\claudish-captures` on the host, so captures persist across container recreates. Compacted nightly to 7z, then backed up to GDrive (see `capture-retention.md` memory).
 
-When VS Code displays "sonnet" or "glm" but the proxy shows `claude-opus-4-8` requests from that machine, the cause is almost always **sub-agents**, not the main session. The Agent tool spawns sub-agents that default to Opus.
+## Traffic Analysis
 
-**Quick check:**
-```bash
-# Are there Opus requests from a specific machine?
-docker logs claudish-proxy --since 1h 2>&1 | grep "machine=HOST.*claude-opus" | head -5
+**Use the scripts, not hand-rolled grep.** The proxy log format has traps that produce false positives when grepped naively (see `proxy-log-monitoring` memory: `bytes=NNNN` matching error codes, timestamp digits matching `429`, `[msg:N]` body previews matching keywords). The scripts below encode the precise filters.
 
-# Is it sub-agents? Check billing header in captures:
-docker exec -i claudish-proxy sh -c "head -c 500 /captures/req-1-NNNN-*.json"
-# Look for: cc_is_subagent=true
+Three levels of analysis — pick by need:
+
+| Need | Script | Source | Speed |
+|------|--------|--------|-------|
+| **Live surveillance** (cron, quick health check) | `traffic-live.ps1` | `docker logs` stdout | fast |
+| **Rich detail** (workspace, session, CC version, tokens) | `traffic-summary.ps1` / `traffic-sessions.ps1` | `req-*.json` captures | slower |
+| **History** (past days from compressed archives) | `traffic-history.ps1` | `captures-*.7z` | slow |
+
+### Scripts
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `traffic-live.ps1` | **Live analysis from docker logs** — model/machine/handler distribution, precise error counts, never-hang check, Anthropic leak check, session-loop detection. This is what the 6h surveillance cron runs. | `.\scripts\traffic-live.ps1 [-Hours N] [-AnthropicMachines 'host1,host2']` |
+| `traffic-summary.ps1` | Overview from captures: machines, models, workspaces, sessions | `.\scripts\traffic-summary.ps1 [-Hours N]` |
+| `traffic-sessions.ps1` | Detailed session list with timing, models, data volume | `.\scripts\traffic-sessions.ps1 [-Hours N] [-All]` |
+| `traffic-history.ps1` | Historical analysis from 7z archives | `.\scripts\traffic-history.ps1 [-Date yyyy-MM-dd] [-Days N]` |
+| `compress-captures.ps1` | Nightly 7z compaction + GDrive backup + 30d local purge (scheduled task) | Runs automatically at 04:17 |
+| `claudish-watchdog.ps1` | Proxy health: tool-call stream test + proactive restart (uptime >11h) + auto-recovery on hang. Scheduled every 15min. | Runs automatically |
+| `CaptureUtils.psm1` | Shared module (capture parsing, device mapping, 7z extraction) | Imported by the scripts above |
+
+### Quick Commands
+
+```powershell
+# Live health check — what's happening right now?
+.\scripts\traffic-live.ps1 -Hours 1
+
+# Standard 6h surveillance window (cron default)
+.\scripts\traffic-live.ps1 -Hours 6
+
+# Rich detail: which workspace/session is active?
+.\scripts\traffic-summary.ps1 -Hours 2
+.\scripts\traffic-sessions.ps1
+
+# Historical analysis from compressed archives
+.\scripts\traffic-history.ps1 -Days 7
 ```
 
-**Root cause:** Claude Code's Agent tool selects the "best available model" for sub-agents. On Anthropic direct, that's Opus. This is client-side behavior — not fixable in the proxy.
+### Capture Format
 
-**Fix:** Add a global rule in `~/.claude/rules/` instructing the model to always specify `model: "sonnet"` (or equivalent) when spawning sub-agents, and reserve Opus for genuinely complex tasks.
+- **`req-*.json`** — Single-line JSON with full Anthropic request body (messages, system, tools, metadata). Extractable: machine (X-Claudish-Machine header), workspace (from system prompt), session_id (from metadata.user_id), CC version (from billing header). Written to `/captures` inside the container, bind-mounted to `D:\claudish-captures` (persists across container recreates).
+- **`resp-*.sse`** — Response SSE with metadata header (elapsed_ms, stop_reason, event count). Correlates with req via shared counter (req-1-0042 → resp-1-r0042).
+- **Archives** — `D:\claudish-captures\archive\captures-YYYY-MM-DD.7z` (LZMA2, ~100-130:1 ratio), mirrored to `G:\Mon Drive\MyIA\backups\claudish-captures\` via Google Drive Desktop (plain Windows file copy, no API). Local purge >30 days (only after confirming the GDrive copy).
+
+### Machine Attribution
+
+Machines are identified by the `X-Claudish-Machine` header (set via `ANTHROPIC_CUSTOM_HEADERS` in Claude Code settings). When missing, `CaptureUtils.psm1` falls back to device_id fingerprinting. Known device IDs are hardcoded in the module's `$DeviceMap` (currently partial — po-2023 + ai-01 only; update when new machines are seen without the header).
+
+### Anthropic Leak Diagnostics
+
+By cluster policy, **Anthropic-billed models (Opus, Fable, Sonnet) must come from `myia-ai-01` only**. `traffic-live.ps1` flags Anthropic traffic from other machines automatically:
+
+- **[OK]** — authorized machine (`-AnthropicMachines`, default `myia-ai-01`).
+- **[REVIEW]** — `myia-po-2025`: may run an authorized Safari workflow (agent-sdk / VS Code) under Anthropic. **Do not auto-flag as leak** — confirm with the user first (lesson 2026-06-21: 6 false WARNs raised on po-2025 before learning Safari was authorized).
+- **[LEAK]** — any other machine on Anthropic. Investigate.
+
+**Sub-agent leaks vs legitimate sessions** — the distinction that matters:
+- **Real sub-agent leak** = requests carry `cc_is_subagent=true` (in the billing header, *not* on the stdout `[Request]` line) + Anthropic model + non-authorized machine. The Agent tool spawns sub-agents that default to "best available" = Opus.
+- **Legitimate Anthropic session** = `agent-sdk/X` + entrypoint `claude-vscode` + same source IP across requests + `msgs=60+` (large context = main session, not sub-agent). No `cc_is_subagent`.
+
+`cc_is_subagent` lives in the request body, not stdout — so it's not visible via `docker logs` alone. To confirm a sub-agent leak, inspect a capture:
+```bash
+# Find the billing header in a suspect capture
+docker exec claudish-proxy sh -c "head -c 500 /captures/req-1-NNNN-*.json"
+# Look for: cc_is_subagent=true  → sub-agent. Absent → main session (not a leak).
+```
+
+**Fix for a confirmed leak:** add a global rule in `~/.claude/rules/` instructing the model to always specify `model: "sonnet"` (or equivalent) when spawning sub-agents, reserving Opus for genuinely complex tasks. This is client-side behavior — not fixable in the proxy.
 
 ## Debug Logging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,42 @@ Located in `handlers/shared/stream-parsers/`:
 - `ollama-jsonl.ts` — Ollama JSONL → Claude SSE
 - `openai-responses-sse.ts` — OpenAI Responses API → Claude SSE (Codex)
 
+## Web Search Interception (v7.1+)
+
+When providers emit web search tool calls (WebSearch/WebFetch) or GLM's `<searchWeb>` tags, claudish intercepts them and executes via a local **SearXNG** instance instead of forwarding to the provider (which would fail for non-Anthropic providers).
+
+### Architecture
+
+Two interception paths, both in the stream parsers:
+
+1. **Structured tool_call** (`openai-sse.ts`): WebSearch/WebFetch tool calls are flagged as `suppressed` in `ToolState`. At finalize, SearXNG is called and results are injected as a text block replacing the tool call. The `suppressed` flag prevents the tool_use content_block from reaching the client.
+
+2. **GLM `<searchWeb>` tags** (`openai-sse.ts`): GLM models emit `<searchWeb><query>...</query></searchWeb>` in text content. At finalize, these tags are detected, SearXNG is called, tags are stripped from text, and results are appended as a separate text block.
+
+3. **Sub-agent requests** (`proxy-server.ts`): Claude Code sometimes sends web search/fetch as a single user message ("Perform a web search for the query: X"). These are intercepted at the proxy level before handler selection.
+
+### Configuration
+
+- **`SEARXNG_URL`** env var (required): URL of the SearXNG instance (e.g. `http://search.myia.io`). When unset, web search interception falls through gracefully with a fallback message.
+- **`SEARXNG_AVAILABLE`** flag: detected at startup from `SEARXNG_URL` presence.
+- **Deadline**: 3s default for SearXNG calls (5s for sub-agent path). Non-blocking — races against timeout.
+
+### Components
+
+- `handlers/shared/web-search-executor.ts` — SearXNG fetch, result formatting, query extraction
+- `handlers/shared/stream-parsers/openai-sse.ts` — tool_call suppression + `<searchWeb>` tag detection
+- `proxy-server.ts` — sub-agent request interception
+
+### Inline System Message Handling
+
+Claude Code v2.1.153+ injects `role: "system"` messages inline (e.g. system-reminders). Anthropic-compatible providers (Z.AI, MiniMax, Kimi) reject these — only "user"/"assistant" accepted. The fix:
+- `composed-handler.ts`: strips inline system messages from `requestPayload.messages` for `anthropic-sse` transport, merges into top-level `system` field
+- `openai-messages.ts`: same strip for the OpenAI format path
+
+### Diagnostic Body Capture
+
+Set `CLAUDISH_CAPTURE_DIR` env var to enable full request body capture for offline reproduction of hangs or malformed responses. Disabled by default (no-op when unset). Files written as JSON with metadata (timestamp, source IP, model, PID).
+
 ## Debug Logging
 
 Debug logging is behind the `--debug` flag and outputs to `logs/` directory. It's disabled by default.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM oven/bun:1.2-alpine
+
+WORKDIR /app
+
+# Copy workspace structure
+COPY package.json ./
+COPY scripts/postinstall.cjs ./scripts/postinstall.cjs
+COPY packages/cli/package.json ./packages/cli/package.json
+
+# Copy source
+COPY packages/cli/src ./packages/cli/src
+COPY packages/cli/bin ./packages/cli/bin
+COPY packages/cli/tsconfig.json ./packages/cli/tsconfig.json
+COPY packages/cli/scripts ./packages/cli/scripts
+
+# Install deps (skip lockfile — partial workspace)
+RUN bun install --production --no-save
+
+# Generate version file
+RUN bun run packages/cli/scripts/generate-version.ts 2>/dev/null || true
+
+# Expose proxy port
+EXPOSE 3000
+
+# Config directory
+VOLUME /root/.claudish
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- http://0.0.0.0:3000/health || exit 1
+
+ENTRYPOINT ["bun", "run", "packages/cli/src/standalone-proxy.ts"]
+CMD ["--port", "3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ VOLUME /root/.claudish
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://0.0.0.0:3000/health || exit 1
 
-ENTRYPOINT ["bun", "run", "packages/cli/src/standalone-proxy.ts"]
+ENTRYPOINT ["bun", "run", "packages/cli/src/fork/server/standalone-proxy.ts"]
 CMD ["--port", "3000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.2-alpine
+FROM oven/bun:1.3-alpine
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Claudish automatically loads `.env` from the current directory at startup. For t
 |----------|----------|---------|
 | `GEMINI_BASE_URL` | Gemini API | `https://generativelanguage.googleapis.com` |
 | `OPENAI_BASE_URL` | OpenAI/Azure | `https://api.openai.com` |
-| `MINIMAX_BASE_URL` | MiniMax | `https://api.minimax.io` |
+| `MINIMAX_BASE_URL` | MiniMax | `https://api.minimaxi.com` |
 | `MOONSHOT_BASE_URL` | Kimi/Moonshot | `https://api.moonshot.ai` |
 | `ZHIPU_BASE_URL` | GLM/Zhipu | `https://open.bigmodel.cn` |
 | `ZAI_BASE_URL` | Z.AI | `https://api.z.ai` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,27 @@ Reference: research findings under `ai-docs/sessions/dev-research-channel-config
 
 ---
 
+## Adaptive / shared backoff pacer for burst rate-limits
+
+Status: not started. Deliberately deferred — current per-request backoff is judged sufficient for the present load.
+
+**What ships today** (the in-stream rate-limit fix): when an `anthropic-sse` provider (notably Z.AI) delivers its burst/RPM limit as HTTP 200 + an in-stream `[1302]` SSE error, ComposedHandler peeks the stream start, detects it, and **temporizes with a per-request jittered exponential backoff** (1s/2s/4s + 0–750ms), retrying the same provider up to 3× before returning 429 so FallbackHandler switches providers (e.g. Z.AI → GLM Coding, a separate quota). The transport layer (`AnthropicProviderTransport.enqueueRequest`) adds a second jittered backoff on genuine HTTP 429. Both are **per-request and independent** — there is no shared, cross-request pressure gauge.
+
+This produces *implicit* aggregate self-throttling: under a storm, more requests hit 429 → more requests back off → offered load drops. It does not, however, make *new arrivals* probe more cautiously while a storm is in progress — each new request still fires at full rate on its first attempt. With the stated load (≤50% of the 5h sustained quota even at peak; only the instantaneous burst limit is hit occasionally, and the cluster shares one key per provider), that residual gap is acceptable and a coordinated pacer would be over-engineering.
+
+**What this item would add**: a shared per-provider pressure gauge (e.g. AIMD — additive-increase/multiplicative-decrease — with time decay) that admission-paces *new* requests as the recent error rate climbs, so the fleet spreads requests **more** under a sustained storm rather than only after each individual request fails. This is the "écarter encore plus les requêtes quand le taux d'erreurs augmente" idea — correct in principle, but only worth the complexity (shared state across 6 machines, or per-process approximation; tuning; new failure modes) if the simpler per-request backoff proves insufficient.
+
+**Trigger conditions** (any one):
+- Sustained-quota utilization regularly approaches its ceiling (not just the instantaneous burst limit) — i.e. the "we have headroom" premise stops holding.
+- Capture/telemetry shows the in-stream-rate-limit fix's 3-retry budget is frequently exhausted (turns still failing over to fallback or to the client) despite the backoff — meaning synchronized full-rate probing during storms is the dominant remaining failure.
+- The cluster grows enough that uncoordinated per-request backoff visibly re-collides on the burst limit even with jitter.
+
+**Effort**: medium. A per-process AIMD gauge is small; a genuinely *shared* cross-machine gauge needs a coordination point (shared store or a designated pacer) and is the bulk of the cost.
+
+**Reference**: in-stream rate-limit fix — `packages/cli/src/handlers/shared/stream-peek.ts`, `composed-handler.ts` (peek+retry block), `providers/transport/anthropic-compat.ts` (`enqueueRequest`). Root-cause analysis in this session's capture diagnosis.
+
+---
+
 ## Adding a new roadmap item
 
 Each item should follow the structure above:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  claudish-proxy:
+    build: .
+    container_name: claudish-proxy
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      # Mount config from host (contains API keys, routing, profiles)
+      - type: bind
+        source: C:\Users\jsboi\.claudish
+        target: /root/.claudish
+        read_only: true
+    environment:
+      - NODE_ENV=production
+    command: ["--port", "3000", "--host", "0.0.0.0"]
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,18 @@ services:
         source: C:\Users\jsboi\.claudish
         target: /root/.claudish
         read_only: true
+      # Persistent diagnostic capture: full request/response bodies for offline
+      # analysis. The proxy writes req-*.json / resp-*.sse here (gated by
+      # CLAUDISH_CAPTURE_DIR). Compacted nightly by ClaudishCaptureCompaction
+      # (compress-captures.ps1), then backed up to GDrive.
+      - type: bind
+        source: D:\claudish-captures
+        target: /captures
     environment:
       - NODE_ENV=production
       - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
       - SEARXNG_URL=http://search.myia.io
-      - CLAUDISH_CAPTURE_DIR=/tmp/captures
+      - CLAUDISH_CAPTURE_DIR=/captures
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
         read_only: true
     environment:
       - NODE_ENV=production
+      - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - NODE_ENV=production
       - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
-      - SEARXNG_URL=http://192.168.0.47:8181
+      - SEARXNG_URL=http://search.myia.io
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - NODE_ENV=production
       - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
       - SEARXNG_URL=http://search.myia.io
+      - CLAUDISH_CAPTURE_DIR=/tmp/captures
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     environment:
       - NODE_ENV=production
       - CLAUDISH_PROXY_KEY=${CLAUDISH_PROXY_KEY:-}
+      - SEARXNG_URL=http://192.168.0.47:8181
     command: ["--port", "3000", "--host", "0.0.0.0"]
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://0.0.0.0:3000/health"]

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -177,7 +177,7 @@ Claudish automatically loads `.env` from the current working directory at startu
 |----------|----------|---------|
 | `GEMINI_BASE_URL` | Google Gemini API | `https://generativelanguage.googleapis.com` |
 | `OPENAI_BASE_URL` | OpenAI API (also for Azure-compatible) | `https://api.openai.com` |
-| `MINIMAX_BASE_URL` | MiniMax API | `https://api.minimax.io` |
+| `MINIMAX_BASE_URL` | MiniMax API | `https://api.minimaxi.com` |
 | `MINIMAX_CODING_BASE_URL` | MiniMax Coding Plan endpoint | `https://api.minimax.io` |
 | `MOONSHOT_BASE_URL` | Kimi/Moonshot API | `https://api.moonshot.ai` |
 | `KIMI_BASE_URL` | Alias for `MOONSHOT_BASE_URL` | |

--- a/packages/cli/bin/claudish.cjs
+++ b/packages/cli/bin/claudish.cjs
@@ -8,17 +8,27 @@ const { execFileSync, execSync } = require("child_process");
 const { resolve } = require("path");
 
 function findBun() {
+  const isWin = process.platform === "win32";
+  // PATH lookup — "which" is POSIX-only; Windows uses "where".
   try {
-    const path = execSync("which bun", { encoding: "utf-8" }).trim();
-    if (path) return path;
+    const out = execSync(isWin ? "where bun" : "which bun", { encoding: "utf-8" }).trim();
+    const first = out.split(/\r?\n/).map((l) => l.trim()).find(Boolean);
+    if (first) return first;
   } catch {}
   // Common install locations
-  const candidates = [
-    process.env.HOME + "/.bun/bin/bun",
-    "/usr/local/bin/bun",
-    "/opt/homebrew/bin/bun",
-  ];
+  const home = process.env.HOME || process.env.USERPROFILE;
+  const candidates = isWin
+    ? [
+        home && resolve(home, ".bun", "bin", "bun.exe"),
+        home && resolve(home, ".bun", "bin", "bun"),
+      ]
+    : [
+        home && home + "/.bun/bin/bun",
+        "/usr/local/bin/bun",
+        "/opt/homebrew/bin/bun",
+      ];
   for (const c of candidates) {
+    if (!c) continue;
     try {
       execFileSync(c, ["--version"], { stdio: "ignore" });
       return c;
@@ -29,10 +39,14 @@ function findBun() {
 
 const bun = findBun();
 if (!bun) {
+  const installCmd =
+    process.platform === "win32"
+      ? 'powershell -c "irm bun.sh/install.ps1 | iex"'
+      : "curl -fsSL https://bun.sh/install | bash";
   console.error(`claudish requires the Bun runtime but it was not found.
 
 Install Bun (one command):
-  curl -fsSL https://bun.sh/install | bash
+  ${installCmd}
 
 Then retry:
   claudish --version

--- a/packages/cli/src/config-command.ts
+++ b/packages/cli/src/config-command.ts
@@ -76,7 +76,7 @@ const PROVIDERS: ProviderDef[] = [
     description: "MiniMax API (mm@, mmax@)",
     keyUrl: "https://www.minimaxi.com/",
     endpointEnvVar: "MINIMAX_BASE_URL",
-    defaultEndpoint: "https://api.minimax.io",
+    defaultEndpoint: "https://api.minimaxi.com",
   },
   {
     name: "kimi",

--- a/packages/cli/src/config-schema.ts
+++ b/packages/cli/src/config-schema.ts
@@ -37,6 +37,14 @@ export const CustomEndpointSimpleSchema = z.object({
   apiKey: z.string().min(1),
   modelPrefix: z.string().optional(),
   models: z.array(z.string()).optional(),
+  /**
+   * Max concurrent in-flight requests to this endpoint (0 = unlimited, 1 =
+   * sequential). Only meaningful for capacity-limited backends (e.g. a single
+   * GPU vLLM server) where parallel large prefills cause engine wedging.
+   * Wires the endpoint through LocalModelQueue — same mechanism as local
+   * models' `:N` concurrency suffix. Omit for unbounded (default behavior).
+   */
+  maxConcurrency: z.number().int().min(0).max(8).optional(),
 });
 
 // "Complex" custom endpoint: a runtime PROVIDER_PROFILES entry.
@@ -61,6 +69,11 @@ export const CustomEndpointComplexSchema = z.object({
     .optional(),
   modelPrefix: z.string().optional(),
   models: z.array(z.string()).optional(),
+  /**
+   * Max concurrent in-flight requests to this endpoint (0 = unlimited, 1 =
+   * sequential). See CustomEndpointSimpleSchema.maxConcurrency.
+   */
+  maxConcurrency: z.number().int().min(0).max(8).optional(),
 });
 
 export const CustomEndpointSchema = z.discriminatedUnion("kind", [

--- a/packages/cli/src/fork/config/profile-extensions.ts
+++ b/packages/cli/src/fork/config/profile-extensions.ts
@@ -1,0 +1,9 @@
+/**
+ * Profile config extension (fork extension).
+ *
+ * Adds proxyKey to the ClaudishProfileConfig type.
+ * This is the fork-specific schema extension — profile-config.ts re-exports it.
+ */
+
+/** Proxy authentication key — clients must send x-proxy-key matching this value */
+export type ProxyKey = string;

--- a/packages/cli/src/fork/index.ts
+++ b/packages/cli/src/fork/index.ts
@@ -1,0 +1,37 @@
+/**
+ * Fork extensions barrel export + registration.
+ *
+ * All fork-specific features are wired through this single entry point.
+ * proxy-server.ts calls registerForkExtensions() to activate them.
+ * This keeps the diff between our fork and upstream minimal.
+ */
+
+import type { Hono } from "hono";
+import { log } from "../logger.js";
+import { createProxyAuthMiddleware } from "./middleware/proxy-auth.js";
+import { registerModelDiscoveryRoute } from "./routes/model-discovery.js";
+
+export { createProxyAuthMiddleware } from "./middleware/proxy-auth.js";
+export { registerModelDiscoveryRoute } from "./routes/model-discovery.js";
+export { stripBillingHeaderFromBody } from "./middleware/billing-header-strip.js";
+export { resolveSourceIp, logRequest } from "./middleware/request-logger.js";
+export { createHostnameConfig, type HostnameConfig } from "./server/hostname-binding.js";
+
+export interface ForkExtensionsOptions {
+  proxyKey?: string;
+}
+
+/**
+ * Register all fork extensions on the Hono app.
+ * Called once from proxy-server.ts during startup.
+ */
+export function registerForkExtensions(app: Hono, opts: ForkExtensionsOptions): void {
+  // 1. Proxy authentication middleware
+  if (opts.proxyKey) {
+    app.use("/v1/*", createProxyAuthMiddleware(opts.proxyKey));
+    log("[Proxy] Authentication enabled (Anthropic pass-through; proxy key required for other providers)");
+  }
+
+  // 2. Model discovery endpoint
+  registerModelDiscoveryRoute(app);
+}

--- a/packages/cli/src/fork/middleware/billing-header-strip.ts
+++ b/packages/cli/src/fork/middleware/billing-header-strip.ts
@@ -1,0 +1,27 @@
+/**
+ * Billing header strip (fork extension).
+ *
+ * Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
+ * into the prompt body — the `cch=` token changes every request, which breaks
+ * vLLM prefix caching (strict hash). Only Anthropic needs this; strip for others.
+ */
+
+export function stripBillingHeaderFromBody(body: any, isNative: boolean): void {
+  if (isNative) return;
+
+  if (typeof body.system === "string") {
+    body.system = body.system.replace(
+      /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+      ""
+    );
+  } else if (Array.isArray(body.system)) {
+    for (const block of body.system) {
+      if (block.type === "text" && typeof block.text === "string") {
+        block.text = block.text.replace(
+          /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+          ""
+        );
+      }
+    }
+  }
+}

--- a/packages/cli/src/fork/middleware/proxy-auth.ts
+++ b/packages/cli/src/fork/middleware/proxy-auth.ts
@@ -1,0 +1,54 @@
+/**
+ * Proxy authentication middleware (fork extension).
+ *
+ * Anthropic pass-through is exempt (OAuth or proxy-key swap handled by NativeHandler).
+ * Non-Anthropic providers require the proxy key in x-api-key / authorization / x-proxy-key.
+ * GET requests and health endpoints are exempt for Docker healthcheck and model discovery.
+ */
+
+import type { MiddlewareHandler } from "hono";
+import { wrapAnthropicError } from "../../handlers/shared/anthropic-error.js";
+import { parseModelSpec } from "../../providers/model-parser.js";
+
+export function createProxyAuthMiddleware(proxyKey: string): MiddlewareHandler {
+  return async (c, next) => {
+    if (c.req.method === "GET") {
+      return await next();
+    }
+
+    // Peek at body.model to determine target provider.
+    // Hono caches parsed JSON — safe to call again from the route handler.
+    let model: string | undefined;
+    try {
+      const body = await c.req.json();
+      model = body?.model;
+    } catch {
+      return await next(); // Malformed body — let handler return 400
+    }
+
+    // Anthropic pass-through: skip proxy key validation entirely.
+    // NativeHandler will either swap proxyKey → stored Anthropic key,
+    // or pass the client's OAuth token through unchanged.
+    if (model) {
+      const spec = parseModelSpec(model);
+      if (spec.provider === "native-anthropic") {
+        return await next();
+      }
+    }
+
+    // Non-Anthropic: enforce proxy key
+    const authHeader = c.req.header("authorization");
+    const apiKeyHeader = c.req.header("x-api-key");
+    const proxyKeyHeader = c.req.header("x-proxy-key");
+
+    const bearerToken = authHeader?.startsWith("Bearer ")
+      ? authHeader.slice(7)
+      : authHeader;
+
+    const provided = proxyKeyHeader || apiKeyHeader || bearerToken;
+    if (!provided || provided !== proxyKey) {
+      return c.json(wrapAnthropicError(401, "invalid proxy authentication"), 401);
+    }
+    await next();
+  };
+}

--- a/packages/cli/src/fork/middleware/request-logger.ts
+++ b/packages/cli/src/fork/middleware/request-logger.ts
@@ -1,0 +1,29 @@
+/**
+ * Request logger (fork extension).
+ *
+ * Logs remote IP + request metadata for cluster traffic analysis.
+ * Resolves source IP from x-forwarded-for, x-real-ip, or direct connection map.
+ */
+
+export function resolveSourceIp(
+  req: Request,
+  remoteAddrMap: WeakMap<Request, string>
+): string {
+  const xff = req.headers.get("x-forwarded-for") || "";
+  const xrip = req.headers.get("x-real-ip") || "";
+  const directIp = remoteAddrMap.get(req) || "";
+  return xff || xrip || directIp || "direct";
+}
+
+export function logRequest(
+  body: { model?: string },
+  handlerName: string,
+  req: Request,
+  remoteAddrMap: WeakMap<Request, string>
+): void {
+  const src = resolveSourceIp(req, remoteAddrMap);
+  const ua = req.headers.get("user-agent") || "";
+  console.log(
+    `[claudish] [Request] model=${body.model ?? "(none)"} handler=${handlerName} src=${src} ua=${ua.slice(0, 60)}`
+  );
+}

--- a/packages/cli/src/fork/middleware/request-logger.ts
+++ b/packages/cli/src/fork/middleware/request-logger.ts
@@ -3,6 +3,8 @@
  *
  * Logs remote IP + request metadata for cluster traffic analysis.
  * Resolves source IP from x-forwarded-for, x-real-ip, or direct connection map.
+ *
+ * Leak investigation mode: dumps system prompt excerpt + first + last user message.
  */
 
 export function resolveSourceIp(
@@ -15,15 +17,84 @@ export function resolveSourceIp(
   return xff || xrip || directIp || "direct";
 }
 
+function excerpt(s: string, maxLen = 200): string {
+  const flat = s.replace(/\n/g, "\\n").replace(/\r/g, "");
+  if (flat.length <= maxLen) return flat;
+  return flat.slice(0, maxLen) + "...";
+}
+
+function extractText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const texts = content
+      .filter((b: Record<string, unknown>) => b.type === "text")
+      .map((b: Record<string, unknown>) => b.text as string);
+    return texts.join(" ");
+  }
+  return "";
+}
+
 export function logRequest(
-  body: { model?: string },
+  body: Record<string, unknown>,
   handlerName: string,
   req: Request,
   remoteAddrMap: WeakMap<Request, string>
 ): void {
   const src = resolveSourceIp(req, remoteAddrMap);
   const ua = req.headers.get("user-agent") || "";
-  console.log(
-    `[claudish] [Request] model=${body.model ?? "(none)"} handler=${handlerName} src=${src} ua=${ua.slice(0, 60)}`
+  const model = (body.model as string) ?? "(none)";
+
+  // Full-body capture (temporary diagnostic — gated by CLAUDISH_CAPTURE_DIR env).
+  // Disabled when the env var is unset, so this is a no-op in normal operation.
+  const captureDir = process.env.CLAUDISH_CAPTURE_DIR;
+  if (captureDir) {
+    try {
+      const fs = require("fs");
+      fs.mkdirSync(captureDir, { recursive: true });
+      const g = globalThis as Record<string, unknown>;
+      const n = (g.__capN = ((g.__capN as number) ?? 0) + 1);
+      const safeSrc = src.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 40);
+      const ts = new Date().toISOString().replace(/[:.]/g, "-");
+      const file = `${captureDir}/req-${process.pid}-${String(n).padStart(4, "0")}-${ts}-${safeSrc}.json`;
+      fs.writeFileSync(file, JSON.stringify({ ts, src, model, pid: process.pid, body }));
+      process.stdout.write(`  [capture] ${file}\n`);
+    } catch (e) {
+      process.stdout.write(`  [capture] error: ${String(e)}\n`);
+    }
+  }
+
+  // Header line
+  const msgs = Array.isArray(body.messages) ? body.messages.length : 0;
+  const stream = body.stream === true ? "stream" : "sync";
+  const maxTokens = body.max_tokens ?? "-";
+  process.stdout.write(
+    `[claudish] [Request] model=${model} handler=${handlerName} src=${src} ${stream} msgs=${msgs} max_tokens=${maxTokens} ua=${ua.slice(0, 80)}\n`
   );
+
+  // System prompt excerpt (first 300 chars)
+  const sysText = typeof body.system === "string"
+    ? body.system
+    : Array.isArray(body.system)
+      ? JSON.stringify(body.system)
+      : "";
+  if (sysText) {
+    process.stdout.write(`  [system] ${excerpt(sysText, 300)}\n`);
+  }
+
+  // First user message excerpt
+  const messages = (body.messages as Record<string, unknown>[]) ?? [];
+  if (messages.length > 0) {
+    const first = extractText(messages[0].content);
+    if (first) {
+      process.stdout.write(`  [msg:0] ${excerpt(first, 200)}\n`);
+    }
+  }
+
+  // Last user message excerpt
+  if (messages.length > 1) {
+    const last = extractText(messages[messages.length - 1].content);
+    if (last) {
+      process.stdout.write(`  [msg:${messages.length - 1}] ${excerpt(last, 300)}\n`);
+    }
+  }
 }

--- a/packages/cli/src/fork/middleware/request-logger.ts
+++ b/packages/cli/src/fork/middleware/request-logger.ts
@@ -67,8 +67,10 @@ export function logRequest(
   const msgs = Array.isArray(body.messages) ? body.messages.length : 0;
   const stream = body.stream === true ? "stream" : "sync";
   const maxTokens = body.max_tokens ?? "-";
+  const machine = req.headers.get("x-claudish-machine") || "";
+  const machineTag = machine ? ` machine=${machine}` : "";
   process.stdout.write(
-    `[claudish] [Request] model=${model} handler=${handlerName} src=${src} ${stream} msgs=${msgs} max_tokens=${maxTokens} ua=${ua.slice(0, 80)}\n`
+    `[claudish] [Request] model=${model} handler=${handlerName} src=${src} ${stream} msgs=${msgs} max_tokens=${maxTokens}${machineTag} ua=${ua.slice(0, 80)}\n`
   );
 
   // System prompt excerpt (first 300 chars)

--- a/packages/cli/src/fork/routes/model-discovery.ts
+++ b/packages/cli/src/fork/routes/model-discovery.ts
@@ -1,0 +1,55 @@
+/**
+ * Model discovery endpoint (fork extension).
+ *
+ * Claude Code queries /v1/models when CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1.
+ * Returns all routable models from config.json routing rules + custom endpoints.
+ */
+
+import type { Hono } from "hono";
+import { loadConfig } from "../../profile-config.js";
+
+export function registerModelDiscoveryRoute(app: Hono): void {
+  app.get("/v1/models", (c) => {
+    const cfg = loadConfig();
+    const seen = new Set<string>();
+    const models: { id: string; display_name: string; created_at: string }[] = [];
+
+    // From routing rules — each key is a model name
+    if (cfg.routing) {
+      for (const modelName of Object.keys(cfg.routing)) {
+        if (!seen.has(modelName)) {
+          seen.add(modelName);
+          models.push({
+            id: modelName,
+            display_name: modelName,
+            created_at: "2026-01-01T00:00:00Z",
+          });
+        }
+      }
+    }
+
+    // From custom endpoints — each declared model
+    if (cfg.customEndpoints) {
+      for (const [, ep] of Object.entries(cfg.customEndpoints)) {
+        const endpoint = ep as { models?: string[] };
+        if (endpoint.models) {
+          for (const m of endpoint.models) {
+            if (!seen.has(m)) {
+              seen.add(m);
+              models.push({
+                id: m,
+                display_name: m,
+                created_at: "2026-01-01T00:00:00Z",
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return c.json({
+      object: "list",
+      data: models,
+    });
+  });
+}

--- a/packages/cli/src/fork/server/hostname-binding.ts
+++ b/packages/cli/src/fork/server/hostname-binding.ts
@@ -1,0 +1,19 @@
+/**
+ * Hostname binding (fork extension).
+ *
+ * Configures the proxy to bind to a specific hostname (default: 127.0.0.1).
+ * For Docker deployments, use "0.0.0.0" to accept connections from all interfaces.
+ * Tracks direct remote addresses via WeakMap since Hono middleware can't access sockets.
+ */
+
+export interface HostnameConfig {
+  hostname: string;
+  remoteAddrMap: WeakMap<Request, string>;
+}
+
+export function createHostnameConfig(hostname?: string): HostnameConfig {
+  return {
+    hostname: hostname ?? "127.0.0.1",
+    remoteAddrMap: new WeakMap<Request, string>(),
+  };
+}

--- a/packages/cli/src/fork/server/standalone-proxy.ts
+++ b/packages/cli/src/fork/server/standalone-proxy.ts
@@ -61,12 +61,18 @@ if (hostIdx !== -1 && args[hostIdx + 1]) {
 }
 
 import { createProxyServer } from "../../proxy-server.js";
-import { loadConfig } from "../../profile-config.js";
+import { loadConfig, getModelMapping } from "../../profile-config.js";
 
-// No modelMap — the proxy is a transparent router. Every model name routes
-// to its provider via config.json routing rules:
-//   claude-opus-4-7 → anthropic, glm-5.1 → z.ai, qwen3.6-35b-a3b → vllm-myia
-// Any model can be used directly; no role remapping.
+// Role remapping from the active profile (2026-06-25). Without a modelMap, a
+// client that sends a literal Anthropic role name — e.g. `claude-sonnet-4-6`
+// because its model selector didn't resolve the "Sonnet" alias to glm-5.2 —
+// fell through to the native-anthropic passthrough check (proxy-server.ts isNative)
+// and leaked budget Anthropic credits on the Sonnet route. Loading the profile's
+// opus/sonnet/haiku map activates proxy-server.ts's role remapping:
+//   claude-sonnet-* → glm-5.2 (gc@), claude-haiku-* → qwen, claude-opus-* → claude-opus-4-8 (native, ai-01).
+// Models already sent by their budgeted name (glm-5.2, qwen3.6-…) are unaffected.
+const profileConfig = loadConfig();
+const modelMap = getModelMapping(profileConfig.defaultProfile);
 
 const server = await createProxyServer(
   port,
@@ -74,7 +80,7 @@ const server = await createProxyServer(
   undefined,
   false,
   process.env.ANTHROPIC_API_KEY,
-  undefined,
+  modelMap,
   { quiet: false, hostname }
 );
 

--- a/packages/cli/src/fork/server/standalone-proxy.ts
+++ b/packages/cli/src/fork/server/standalone-proxy.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env bun
 /**
- * Claudish Standalone Proxy Server
+ * Claudish Standalone Proxy Server (fork extension)
  *
  * Starts the proxy server without wrapping Claude Code.
  * Used for cluster deployments where other machines route LLM requests
  * through this proxy.
  *
- * Usage: bun packages/cli/src/standalone-proxy.ts [--port 3000]
+ * Usage: bun packages/cli/src/fork/server/standalone-proxy.ts [--port 3000]
  */
 
 import { config } from "dotenv";
@@ -60,8 +60,8 @@ if (hostIdx !== -1 && args[hostIdx + 1]) {
   hostname = args[hostIdx + 1];
 }
 
-import { createProxyServer } from "./proxy-server.js";
-import { loadConfig } from "./profile-config.js";
+import { createProxyServer } from "../../proxy-server.js";
+import { loadConfig } from "../../profile-config.js";
 
 // No modelMap — the proxy is a transparent router. Every model name routes
 // to its provider via config.json routing rules:

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -1935,4 +1935,45 @@ describe("Regression: empty-response cause classification", () => {
     // A content filter is NOT a context-size problem.
     expect(text).not.toMatch(/context is very large/i);
   });
+
+  // A normal response WITH text content must never get the empty-response error
+  // appended. Broken by the a519a95 reorder: finalize() cleared state.textStarted
+  // when closing the text block BEFORE hasContent read it, so every pure-text
+  // response was misclassified as empty — clients saw their real answer followed
+  // by "[Error: ... Try /compact ...]" and large-context sessions ran destructive
+  // compactions in a loop (cluster-wide incident, 2026-06-12).
+  const TEXT_THEN_STOP = [
+    `data: {"id":"c4","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Hello, here is my answer."},"finish_reason":null}]}`,
+    ``,
+    `data: {"id":"c4","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":150000,"completion_tokens":7}}`,
+    ``,
+    `data: [DONE]`,
+    ``,
+  ].join("\n");
+
+  test("response with real text content must NOT get an empty-response error appended", async () => {
+    const createStreamingResponseHandler = await getParser();
+    const adapter = await getDefaultAdapter();
+    const ctx = createMockContext();
+
+    const response = createStreamingResponseHandler(
+      ctx,
+      sseToResponse(TEXT_THEN_STOP),
+      adapter,
+      "glm-5.1",
+      null,
+      undefined,
+      undefined
+    );
+
+    const events = await parseClaudeSseStream(response);
+    const text = extractText(events);
+
+    expect(text).toContain("Hello, here is my answer.");
+    // The empty-response guidance must NOT appear after valid content —
+    // even with a very large prompt (150k tokens would classify as overflow).
+    expect(text).not.toMatch(/empty response/i);
+    expect(text).not.toMatch(/\/compact/);
+    expect(extractStopReason(events)).toBe("end_turn");
+  });
 });

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -259,6 +259,67 @@ describe("Anthropic SSE Passthrough (createAnthropicPassthroughStream)", () => {
     expect(tokenInput).toBe(50);
     expect(tokenOutput).toBe(5);
   });
+
+  // never-hang regression: Z.AI / GLM Coding close the socket mid-stream under
+  // load. Before the fix, the reader.read() throw escaped to a catch that did a
+  // bare controller.close() with NO terminal message_stop, so Claude Code saw
+  // "socket connection was closed unexpectedly" and froze the turn.
+  test("never-hang: upstream socket close mid-stream still emits terminal message_stop", async () => {
+    const createAnthropicPassthroughStream = await getParser();
+    const encoder = new TextEncoder();
+    // Fixture: a few valid events, then the upstream body ERRORS (socket close).
+    const upstream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            "event: message_start\n" +
+              `data: {"type":"message_start","message":{"id":"msg_test","type":"message","role":"assistant","model":"glm-5.1","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}\n\n`
+          )
+        );
+        controller.enqueue(
+          encoder.encode(
+            "event: content_block_start\n" +
+              `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`
+          )
+        );
+        controller.enqueue(
+          encoder.encode(
+            "event: content_block_delta\n" +
+              `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Partial answer before cutoff"}}\n\n`
+          )
+        );
+        // Simulate the upstream TCP socket dying mid-stream — deferred so the
+        // enqueued chunks are read first (a real close arrives after a network
+        // round-trip, not synchronously in the same tick as the writes).
+        setTimeout(
+          () => controller.error(new Error("The socket connection was closed unexpectedly.")),
+          5
+        );
+      },
+    });
+    const fixture = new Response(upstream, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+    const ctx = createMockContext();
+
+    const response = createAnthropicPassthroughStream(ctx, fixture, {
+      modelName: "glm-5.1",
+    });
+
+    const events = await parseClaudeSseStream(response);
+
+    // Partial content must survive (not lost to the cutoff).
+    expect(extractText(events)).toContain("Partial answer before cutoff");
+
+    // CRITICAL: a terminal message_stop MUST be present so Claude Code ends the
+    // turn cleanly instead of freezing. This is the assertion that failed
+    // before the fix.
+    expect(events.some((e) => e.data?.type === "message_stop")).toBe(true);
+
+    // Synthesized stop_reason so the client treats it as a completed turn.
+    expect(extractStopReason(events)).toBe("end_turn");
+  });
 });
 
 // ─── Adapter Message Conversion Tests ───────────────────────────────────────

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -1797,3 +1797,142 @@ describe("Regression: web search remap to client WebSearch tool_use", () => {
     expect(extractStopReason(events)).toBe("tool_use");
   });
 });
+
+// ─── Regression: empty-response cause classification (no destructive /compact) ─
+// Providers (GLM, qwen) sometimes return finish_reason with zero content. The
+// old code injected a blanket "context too large → compact" message for every
+// empty response, pushing agents into a destructive /compact on transient
+// empties (sub-agents with tiny contexts) — discarding context mid-task.
+// The fix classifies by finish_reason + prompt_tokens and leads transient
+// empties with "retry, NOT a context problem".
+describe("Regression: empty-response cause classification", () => {
+  async function getParser() {
+    const mod = await import("./handlers/shared/openai-compat.js");
+    return mod.createStreamingResponseHandler;
+  }
+
+  async function getDefaultAdapter() {
+    const mod = await import("./adapters/base-api-format.js");
+    return new mod.DefaultAPIFormat("test-model");
+  }
+
+  function sseToResponse(content: string): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(content));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }
+
+  // finish_reason "stop", tiny context → TRANSIENT (must NOT push /compact)
+  const EMPTY_STOP_SMALL = [
+    `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+    ``,
+    `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":12,"completion_tokens":0}}`,
+    ``,
+    `data: [DONE]`,
+    ``,
+  ].join("\n");
+
+  // finish_reason "length" → OVERFLOW (mentions /compact)
+  const EMPTY_LENGTH = [
+    `data: {"id":"c2","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+    ``,
+    `data: {"id":"c2","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"length"}],"usage":{"prompt_tokens":5000,"completion_tokens":0}}`,
+    ``,
+    `data: [DONE]`,
+    ``,
+  ].join("\n");
+
+  // finish_reason "content_filter" → CONTENT-FILTER message
+  const EMPTY_FILTER = [
+    `data: {"id":"c3","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":""},"finish_reason":null}]}`,
+    ``,
+    `data: {"id":"c3","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}],"usage":{"prompt_tokens":20,"completion_tokens":0}}`,
+    ``,
+    `data: [DONE]`,
+    ``,
+  ].join("\n");
+
+  test("empty + finish_reason=stop + small context → transient message (no /compact push)", async () => {
+    const createStreamingResponseHandler = await getParser();
+    const adapter = await getDefaultAdapter();
+    const ctx = createMockContext();
+
+    const response = createStreamingResponseHandler(
+      ctx,
+      sseToResponse(EMPTY_STOP_SMALL),
+      adapter,
+      "glm-5.1",
+      null,
+      undefined,
+      undefined
+    );
+
+    const events = await parseClaudeSseStream(response);
+    const text = extractText(events);
+
+    // Transient empties lead with retry guidance, NOT compact.
+    expect(text).toMatch(/transient/i);
+    expect(text).toMatch(/retry/i);
+    expect(text).toMatch(/NOT a context-size problem/i);
+    // Must NOT be the old blanket "context is too large → compact" framing.
+    expect(text).not.toMatch(/This usually happens when the conversation context is too large/);
+
+    // Still terminates cleanly so the agent's turn ends gracefully.
+    expect(extractStopReason(events)).toBe("end_turn");
+  });
+
+  test("empty + finish_reason=length → overflow message (mentions /compact)", async () => {
+    const createStreamingResponseHandler = await getParser();
+    const adapter = await getDefaultAdapter();
+    const ctx = createMockContext();
+
+    const response = createStreamingResponseHandler(
+      ctx,
+      sseToResponse(EMPTY_LENGTH),
+      adapter,
+      "glm-5.1",
+      null,
+      undefined,
+      undefined
+    );
+
+    const events = await parseClaudeSseStream(response);
+    const text = extractText(events);
+
+    // A genuine length/overflow empty correctly advises /compact.
+    expect(text).toMatch(/context is very large|\/compact/i);
+    // And surfaces the real finish_reason.
+    expect(text).toMatch(/length/);
+  });
+
+  test("empty + finish_reason=content_filter → content-filter message (not context)", async () => {
+    const createStreamingResponseHandler = await getParser();
+    const adapter = await getDefaultAdapter();
+    const ctx = createMockContext();
+
+    const response = createStreamingResponseHandler(
+      ctx,
+      sseToResponse(EMPTY_FILTER),
+      adapter,
+      "glm-5.1",
+      null,
+      undefined,
+      undefined
+    );
+
+    const events = await parseClaudeSseStream(response);
+    const text = extractText(events);
+
+    expect(text).toMatch(/content policy|filtered/i);
+    // A content filter is NOT a context-size problem.
+    expect(text).not.toMatch(/context is very large/i);
+  });
+});

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -1688,6 +1688,51 @@ describe("Regression: Anthropic SSE in-stream error handling (#106)", () => {
     const msgStop = events.find((e) => e.data?.type === "message_stop");
     expect(msgStop).toBeDefined();
   });
+
+  test("server_tool_use block does not crash the proxy (scope bug: highestSeenIndex ReferenceError)", async () => {
+    // REGRESSION (po-2025 freeze, 2026-06-14): Z.AI emits a real server_tool_use
+    // block (webReader). The suppression handler `handleServerToolResult` is an
+    // async closure that writes `highestSeenIndex`. That variable was declared
+    // inside the inner read-loop `try {}` block, while the closure lived in the
+    // outer `start()` scope — two separate block scopes. When a real
+    // server_tool_use fired the handler, the closure hit a ReferenceError and
+    // CRASHED the proxy process (client then saw "socket closed" / "Content block
+    // not found"). Fix: hoist highestSeenIndex (and friends) into the shared
+    // start() scope. This test replays a server_tool_use stream end-to-end; it
+    // must NOT throw and must emit a clean terminal message_stop.
+    const createAnthropicPassthroughStream = await getParser();
+    const fixture = fixtureToResponse(join(FIXTURES_DIR, "regression-zai-server-tool-use.sse"));
+    const ctx = createMockContext();
+
+    const response = createAnthropicPassthroughStream(ctx, fixture, {
+      modelName: "glm-5.2",
+    });
+
+    // Drain the full stream into a single buffer. The bug threw inside stream
+    // consumption — this must complete without throwing or rejecting.
+    const reader = response.body!.getReader();
+    const decoder = new TextDecoder();
+    let raw = "";
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      raw += decoder.decode(value, { stream: true });
+    }
+    // Allow the async handleServerToolResult (web fetch) to settle before
+    // asserting — its injected text block lands after the read loop closes.
+    await new Promise((r) => setTimeout(r, 50));
+
+    // The pre-server_tool text block is preserved.
+    expect(raw).toContain('"text":"Let me look that up."');
+
+    // server_tool_use blocks are suppressed — no content_block with that type
+    // reaches the client (which cannot render it).
+    expect(raw).not.toContain('"type":"server_tool_use"');
+
+    // The turn terminates cleanly with message_stop (proves no proxy crash /
+    // unterminated stream, which is the never-hang-priority contract).
+    expect(raw).toContain('"type":"message_stop"');
+  });
 });
 
 // ─── Regression: web search remap (agentic blocking fix) ───────────────────

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -1628,3 +1628,172 @@ describe("Regression: Anthropic SSE in-stream error handling (#106)", () => {
     expect(msgStop).toBeDefined();
   });
 });
+
+// ─── Regression: web search remap (agentic blocking fix) ───────────────────
+//
+// CoursIA incident 2026-06-10: provider-side web search (web_search tool call
+// or GLM <searchWeb> tag) was suppressed and replaced with a text block +
+// stop_reason "end_turn" — the agent ended its turn on raw search results and
+// the agentic loop stalled. The fix remaps these to a synthetic WebSearch
+// tool_use (stop_reason "tool_use") whenever the client declared WebSearch,
+// so Claude Code runs its own WebSearch and the conversation continues.
+
+describe("Regression: web search remap to client WebSearch tool_use", () => {
+  async function getParser() {
+    const mod = await import("./handlers/shared/openai-compat.js");
+    return mod.createStreamingResponseHandler;
+  }
+
+  async function getDefaultAdapter() {
+    const mod = await import("./adapters/base-api-format.js");
+    return new mod.DefaultAPIFormat("test-model");
+  }
+
+  function sseToResponse(content: string): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(content));
+        controller.close();
+      },
+    });
+    return new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }
+
+  const WEBSEARCH_SCHEMA = {
+    name: "WebSearch",
+    description: "Search the web",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+  };
+  const READ_SCHEMA = {
+    name: "Read",
+    description: "Read a file",
+    input_schema: {
+      type: "object",
+      properties: { file_path: { type: "string" } },
+      required: ["file_path"],
+    },
+  };
+
+  // Provider emits a structured web_search tool call (GLM/z.ai dialect)
+  const WEB_SEARCH_TOOLCALL_SSE = [
+    `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"Let me look that up."},"finish_reason":null}]}`,
+    ``,
+    `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_ws_1","type":"function","function":{"name":"web_search","arguments":""}}]},"finish_reason":null}]}`,
+    ``,
+    `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"query\\":\\"chatterbox tts docker compose\\"}"}}]},"finish_reason":null}]}`,
+    ``,
+    `data: {"id":"c1","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":12,"completion_tokens":7}}`,
+    ``,
+    `data: [DONE]`,
+    ``,
+  ].join("\n");
+
+  test("web_search tool call + WebSearch declared → remapped tool_use, stop_reason=tool_use", async () => {
+    const createStreamingResponseHandler = await getParser();
+    const adapter = await getDefaultAdapter();
+    const ctx = createMockContext();
+
+    const response = createStreamingResponseHandler(
+      ctx,
+      sseToResponse(WEB_SEARCH_TOOLCALL_SSE),
+      adapter,
+      "glm-5.1",
+      null,
+      undefined,
+      [WEBSEARCH_SCHEMA, READ_SCHEMA]
+    );
+
+    const events = await parseClaudeSseStream(response);
+
+    // The provider tool call is remapped to the client's WebSearch tool
+    const tools = extractToolNames(events);
+    expect(tools).toContain("WebSearch");
+
+    // The remapped input carries the original query
+    const inputJson = events
+      .filter((e) => e.data?.type === "content_block_delta" && e.data?.delta?.type === "input_json_delta")
+      .map((e) => e.data.delta.partial_json)
+      .join("");
+    expect(JSON.parse(inputJson)).toEqual({ query: "chatterbox tts docker compose" });
+
+    // THE fix: the turn must continue, not end on injected text
+    expect(extractStopReason(events)).toBe("tool_use");
+
+    // No raw search-results text block injected
+    expect(extractText(events)).not.toContain("[Web search");
+  });
+
+  test("web_search tool call WITHOUT WebSearch declared → suppression fallback, stop_reason=end_turn", async () => {
+    const createStreamingResponseHandler = await getParser();
+    const adapter = await getDefaultAdapter();
+    const ctx = createMockContext();
+
+    const response = createStreamingResponseHandler(
+      ctx,
+      sseToResponse(WEB_SEARCH_TOOLCALL_SSE),
+      adapter,
+      "glm-5.1",
+      null,
+      undefined,
+      [READ_SCHEMA] // no WebSearch in the request
+    );
+
+    const events = await parseClaudeSseStream(response);
+
+    // No tool_use leaks through (web_search must not reach the client)
+    expect(extractToolNames(events)).toHaveLength(0);
+
+    // Results (or a graceful degradation notice) are injected as text
+    expect(extractText(events)).toContain("[Web search");
+
+    // Legitimate end_turn: without WebSearch declared the client could not
+    // execute a remapped tool anyway (e.g. sub-agents without web tools).
+    expect(extractStopReason(events)).toBe("end_turn");
+  });
+
+  test("GLM <searchWeb> tag + WebSearch declared → remapped tool_use, stop_reason=tool_use", async () => {
+    const createStreamingResponseHandler = await getParser();
+    const adapter = await getDefaultAdapter();
+    const ctx = createMockContext();
+
+    const glmSse = [
+      `data: {"id":"c2","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant","content":"<searchWeb><query>devnen Chatterbox-TTS-Server docker run</query></searchWeb>"},"finish_reason":null}]}`,
+      ``,
+      `data: {"id":"c2","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":9,"completion_tokens":4}}`,
+      ``,
+      `data: [DONE]`,
+      ``,
+    ].join("\n");
+
+    const response = createStreamingResponseHandler(
+      ctx,
+      sseToResponse(glmSse),
+      adapter,
+      "glm-5.1",
+      null,
+      undefined,
+      [WEBSEARCH_SCHEMA, READ_SCHEMA]
+    );
+
+    const events = await parseClaudeSseStream(response);
+
+    const tools = extractToolNames(events);
+    expect(tools).toContain("WebSearch");
+
+    const inputJson = events
+      .filter((e) => e.data?.type === "content_block_delta" && e.data?.delta?.type === "input_json_delta")
+      .map((e) => e.data.delta.partial_json)
+      .join("");
+    expect(JSON.parse(inputJson)).toEqual({ query: "devnen Chatterbox-TTS-Server docker run" });
+
+    expect(extractStopReason(events)).toBe("tool_use");
+  });
+});

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -1535,10 +1535,15 @@ describe("Regression: Anthropic SSE in-stream error handling (#106)", () => {
     return mod.createAnthropicPassthroughStream;
   }
 
-  test("in-stream error payload emits proper error event instead of crashing (non-filtering path)", async () => {
-    // REGRESSION: Z.AI returns HTTP 200 with {"error":{"code":"1305","message":"..."}} in-stream.
-    // Before fix: raw error payload passed through, Claude Code crashes with "undefined is not an object"
-    // because it expects a `type` field. Fixed in /dev:fix session dev-fix-20260417-224919-72cb371e
+  test("mid-stream error finalizes gracefully with message_stop instead of a bare error event (non-filtering path)", async () => {
+    // REGRESSION (#106 → no-crash hardening): Z.AI returns HTTP 200 with
+    // {"error":{"code":"1305","message":"..."}} in-stream. The original fix
+    // forwarded a Claude-shaped `error` event, but Claude Code still treats a
+    // turn that ends on a bare `error` event (no message_stop) as "empty or
+    // malformed response (HTTP 200)" and crashes. The hardened contract:
+    // ALWAYS emit a valid terminal message. Mid-stream (text already sent), we
+    // close the open block and emit message_delta + message_stop — preserving
+    // the partial text and ending the turn cleanly.
     const createAnthropicPassthroughStream = await getParser();
     const fixture = fixtureToResponse(join(FIXTURES_DIR, "regression-zai-glm5-instream-error.sse"));
     const ctx = createMockContext();
@@ -1549,23 +1554,27 @@ describe("Regression: Anthropic SSE in-stream error handling (#106)", () => {
 
     const events = await parseClaudeSseStream(response);
 
-    // Should have received text content before the error
+    // Partial text received before the error is preserved.
     const text = extractText(events);
     expect(text).toContain("Hello");
 
-    // Should have an error event with proper structure
+    // No bare `error` event reaches the client — that is what crashes the turn.
     const errorEvent = events.find((e) => e.data?.type === "error");
-    expect(errorEvent).toBeDefined();
-    expect(errorEvent?.data?.error?.type).toBe("api_error");
-    expect(errorEvent?.data?.error?.message).toContain("temporarily overloaded");
+    expect(errorEvent).toBeUndefined();
 
-    // Should NOT have a message_stop (stream was terminated by error)
+    // The open content block is closed.
+    const blockStop = events.find((e) => e.data?.type === "content_block_stop");
+    expect(blockStop).toBeDefined();
+
+    // The turn ends cleanly with message_delta + message_stop.
+    const msgDelta = events.find((e) => e.data?.type === "message_delta");
+    expect(msgDelta?.data?.delta?.stop_reason).toBe("end_turn");
     const msgStop = events.find((e) => e.data?.type === "message_stop");
-    expect(msgStop).toBeUndefined();
+    expect(msgStop).toBeDefined();
   });
 
-  test("in-stream error payload handled in filtering path (adapter present)", async () => {
-    // Same scenario but with filterThinking enabled (MiniMax, Kimi)
+  test("mid-stream error finalizes gracefully in the filtering path (adapter present)", async () => {
+    // Same scenario with filterThinking enabled (MiniMax, Kimi).
     const createAnthropicPassthroughStream = await getParser();
     const { MiniMaxModelDialect } = await import("./adapters/minimax-model-dialect.js");
     const adapter = new MiniMaxModelDialect("minimax-m2.5");
@@ -1580,9 +1589,42 @@ describe("Regression: Anthropic SSE in-stream error handling (#106)", () => {
 
     const events = await parseClaudeSseStream(response);
 
-    // Should have an error event
+    // No bare error event; the turn terminates with message_stop.
     const errorEvent = events.find((e) => e.data?.type === "error");
-    expect(errorEvent).toBeDefined();
-    expect(errorEvent?.data?.error?.message).toContain("temporarily overloaded");
+    expect(errorEvent).toBeUndefined();
+    const msgStop = events.find((e) => e.data?.type === "message_stop");
+    expect(msgStop).toBeDefined();
+  });
+
+  test("start-of-stream rate-limit emits a synthetic message with a rate-limit notice (no message_start yet)", async () => {
+    // The burst-limit ([1302]) case: the provider sends a ping then an error
+    // BEFORE any message envelope. finalizeWithError must synthesize the whole
+    // message (message_start + a user-visible notice + message_stop) so the
+    // client renders a clean turn rather than crashing on an empty 200.
+    const createAnthropicPassthroughStream = await getParser();
+    const fixture = fixtureToResponse(
+      join(FIXTURES_DIR, "regression-zai-glm5-startofstream-ratelimit.sse")
+    );
+    const ctx = createMockContext();
+
+    const response = createAnthropicPassthroughStream(ctx, fixture, {
+      modelName: "glm-5.1",
+    });
+
+    const events = await parseClaudeSseStream(response);
+
+    // A synthetic message envelope is produced even though upstream sent none.
+    const msgStart = events.find((e) => e.data?.type === "message_start");
+    expect(msgStart).toBeDefined();
+
+    // The notice is rate-limit-aware (mentions retrying / a moment), not a raw dump.
+    const text = extractText(events);
+    expect(text.toLowerCase()).toContain("rate limited");
+
+    // No bare error event; the turn ends with message_stop.
+    const errorEvent = events.find((e) => e.data?.type === "error");
+    expect(errorEvent).toBeUndefined();
+    const msgStop = events.find((e) => e.data?.type === "message_stop");
+    expect(msgStop).toBeDefined();
   });
 });

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -301,7 +301,37 @@ export class ComposedHandler implements ModelHandler {
     // 4. Build request payload
     let requestPayload = adapter.buildPayload(claudeRequest, messages, tools);
 
-    // Merge provider-specific extra fields
+    // 4b. Strip inline system messages from messages[] for Anthropic-transport providers.
+    // Claude Code v2.1.153+ injects system messages inline (e.g. system-reminders).
+    // Providers like Z.AI reject role:"system" in messages — only role:"user"/"assistant" accepted.
+    // Merge them into the top-level system field instead.
+    if (this.provider.streamFormat === "anthropic-sse" && requestPayload.messages) {
+      const inlineSystemTexts: string[] = [];
+      requestPayload.messages = requestPayload.messages.filter((msg: any) => {
+        if (msg.role === "system") {
+          const text = typeof msg.content === "string"
+            ? msg.content
+            : Array.isArray(msg.content)
+              ? msg.content.map((c: any) => c.text || "").join("\n")
+              : "";
+          if (text) inlineSystemTexts.push(text);
+          return false;
+        }
+        return true;
+      });
+      if (inlineSystemTexts.length > 0) {
+        const merged = inlineSystemTexts.join("\n\n");
+        if (requestPayload.system) {
+          const existing = Array.isArray(requestPayload.system)
+            ? requestPayload.system.map((s: any) => s.text || s).join("\n\n")
+            : requestPayload.system;
+          requestPayload.system = existing + "\n\n" + merged;
+        } else {
+          requestPayload.system = merged;
+        }
+        log(`[ComposedHandler] Merged ${inlineSystemTexts.length} inline system message(s) into system prompt for ${this.provider.displayName}`);
+      }
+    }
     const extraFields = this.provider.getExtraPayloadFields?.();
     if (extraFields) {
       Object.assign(requestPayload, extraFields);

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -332,6 +332,26 @@ export class ComposedHandler implements ModelHandler {
         log(`[ComposedHandler] Merged ${inlineSystemTexts.length} inline system message(s) into system prompt for ${this.provider.displayName}`);
       }
     }
+
+    // Strip thinking blocks from message history for non-native providers.
+    // ComposedHandler is never used for native Anthropic (that's NativeHandler),
+    // so every request here goes to a provider that doesn't understand Anthropic
+    // thinking signatures. Without this strip, Opus thinking blocks (with signatures)
+    // flow through to Z.AI/GLM/MiniMax/etc., which either ignore or corrupt them.
+    if (requestPayload.messages) {
+      let stripped = 0;
+      for (const msg of requestPayload.messages) {
+        if (msg.role === "assistant" && Array.isArray(msg.content)) {
+          const before = msg.content.length;
+          msg.content = msg.content.filter((block: any) => block.type !== "thinking");
+          stripped += before - msg.content.length;
+        }
+      }
+      if (stripped > 0) {
+        log(`[ComposedHandler] Stripped ${stripped} thinking block(s) from message history for ${this.provider.displayName}`);
+      }
+    }
+
     const extraFields = this.provider.getExtraPayloadFields?.();
     if (extraFields) {
       Object.assign(requestPayload, extraFields);

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -530,6 +530,30 @@ export class ComposedHandler implements ModelHandler {
       throw error;
     }
 
+    // ── Patient overload backoff (2026-06-25) ──────────────────────────────
+    // GLM/Z.AI concurrency contention arrives as a direct HTTP 429/503 whose
+    // body says "overloaded" (NOT a quota wall — both Anthropic and GLM quotas
+    // have headroom). The transport already ran a fast ~60s first-line retry; if
+    // the error still persists, back off patiently (~5 min — fits the 600s
+    // client timeout, far better than hammering a server that already warned us)
+    // via doFetch (direct, bypassing transport 429-retry to avoid compounding)
+    // before surfacing 529. The in-stream [1305] variant (HTTP 200 + SSE error)
+    // is handled by the peek loop below. Worst case bounded: transport 60s +
+    // patient loop ~5 min ≈ 6 min, well under the 10-min client timeout.
+    if (!response.ok) {
+      let probeText = "";
+      try {
+        probeText = await response.clone().text();
+      } catch {
+        // body read is best-effort
+      }
+      if (isTransientOverload(response.status, probeText)) {
+        const recovered = await this.patientOverloadBackoff(doFetch);
+        if (recovered) response = recovered;
+        // null = exhausted → response stays the overload → !response.ok below → 529
+      }
+    }
+
     // Check if the transport fell back to a different model (e.g., capacity exhaustion)
     if (this.provider.getActiveModelName?.()) {
       const activeModel = this.provider.getActiveModelName()!;
@@ -710,6 +734,30 @@ export class ComposedHandler implements ModelHandler {
         } catch {
           errorBody = { error: { type: "api_error", message: errorText } };
         }
+
+        // Transient overload (gc@/Z.AI concurrency limit delivered as a direct
+        // HTTP 429/503, body says "overloaded"). By the time we reach here, the
+        // patient backoff loop (patientOverloadBackoff, ~5 min via doFetch) has
+        // already exhausted — so this is genuinely sustained contention. Surface
+        // HTTP 529 overloaded_error so the client retries with its own backoff,
+        // NOT 429 (which the client reads as a quota wall and stops the turn).
+        // (2026-06-25 patient-backoff.)
+        if (isTransientOverload(response.status, errorText)) {
+          logStderr(
+            `[Overload] [${this.provider.displayName}] HTTP ${response.status} transient overload → returning 529 overloaded_error (patient ~5min backoff exhausted)`,
+            true // forceConsole — operational event
+          );
+          c.header("Retry-After", "5");
+          return c.json(
+            wrapAnthropicError(
+              529,
+              `${this.provider.displayName} temporarily overloaded (concurrency limit) — please retry shortly`,
+              "overloaded_error"
+            ),
+            529 as any
+          );
+        }
+
         return c.json(ensureAnthropicErrorFormat(response.status, errorBody), response.status as any);
       }
     }
@@ -723,8 +771,11 @@ export class ComposedHandler implements ModelHandler {
     // short window catches it without delaying slow-but-healthy big-context
     // responses), temporize with a jittered backoff + retry the SAME provider
     // (the sustained quota has headroom — only the instantaneous burst limit is
-    // hit), and on persistence return a 429 so FallbackHandler switches to the
-    // next provider in the chain (e.g. GLM Coding — a separate quota).
+    // hit). On persistence we return HTTP 529 (overloaded_error), NOT 429 — a
+    // 429 is read by clients as a quota/usage-wall and stops the turn, whereas
+    // 529 means "temporarily overloaded, not your usage limit" and the client
+    // retries. 529 is also retryable so FallbackHandler advances in multi-
+    // candidate mode. See the 2026-06-25 patient-backoff revision.
     //
     // The whole block is fail-open: peekStreamStart() only ever returns a
     // usable Response, and any classification other than "rate-limit" flows
@@ -735,15 +786,22 @@ export class ComposedHandler implements ModelHandler {
         (this.explicitAdapter?.getStreamFormat() ?? this.modelAdapter?.getStreamFormat()) ??
         this.getAdapter().getStreamFormat();
       if (peekFormat === "anthropic-sse") {
-        const maxRlRetries = 3;
+        // Patient overload backoff (2026-06-25): GLM/Z.AI concurrency limits
+        // surface as HTTP 200 + in-stream [130x]. Clients (Claude Code) have
+        // generous request timeouts (API_TIMEOUT_MS=600000) and would rather
+        // wait several minutes for concurrency to settle than hit a hard error.
+        // So we retry up to 6× with a ~5-minute spread (5s/10s/20s/40s/80s/150s
+        // + jitter ≈ 305s) and only surface 529 if contention is genuinely
+        // sustained. Retries use doFetch DIRECTLY (not enqueueRequest) so the
+        // transport's own 429-retry doesn't compound into an unbounded wait.
+        // Jitter (the cluster shares one key per provider) prevents synchronized
+        // retries from re-colliding on the burst limit.
+        const maxRlRetries = 6;
         let rlAttempt = 0;
         let peeked = await peekStreamStart(response);
         while (peeked.cls === "rate-limit" && rlAttempt < maxRlRetries) {
-          // Jittered exponential backoff: 1s, 2s, 4s (+0-750ms). The cluster
-          // shares one key per provider, so jitter prevents synchronized
-          // retries from re-colliding on the burst limit.
           const backoffMs =
-            Math.min(1000 * 2 ** rlAttempt, 8000) + Math.floor(Math.random() * 750);
+            Math.min(5000 * 2 ** rlAttempt, 150000) + Math.floor(Math.random() * 1000);
           log(
             `[RateLimit] [${this.provider.displayName}] in-stream rate-limit (HTTP 200), temporizing — retry ${rlAttempt + 1}/${maxRlRetries} in ${(backoffMs / 1000).toFixed(1)}s${peeked.detail ? `: ${peeked.detail}` : ""}`,
             true // forceConsole — operational event, must be visible without --debug
@@ -752,9 +810,9 @@ export class ComposedHandler implements ModelHandler {
           rlAttempt++;
           let retryResp: Response;
           try {
-            retryResp = this.provider.enqueueRequest
-              ? await this.provider.enqueueRequest(doFetch)
-              : await doFetch();
+            // doFetch direct (not enqueueRequest): the transport's 429-retry
+            // would compound with this patient loop into an unbounded wait.
+            retryResp = await doFetch();
           } catch (e: any) {
             log(
               `[RateLimit] [${this.provider.displayName}] rate-limit retry fetch failed: ${e?.message ?? e}`,
@@ -773,13 +831,13 @@ export class ComposedHandler implements ModelHandler {
         }
         if (peeked.cls === "rate-limit") {
           log(
-            `[RateLimit] [${this.provider.displayName}] in-stream rate-limit persisted after ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} → returning 429 for cross-provider fallback`,
+            `[Overload] [${this.provider.displayName}] in-stream overload persisted after ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} → returning 529 overloaded_error (patient backoff exhausted)`,
             true // forceConsole — operational event, must be visible without --debug
           );
           try {
             const { error_class, error_code } = classifyError(
-              new Error("in-stream rate limit"),
-              429,
+              new Error("in-stream overload"),
+              529,
               peeked.detail
             );
             recordStats({
@@ -788,7 +846,7 @@ export class ComposedHandler implements ModelHandler {
               stream_format: this.provider.streamFormat,
               latency_ms: Math.round(performance.now() - startTime),
               success: false,
-              http_status: 429,
+              http_status: 529,
               error_class,
               error_code,
               token_strategy: this.options.tokenStrategy ?? "standard",
@@ -802,13 +860,19 @@ export class ComposedHandler implements ModelHandler {
           } catch {
             // Stats must never crash claudish
           }
+          // 529 overloaded_error (NOT 429): a 429 is read by Claude Code as a
+          // quota/usage-wall and stops the turn; 529 means "temporarily
+          // overloaded, not your usage limit" and the client retries with its
+          // own backoff. Retry-After nudges impatient clients to wait rather
+          // than hammer a server that already warned us.
+          c.header("Retry-After", "5");
           return c.json(
             wrapAnthropicError(
-              429,
-              `${this.provider.displayName} rate limited (in-stream burst limit); ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} exhausted`,
-              "rate_limit_error"
+              529,
+              `${this.provider.displayName} temporarily overloaded (concurrency limit); ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} exhausted — please retry shortly`,
+              "overloaded_error"
             ),
-            429 as any
+            529 as any
           );
         }
         // healthy or other-error → use the peeked (tee'd, full) stream below.
@@ -1027,11 +1091,88 @@ export class ComposedHandler implements ModelHandler {
     this.pendingFallbackMeta = { chain, attempts };
   }
 
+  /**
+   * Patient backoff for transient provider overload (HTTP 429/503 whose body
+   * indicates concurrency/overload — NOT a quota wall). Retries the SAME provider
+   * via `doFetch` directly (bypassing the transport's own 429-retry so the two
+   * don't compound) with a ~5-minute exponential spread (5s/10s/20s/40s/80s/150s
+   * + jitter ≈ 305s), which fits comfortably in the 600s client request timeout.
+   *
+   * Returns:
+   *   - a recovered (ok) Response → caller streams it normally.
+   *   - a non-transient !ok Response (the error morphed, e.g. into a 500) →
+   *     caller surfaces the real error via the normal !response.ok path.
+   *   - null → contention genuinely sustained after ~5 min → caller surfaces 529.
+   *
+   * (2026-06-25 patient-backoff revision.)
+   */
+  private async patientOverloadBackoff(
+    doFetch: () => Promise<Response>
+  ): Promise<Response | null> {
+    const maxRetries = 6;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      const backoffMs =
+        Math.min(5000 * 2 ** attempt, 150000) + Math.floor(Math.random() * 1000);
+      log(
+        `[Overload] [${this.provider.displayName}] transient overload (HTTP) — patient retry ${attempt + 1}/${maxRetries} in ${(backoffMs / 1000).toFixed(1)}s`,
+        true // forceConsole — operational event, must be visible without --debug
+      );
+      await new Promise((r) => setTimeout(r, backoffMs));
+      try {
+        const retryResp = await doFetch();
+        if (retryResp.ok) return retryResp; // recovered
+        const retryText = await retryResp.clone().text();
+        if (!isTransientOverload(retryResp.status, retryText)) {
+          // Morphed into a non-transient error (e.g. 500) — stop retrying and
+          // let the caller surface the real error rather than masking it as 529.
+          return retryResp;
+        }
+        // still transient overload → keep backing off
+      } catch (e: any) {
+        log(
+          `[Overload] [${this.provider.displayName}] patient retry fetch failed: ${e?.message ?? e}`,
+          true
+        );
+        // transient network blip — keep retrying
+      }
+    }
+    return null; // exhausted — contention genuinely sustained
+  }
+
   async shutdown(): Promise<void> {
     if (this.provider.shutdown) {
       await this.provider.shutdown();
     }
   }
+}
+
+/**
+ * Detect whether an HTTP error represents a TRANSIENT provider overload
+ * (concurrency/burst limit, server-side) rather than a quota/usage wall.
+ *
+ * Used to surface the error as HTTP 529 (overloaded_error) instead of 429
+ * (rate_limit_error): clients read 429 as "quota reached" and stop the turn,
+ * whereas 529 means "temporarily overloaded, not your usage limit" and the
+ * client retries with its own backoff. GLM Coding (gc@) frequently delivers
+ * concurrency limits as a direct HTTP 429 whose body contains "overloaded" —
+ * this is NOT a quota wall, and in no-fallback mode there is no other provider
+ * to switch to, so the only useful outcome is a patient client retry. See the
+ * 2026-06-25 patient-backoff revision.
+ */
+function isTransientOverload(status: number, errorText: string): boolean {
+  const lower = errorText.toLowerCase();
+  if (status === 503) return true;
+  if (status === 429) {
+    return (
+      lower.includes("overloaded") ||
+      lower.includes("concurrency") ||
+      lower.includes("concurrent") ||
+      lower.includes("temporarily") ||
+      lower.includes("service may be") ||
+      lower.includes("try again later")
+    );
+  }
+  return false;
 }
 
 /**

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -303,6 +303,42 @@ export class ComposedHandler implements ModelHandler {
     // 4. Build request payload
     let requestPayload = adapter.buildPayload(claudeRequest, messages, tools);
 
+    // 4a. Fallback de-escalation system message (cost control).
+    // When a low-capability local model is reached ONLY via provider fallback —
+    // i.e. the primary model (GLM) failed on every upstream provider (zai, gc)
+    // — instruct the fallback model to behave conservatively: keep the session
+    // alive with simple, safe responses rather than attempting complex work the
+    // primary model would have to redo. This preserves the agent without burning
+    // metered tokens on ambitious-but-low-quality output.
+    //
+    // Gated on `fallbackMeta.attempts > 0` so DIRECT calls to the same model are
+    // unaffected (explicit qwen usage keeps full capability). Generalize the
+    // model match to a configurable set if more economy-fallback models are added.
+    if (
+      fallbackMeta &&
+      fallbackMeta.attempts > 0 &&
+      this.bareModelName === "qwen3.6-35b-a3b"
+    ) {
+      const FALLBACK_NOTICE =
+        "You are operating in TEMPORARY FALLBACK mode because the primary model is temporarily unavailable (the proxy fell back to you after all upstream providers failed). Behave conservatively: avoid complex multi-step reasoning, risky operations, destructive commands, and large refactors. Prioritize keeping the session alive with a safe, simple response. Do NOT attempt ambitious work — the primary model will resume shortly and any complex work you start would need to be redone. If a task is too complex for conservative execution, say so briefly rather than attempting it.";
+      const msgs = requestPayload.messages;
+      if (Array.isArray(msgs) && msgs.length > 0 && msgs[0]?.role === "system") {
+        const existing = msgs[0];
+        const existingText =
+          typeof existing.content === "string"
+            ? existing.content
+            : Array.isArray(existing.content)
+              ? existing.content.map((c: any) => c.text || "").join("\n")
+              : "";
+        msgs[0] = { ...existing, content: FALLBACK_NOTICE + "\n\n" + existingText };
+      } else if (Array.isArray(msgs)) {
+        msgs.unshift({ role: "system", content: FALLBACK_NOTICE });
+      }
+      logStderr(
+        `[Fallback] ${this.provider.displayName} reached as fallback (attempts=${fallbackMeta.attempts}) — injected conservative-mode system message`
+      );
+    }
+
     // 4b. Strip inline system messages from messages[] for Anthropic-transport providers.
     // Claude Code v2.1.153+ injects system messages inline (e.g. system-reminders).
     // Providers like Z.AI reject role:"system" in messages — only role:"user"/"assistant" accepted.

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -32,6 +32,7 @@ import { createResponsesStreamHandler } from "./shared/stream-parsers/openai-res
 import { createAnthropicPassthroughStream } from "./shared/stream-parsers/anthropic-sse.js";
 import { createOllamaJsonlStream } from "./shared/stream-parsers/ollama-jsonl.js";
 import { createGeminiSseStream } from "./shared/stream-parsers/gemini-sse.js";
+import { collectAnthropicSseToMessage } from "./shared/collect-sse-message.js";
 import { log, logStderr, logStructured, getLogLevel, truncateContent } from "../logger.js";
 import {
   describeImages,
@@ -819,7 +820,30 @@ export class ComposedHandler implements ModelHandler {
       }
     };
 
-    return this.handleStream(c, response, adapter, claudeRequest, toolNameMap, onStreamComplete);
+    const streamResponse = this.handleStream(
+      c,
+      response,
+      adapter,
+      claudeRequest,
+      toolNameMap,
+      onStreamComplete
+    );
+
+    // Non-streaming clients (notably Claude Code's `/compact`, and any caller that
+    // sent `stream: false`) expect a single JSON `message` body, NOT SSE. Every
+    // adapter drives the upstream provider in streaming mode and the whole pipeline
+    // emits Claude SSE, so we buffer that translated SSE back into one Anthropic
+    // message here. Mirrors request-logger.ts's `stream` definition exactly
+    // (`body.stream === true` ⇒ streaming; anything else ⇒ sync). NativeHandler
+    // already honors this for Anthropic-direct; this closes the same gap for every
+    // proxied/composed model. See collect-sse-message.ts.
+    const wantsStreaming = payload?.stream === true;
+    if (wantsStreaming) return streamResponse;
+
+    const message = await collectAnthropicSseToMessage(streamResponse, this.bareModelName);
+    return c.json(message, {
+      headers: { "Content-Type": "application/json", "anthropic-version": "2023-06-01" },
+    });
   }
 
   private handleStream(

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -41,6 +41,7 @@ import {
 import { reportError, classifyError } from "../telemetry.js";
 import { recordStats } from "../stats.js";
 import { wrapAnthropicError, ensureAnthropicErrorFormat } from "./shared/anthropic-error.js";
+import { peekStreamStart } from "./shared/stream-peek.js";
 
 function extractAuthHeaders(c: Context): VisionProxyAuthHeaders {
   const headers = c.req.header();
@@ -673,6 +674,108 @@ export class ComposedHandler implements ModelHandler {
           errorBody = { error: { type: "api_error", message: errorText } };
         }
         return c.json(ensureAnthropicErrorFormat(response.status, errorBody), response.status as any);
+      }
+    }
+
+    // ── In-stream rate-limit handling (temporize, then fall back) ──────────
+    // Some anthropic-sse providers (notably Z.AI) deliver their burst / RPM
+    // limit as HTTP 200 + an in-stream SSE error ([1302]) with no message
+    // envelope. That escapes `response.ok` above and FallbackHandler (both key
+    // off HTTP status), so it used to reach the client as a bare error and
+    // crash the turn. We peek the first bytes (the error arrives in 0-4ms, so a
+    // short window catches it without delaying slow-but-healthy big-context
+    // responses), temporize with a jittered backoff + retry the SAME provider
+    // (the sustained quota has headroom — only the instantaneous burst limit is
+    // hit), and on persistence return a 429 so FallbackHandler switches to the
+    // next provider in the chain (e.g. GLM Coding — a separate quota).
+    //
+    // The whole block is fail-open: peekStreamStart() only ever returns a
+    // usable Response, and any classification other than "rate-limit" flows
+    // straight through to handleStream() unchanged.
+    {
+      const peekFormat =
+        this.provider.overrideStreamFormat?.() ??
+        (this.explicitAdapter?.getStreamFormat() ?? this.modelAdapter?.getStreamFormat()) ??
+        this.getAdapter().getStreamFormat();
+      if (peekFormat === "anthropic-sse") {
+        const maxRlRetries = 3;
+        let rlAttempt = 0;
+        let peeked = await peekStreamStart(response);
+        while (peeked.cls === "rate-limit" && rlAttempt < maxRlRetries) {
+          // Jittered exponential backoff: 1s, 2s, 4s (+0-750ms). The cluster
+          // shares one key per provider, so jitter prevents synchronized
+          // retries from re-colliding on the burst limit.
+          const backoffMs =
+            Math.min(1000 * 2 ** rlAttempt, 8000) + Math.floor(Math.random() * 750);
+          log(
+            `[RateLimit] [${this.provider.displayName}] in-stream rate-limit (HTTP 200), temporizing — retry ${rlAttempt + 1}/${maxRlRetries} in ${(backoffMs / 1000).toFixed(1)}s${peeked.detail ? `: ${peeked.detail}` : ""}`,
+            true // forceConsole — operational event, must be visible without --debug
+          );
+          await new Promise((r) => setTimeout(r, backoffMs));
+          rlAttempt++;
+          let retryResp: Response;
+          try {
+            retryResp = this.provider.enqueueRequest
+              ? await this.provider.enqueueRequest(doFetch)
+              : await doFetch();
+          } catch (e: any) {
+            log(
+              `[RateLimit] [${this.provider.displayName}] rate-limit retry fetch failed: ${e?.message ?? e}`,
+              true
+            );
+            break;
+          }
+          if (!retryResp.ok) {
+            // A genuine HTTP error this time — surface it for fallback below.
+            response = retryResp;
+            peeked = { cls: "rate-limit", response: retryResp };
+            break;
+          }
+          response = retryResp;
+          peeked = await peekStreamStart(response);
+        }
+        if (peeked.cls === "rate-limit") {
+          log(
+            `[RateLimit] [${this.provider.displayName}] in-stream rate-limit persisted after ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} → returning 429 for cross-provider fallback`,
+            true // forceConsole — operational event, must be visible without --debug
+          );
+          try {
+            const { error_class, error_code } = classifyError(
+              new Error("in-stream rate limit"),
+              429,
+              peeked.detail
+            );
+            recordStats({
+              model_id: this.targetModel,
+              provider_name: this.provider.name,
+              stream_format: this.provider.streamFormat,
+              latency_ms: Math.round(performance.now() - startTime),
+              success: false,
+              http_status: 429,
+              error_class,
+              error_code,
+              token_strategy: this.options.tokenStrategy ?? "standard",
+              adapter_name: this.getActiveAdapterName(),
+              middleware_names: this.middlewareManager.getActiveNames(this.bareModelName),
+              fallback_used: fallbackMeta !== undefined,
+              fallback_chain: fallbackMeta?.chain,
+              fallback_attempts: fallbackMeta?.attempts,
+              invocation_mode: this.options.invocationMode ?? "auto-route",
+            });
+          } catch {
+            // Stats must never crash claudish
+          }
+          return c.json(
+            wrapAnthropicError(
+              429,
+              `${this.provider.displayName} rate limited (in-stream burst limit); ${rlAttempt} retr${rlAttempt === 1 ? "y" : "ies"} exhausted`,
+              "rate_limit_error"
+            ),
+            429 as any
+          );
+        }
+        // healthy or other-error → use the peeked (tee'd, full) stream below.
+        response = peeked.response;
       }
     }
 

--- a/packages/cli/src/handlers/fallback-handler.ts
+++ b/packages/cli/src/handlers/fallback-handler.ts
@@ -162,7 +162,10 @@ function isRetryableError(status: number, errorBody: string): boolean {
   if (status === 404) return true;
 
   // Rate limited — per-provider limit, a different provider may have capacity
-  if (status === 429) return true;
+  // 529 overloaded — provider-wide overload, the next provider may not be hit.
+  // Both are retryable → advance to the next candidate (no-op in single-candidate
+  // no-fallback mode, where this handler isn't constructed at all).
+  if (status === 429 || status === 529) return true;
 
   const lower = errorBody.toLowerCase();
 

--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -2,6 +2,7 @@ import type { Context } from "hono";
 import type { ModelHandler } from "./types.js";
 import { log, maskCredential } from "../logger.js";
 import { wrapAnthropicError } from "./shared/anthropic-error.js";
+import { createResponseCapture } from "./shared/response-capture.js";
 import {
   fetchMultiModelAdvice,
   findPendingAdvisorToolResults,
@@ -214,6 +215,7 @@ export class NativeHandler implements ModelHandler {
       // Handle streaming
       if (contentType.includes("text/event-stream")) {
         log("[Native] Streaming response detected");
+        const cap = createResponseCapture("native", target);
         return c.body(
           new ReadableStream({
             async start(controller) {
@@ -229,6 +231,7 @@ export class NativeHandler implements ModelHandler {
                   const { done, value } = await reader.read();
                   if (done) break;
 
+                  cap.tap(value);
                   controller.enqueue(value);
 
                   // Basic logging
@@ -242,9 +245,13 @@ export class NativeHandler implements ModelHandler {
                   for (const line of lines) if (line.trim()) eventLog += line + "\n";
                 }
                 if (eventLog) log(eventLog);
+                cap.note("reader done");
+                cap.done({ closed: true, reason: "done" });
                 controller.close();
               } catch (e) {
                 log(`[Native] Stream Error: ${e}`);
+                cap.note(`stream error: ${String(e)}`);
+                cap.done({ closed: true, reason: "error", err: String(e) });
                 controller.close();
               }
             },

--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -19,13 +19,14 @@ export class NativeHandler implements ModelHandler {
   private baseUrl: string;
   private advisorModels?: string[];
   private advisorCollector?: string | null;
+  private proxyKey?: string;
 
-  constructor(apiKey?: string, advisorModels?: string[], advisorCollector?: string | null) {
+  constructor(apiKey?: string, advisorModels?: string[], advisorCollector?: string | null, proxyKey?: string) {
     this.apiKey = apiKey;
-    // Always forward to real Anthropic API
     this.baseUrl = "https://api.anthropic.com";
     this.advisorModels = advisorModels;
     this.advisorCollector = advisorCollector;
+    this.proxyKey = proxyKey;
   }
 
   async handle(c: Context, payload: any): Promise<Response> {
@@ -145,13 +146,28 @@ export class NativeHandler implements ModelHandler {
       "anthropic-version": originalHeaders["anthropic-version"] || "2023-06-01",
     };
 
-    // Auth: pass through client headers, or fall back to stored API key
-    const clientAuth = originalHeaders["authorization"] || originalHeaders["x-api-key"];
-    if (clientAuth) {
-      if (originalHeaders["authorization"]) headers["authorization"] = originalHeaders["authorization"];
+    // Auth: pass through client headers unless they contain the proxy key,
+    // in which case fall back to stored API key (proxy key is for the local
+    // proxy only, not for api.anthropic.com).
+    const bearerToken = originalHeaders["authorization"]?.startsWith("Bearer ")
+      ? originalHeaders["authorization"].slice(7)
+      : originalHeaders["authorization"];
+    const clientAuthToken = originalHeaders["x-api-key"] || bearerToken;
+    const isProxyKey = this.proxyKey && clientAuthToken === this.proxyKey;
+
+    if (!isProxyKey && clientAuthToken) {
+      // Genuine client auth (OAuth token, API key) — pass through
       if (originalHeaders["x-api-key"]) headers["x-api-key"] = originalHeaders["x-api-key"];
+      else if (originalHeaders["authorization"]) headers["authorization"] = originalHeaders["authorization"];
     } else if (this.apiKey) {
-      headers["x-api-key"] = this.apiKey;
+      // Proxy key detected or no auth — use stored Anthropic key.
+      // OAuth tokens (sk-ant-oat01-) MUST be sent as authorization: Bearer,
+      // not as x-api-key — Anthropic rejects them in the latter header.
+      if (this.apiKey.startsWith("sk-ant-oat")) {
+        headers["authorization"] = `Bearer ${this.apiKey}`;
+      } else {
+        headers["x-api-key"] = this.apiKey;
+      }
     }
     if (originalHeaders["anthropic-beta"]) {
       const incomingBeta = originalHeaders["anthropic-beta"];

--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -140,56 +140,65 @@ export class NativeHandler implements ModelHandler {
     log(`Request body (Model: ${target}):`);
     log("=== End Request ===\n");
 
-    // Build headers - pass through auth headers exactly as received
+    // Transparent passthrough: forward ALL incoming headers to api.anthropic.com.
+    // This is essential for Max subscription auth — Claude Code sends internal
+    // headers that make the subscription work for Opus/Sonnet, and we must not
+    // drop any of them.
+    //
+    // Skip hop-by-hop headers and Hono-internal headers that must not be
+    // forwarded to an upstream API.
+    const HOP_BY_HOP = new Set([
+      "host", "connection", "keep-alive", "transfer-encoding", "te",
+      "trailer", "upgrade", "content-length",
+    ]);
     const headers: Record<string, string> = {
       "Content-Type": "application/json",
-      "anthropic-version": originalHeaders["anthropic-version"] || "2023-06-01",
     };
+    for (const [key, value] of Object.entries(originalHeaders)) {
+      if (HOP_BY_HOP.has(key.toLowerCase())) continue;
+      if (typeof value !== "string") continue;
+      headers[key] = value;
+    }
 
-    // Auth: pass through client headers unless they contain the proxy key,
-    // in which case fall back to stored API key (proxy key is for the local
-    // proxy only, not for api.anthropic.com).
-    const bearerToken = originalHeaders["authorization"]?.startsWith("Bearer ")
-      ? originalHeaders["authorization"].slice(7)
-      : originalHeaders["authorization"];
-    const clientAuthToken = originalHeaders["x-api-key"] || bearerToken;
-    const isProxyKey = this.proxyKey && clientAuthToken === this.proxyKey;
-
-    if (!isProxyKey && clientAuthToken) {
-      // Genuine client auth (OAuth token, API key) — pass through
-      if (originalHeaders["x-api-key"]) headers["x-api-key"] = originalHeaders["x-api-key"];
-      else if (originalHeaders["authorization"]) headers["authorization"] = originalHeaders["authorization"];
-    } else if (this.apiKey) {
-      // Proxy key detected or no auth — use stored Anthropic key.
-      // OAuth tokens (sk-ant-oat01-) MUST be sent as authorization: Bearer,
-      // not as x-api-key — Anthropic rejects them in the latter header.
-      if (this.apiKey.startsWith("sk-ant-oat")) {
-        headers["authorization"] = `Bearer ${this.apiKey}`;
-      } else {
-        headers["x-api-key"] = this.apiKey;
+    // Proxy key override: if the client auth matches our proxy key, replace it
+    // with the stored Anthropic key (proxy key is for the local proxy only,
+    // not for api.anthropic.com). When no proxy key is configured (pass-through
+    // mode), everything flows through unmodified.
+    if (this.proxyKey) {
+      const bearerToken = originalHeaders["authorization"]?.startsWith("Bearer ")
+        ? originalHeaders["authorization"].slice(7)
+        : originalHeaders["authorization"];
+      const clientAuthToken = originalHeaders["x-api-key"] || bearerToken;
+      if (clientAuthToken === this.proxyKey) {
+        // Strip proxy key from forwarded headers
+        delete headers["x-api-key"];
+        delete headers["authorization"];
+        if (this.apiKey) {
+          if (this.apiKey.startsWith("sk-ant-oat")) {
+            headers["authorization"] = `Bearer ${this.apiKey}`;
+          } else {
+            headers["x-api-key"] = this.apiKey;
+          }
+        }
       }
     }
-    if (originalHeaders["anthropic-beta"]) {
+
+    // Advisor-swap: strip advisor beta flag when we swapped the tool
+    if (advisorSwapped && originalHeaders["anthropic-beta"]) {
       const incomingBeta = originalHeaders["anthropic-beta"];
-      if (advisorSwapped) {
-        // When we swap the advisor tool we must also strip the matching beta
-        // flag; otherwise Anthropic rejects the request (beta enabled but no
-        // matching server tool declared).
-        const { stripped, changed } = stripAdvisorBeta(incomingBeta);
-        if (changed) {
-          log(
-            `[Native][advisor-swap] stripped advisor-tool beta; before=${incomingBeta} after=${stripped ?? "(empty)"}`
-          );
-          logAdvisorEvent(advisorCfg, {
-            kind: "beta_stripped",
-            before: incomingBeta,
-            after: stripped ?? "",
-          });
-        }
-        if (stripped) headers["anthropic-beta"] = stripped;
-      } else {
-        headers["anthropic-beta"] = incomingBeta;
+      const { stripped, changed } = stripAdvisorBeta(incomingBeta);
+      if (changed) {
+        log(
+          `[Native][advisor-swap] stripped advisor-tool beta; before=${incomingBeta} after=${stripped ?? "(empty)"}`
+        );
+        logAdvisorEvent(advisorCfg, {
+          kind: "beta_stripped",
+          before: incomingBeta,
+          after: stripped ?? "",
+        });
       }
+      if (stripped) headers["anthropic-beta"] = stripped;
+      else delete headers["anthropic-beta"];
     }
 
     // Execute fetch

--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -145,12 +145,13 @@ export class NativeHandler implements ModelHandler {
       "anthropic-version": originalHeaders["anthropic-version"] || "2023-06-01",
     };
 
-    // Pass through auth headers as-is
-    if (originalHeaders["authorization"]) {
-      headers["authorization"] = originalHeaders["authorization"];
-    }
-    if (originalHeaders["x-api-key"]) {
-      headers["x-api-key"] = originalHeaders["x-api-key"];
+    // Auth: pass through client headers, or fall back to stored API key
+    const clientAuth = originalHeaders["authorization"] || originalHeaders["x-api-key"];
+    if (clientAuth) {
+      if (originalHeaders["authorization"]) headers["authorization"] = originalHeaders["authorization"];
+      if (originalHeaders["x-api-key"]) headers["x-api-key"] = originalHeaders["x-api-key"];
+    } else if (this.apiKey) {
+      headers["x-api-key"] = this.apiKey;
     }
     if (originalHeaders["anthropic-beta"]) {
       const incomingBeta = originalHeaders["anthropic-beta"];

--- a/packages/cli/src/handlers/shared/collect-sse-message.test.ts
+++ b/packages/cli/src/handlers/shared/collect-sse-message.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "bun:test";
+import { collectAnthropicSseToMessage } from "./collect-sse-message.js";
+
+/** Build a Response whose body streams the given Claude-format SSE events. */
+function sseResponse(events: any[]): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const evt of events) {
+        controller.enqueue(
+          encoder.encode(`event: ${evt.type}\ndata: ${JSON.stringify(evt)}\n\n`)
+        );
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+describe("collectAnthropicSseToMessage", () => {
+  it("reconstructs a plain text message from SSE", async () => {
+    const res = sseResponse([
+      { type: "message_start", message: { id: "msg_abc", model: "glm-5.1", role: "assistant", usage: { input_tokens: 10, output_tokens: 0 } } },
+      { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "Hello " } },
+      { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "world" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 5 } },
+      { type: "message_stop" },
+    ]);
+
+    const msg = await collectAnthropicSseToMessage(res, "fallback-model");
+
+    expect(msg.type).toBe("message");
+    expect(msg.role).toBe("assistant");
+    expect(msg.id).toBe("msg_abc");
+    expect(msg.model).toBe("glm-5.1");
+    expect(msg.content).toEqual([{ type: "text", text: "Hello world" }]);
+    expect(msg.stop_reason).toBe("end_turn");
+    expect(msg.usage.input_tokens).toBe(10);
+    expect(msg.usage.output_tokens).toBe(5);
+  });
+
+  it("reconstructs a tool_use message with accumulated JSON input", async () => {
+    const res = sseResponse([
+      { type: "message_start", message: { id: "msg_t", model: "glm-5.1", role: "assistant" } },
+      { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "toolu_1", name: "Bash" } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '{"command":' } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: '"ls -la"}' } },
+      { type: "content_block_stop", index: 0 },
+      { type: "message_delta", delta: { stop_reason: "tool_use" } },
+      { type: "message_stop" },
+    ]);
+
+    const msg = await collectAnthropicSseToMessage(res, "fallback-model");
+
+    expect(msg.content).toEqual([
+      { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "ls -la" } },
+    ]);
+    expect(msg.stop_reason).toBe("tool_use");
+  });
+
+  it("infers stop_reason=tool_use when a tool block is present but no message_delta", async () => {
+    const res = sseResponse([
+      { type: "message_start", message: { id: "msg_x", model: "m", role: "assistant" } },
+      { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "t1", name: "Read" } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: "{}" } },
+      { type: "content_block_stop", index: 0 },
+    ]);
+
+    const msg = await collectAnthropicSseToMessage(res, "m");
+    expect(msg.stop_reason).toBe("tool_use");
+  });
+
+  it("preserves block order across mixed thinking + text + tool blocks", async () => {
+    const res = sseResponse([
+      { type: "message_start", message: { id: "msg_m", model: "m", role: "assistant" } },
+      { type: "content_block_start", index: 0, content_block: { type: "thinking", thinking: "" } },
+      { type: "content_block_delta", index: 0, delta: { type: "thinking_delta", thinking: "reasoning" } },
+      { type: "content_block_stop", index: 0 },
+      { type: "content_block_start", index: 1, content_block: { type: "text", text: "" } },
+      { type: "content_block_delta", index: 1, delta: { type: "text_delta", text: "answer" } },
+      { type: "content_block_stop", index: 1 },
+      { type: "message_delta", delta: { stop_reason: "end_turn" } },
+    ]);
+
+    const msg = await collectAnthropicSseToMessage(res, "m");
+    expect(msg.content[0]).toEqual({ type: "thinking", thinking: "reasoning" });
+    expect(msg.content[1]).toEqual({ type: "text", text: "answer" });
+  });
+
+  it("never throws on an empty body and yields a well-formed empty text message", async () => {
+    const res = new Response(null, { status: 200 });
+    const msg = await collectAnthropicSseToMessage(res, "fallback-model");
+
+    expect(msg.type).toBe("message");
+    expect(msg.model).toBe("fallback-model");
+    expect(msg.content).toEqual([{ type: "text", text: "" }]);
+    expect(msg.stop_reason).toBe("end_turn");
+  });
+
+  it("never throws on malformed SSE lines and skips them", async () => {
+    const encoder = new TextEncoder();
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: {not json}\n\n"));
+        controller.enqueue(encoder.encode("event: ping\ndata: {\"type\":\"ping\"}\n\n"));
+        controller.enqueue(
+          encoder.encode(
+            'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n'
+          )
+        );
+        controller.enqueue(
+          encoder.encode(
+            'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}\n\n'
+          )
+        );
+        controller.close();
+      },
+    });
+    const res = new Response(body, { status: 200 });
+
+    const msg = await collectAnthropicSseToMessage(res, "m");
+    expect(msg.content).toEqual([{ type: "text", text: "ok" }]);
+  });
+
+  it("falls back to {} for unparseable tool input JSON without throwing", async () => {
+    const res = sseResponse([
+      { type: "content_block_start", index: 0, content_block: { type: "tool_use", id: "t", name: "X" } },
+      { type: "content_block_delta", index: 0, delta: { type: "input_json_delta", partial_json: "{broken" } },
+      { type: "content_block_stop", index: 0 },
+    ]);
+    const msg = await collectAnthropicSseToMessage(res, "m");
+    expect(msg.content).toEqual([{ type: "tool_use", id: "t", name: "X", input: {} }]);
+  });
+});

--- a/packages/cli/src/handlers/shared/collect-sse-message.ts
+++ b/packages/cli/src/handlers/shared/collect-sse-message.ts
@@ -1,0 +1,186 @@
+/**
+ * Collect a translated Claude-format SSE stream into a single Anthropic
+ * `message` object for non-streaming clients.
+ *
+ * Why this exists: ComposedHandler always drives the upstream provider in
+ * streaming mode (every adapter's buildPayload hardcodes `stream: true`) and
+ * the whole translation pipeline emits Claude SSE. But a client that sent
+ * `stream: false` (notably Claude Code's `/compact`, and any non-streaming
+ * Anthropic API caller) expects a JSON `message` body with
+ * `Content-Type: application/json`, NOT `text/event-stream`. Returning SSE to
+ * such a client surfaces as `"API returned an empty or malformed response
+ * (HTTP 200)"`. This collector buffers the already-translated SSE and rebuilds
+ * the single message, so the existing pipeline (all stream formats, web-tool
+ * interception, empty-response classification) is reused verbatim.
+ *
+ * HARD constraint (never-hang priority): this function NEVER throws. A broken
+ * or empty stream degrades to a well-formed message with an empty text block,
+ * so the client always receives valid JSON and the agent never stalls.
+ */
+
+export interface CollectedMessage {
+  id: string;
+  type: "message";
+  role: "assistant";
+  model: string;
+  content: any[];
+  stop_reason: string | null;
+  stop_sequence: string | null;
+  usage: Record<string, any>;
+}
+
+interface BlockAccum {
+  type: string;
+  text?: string;
+  json?: string;
+  thinking?: string;
+  signature?: string;
+  id?: string;
+  name?: string;
+}
+
+/**
+ * Read a Claude-format SSE Response body and assemble the equivalent
+ * non-streaming Anthropic message. Always resolves (never rejects).
+ */
+export async function collectAnthropicSseToMessage(
+  response: Response,
+  fallbackModel: string
+): Promise<CollectedMessage> {
+  const message: CollectedMessage = {
+    id: `msg_${Date.now()}`,
+    type: "message",
+    role: "assistant",
+    model: fallbackModel,
+    content: [],
+    stop_reason: null,
+    stop_sequence: null,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  };
+
+  const blocks = new Map<number, BlockAccum>();
+  const getBlock = (idx: number): BlockAccum => {
+    let b = blocks.get(idx);
+    if (!b) {
+      b = { type: "text", text: "" };
+      blocks.set(idx, b);
+    }
+    return b;
+  };
+
+  try {
+    const reader = response.body?.getReader();
+    if (reader) {
+      const decoder = new TextDecoder();
+      let buffer = "";
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() || "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (!trimmed.startsWith("data:")) continue;
+          const dataStr = trimmed.slice(5).trim();
+          if (!dataStr || dataStr === "[DONE]") continue;
+          let evt: any;
+          try {
+            evt = JSON.parse(dataStr);
+          } catch {
+            continue;
+          }
+          switch (evt?.type) {
+            case "message_start": {
+              const m = evt.message;
+              if (m) {
+                if (m.id) message.id = m.id;
+                if (m.model) message.model = m.model;
+                if (m.role) message.role = m.role;
+                if (m.usage) message.usage = { ...message.usage, ...m.usage };
+              }
+              break;
+            }
+            case "content_block_start": {
+              const idx = evt.index ?? 0;
+              const cb = evt.content_block || {};
+              if (cb.type === "tool_use") {
+                blocks.set(idx, { type: "tool_use", id: cb.id, name: cb.name, json: "" });
+              } else if (cb.type === "thinking") {
+                blocks.set(idx, {
+                  type: "thinking",
+                  thinking: cb.thinking || "",
+                  signature: cb.signature,
+                });
+              } else if (cb.type === "text") {
+                blocks.set(idx, { type: "text", text: cb.text || "" });
+              } else {
+                blocks.set(idx, { type: cb.type || "text", text: cb.text || "" });
+              }
+              break;
+            }
+            case "content_block_delta": {
+              const idx = evt.index ?? 0;
+              const b = getBlock(idx);
+              const d = evt.delta || {};
+              if (d.type === "text_delta") b.text = (b.text || "") + (d.text || "");
+              else if (d.type === "input_json_delta") b.json = (b.json || "") + (d.partial_json || "");
+              else if (d.type === "thinking_delta") b.thinking = (b.thinking || "") + (d.thinking || "");
+              else if (d.type === "signature_delta")
+                b.signature = (b.signature || "") + (d.signature || "");
+              break;
+            }
+            case "message_delta": {
+              if (evt.delta) {
+                if (evt.delta.stop_reason !== undefined) message.stop_reason = evt.delta.stop_reason;
+                if (evt.delta.stop_sequence !== undefined)
+                  message.stop_sequence = evt.delta.stop_sequence;
+              }
+              if (evt.usage) message.usage = { ...message.usage, ...evt.usage };
+              break;
+            }
+            // content_block_stop / message_stop / ping carry no payload we need.
+            default:
+              break;
+          }
+        }
+      }
+    }
+  } catch {
+    // Never throw — fall through and emit whatever we accumulated.
+  }
+
+  // Assemble content blocks in ascending index order.
+  const content: any[] = [];
+  for (const idx of [...blocks.keys()].sort((a, b) => a - b)) {
+    const b = blocks.get(idx)!;
+    if (b.type === "text") {
+      if (b.text) content.push({ type: "text", text: b.text });
+    } else if (b.type === "thinking") {
+      const block: any = { type: "thinking", thinking: b.thinking || "" };
+      if (b.signature) block.signature = b.signature;
+      content.push(block);
+    } else if (b.type === "tool_use") {
+      let input: any = {};
+      if (b.json) {
+        try {
+          input = JSON.parse(b.json);
+        } catch {
+          input = {};
+        }
+      }
+      content.push({ type: "tool_use", id: b.id, name: b.name, input });
+    }
+  }
+
+  // A well-formed message must always carry at least one content block.
+  if (content.length === 0) content.push({ type: "text", text: "" });
+  message.content = content;
+
+  if (message.stop_reason == null) {
+    message.stop_reason = content.some((b) => b.type === "tool_use") ? "tool_use" : "end_turn";
+  }
+
+  return message;
+}

--- a/packages/cli/src/handlers/shared/format/openai-messages.ts
+++ b/packages/cli/src/handlers/shared/format/openai-messages.ts
@@ -39,6 +39,22 @@ export function convertMessagesToOpenAI(
     for (const msg of req.messages) {
       if (msg.role === "user") processUserMessage(msg, messages, simpleFormat);
       else if (msg.role === "assistant") processAssistantMessage(msg, messages, simpleFormat);
+      else if (msg.role === "system") {
+        // Inline system messages (Claude Code v2.1.153+): merge into the system prompt
+        // or prepend as a user message if no system prompt exists.
+        const content = typeof msg.content === "string"
+          ? msg.content
+          : Array.isArray(msg.content)
+            ? msg.content.map((c: any) => c.text || "").join("\n")
+            : "";
+        if (content) {
+          if (messages.length > 0 && messages[0].role === "system") {
+            messages[0].content += "\n\n" + content;
+          } else {
+            messages.unshift({ role: "system", content });
+          }
+        }
+      }
     }
   }
 

--- a/packages/cli/src/handlers/shared/mcp-searxng-client.test.ts
+++ b/packages/cli/src/handlers/shared/mcp-searxng-client.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for the MCP streamable-http client (mcp-searxng-client.ts).
+ *
+ * Uses a local Bun.serve mock that simulates the TBXark mcp-proxy +
+ * mcp-searxng backend: JSON and SSE response formats, session handshake,
+ * auth header check, error shapes, and timeouts.
+ *
+ * The hard contract under test: callMcpTool NEVER throws — every failure
+ * mode resolves to { ok: false, error }.
+ */
+
+import { describe, test, expect, beforeEach, afterAll } from "bun:test";
+import {
+  callMcpTool,
+  mcpWebSearch,
+  mcpUrlRead,
+  isMcpSearxngAvailable,
+  _resetMcpClientState,
+} from "./mcp-searxng-client.js";
+
+type MockBehavior =
+  | "json-ok"
+  | "sse-ok"
+  | "session-required"
+  | "http-500"
+  | "tool-error"
+  | "hang"
+  | "rpc-error";
+
+let behavior: MockBehavior = "json-ok";
+let sawAuthHeader: string | null = null;
+let initializeCount = 0;
+
+function rpcResult(id: any, text: string, isError = false) {
+  return JSON.stringify({
+    jsonrpc: "2.0",
+    id,
+    result: { content: [{ type: "text", text }], isError },
+  });
+}
+
+const server = Bun.serve({
+  port: 0,
+  async fetch(req) {
+    sawAuthHeader = req.headers.get("authorization");
+    const body = (await req.json().catch(() => ({}))) as any;
+    const { id, method } = body;
+
+    if (method === "notifications/initialized") {
+      return new Response(null, { status: 202 });
+    }
+
+    if (method === "initialize") {
+      initializeCount++;
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id,
+          result: { protocolVersion: "2025-03-26", capabilities: {}, serverInfo: { name: "mock" } },
+        }),
+        { headers: { "Content-Type": "application/json", "mcp-session-id": "mock-session-123" } }
+      );
+    }
+
+    // tools/call
+    switch (behavior) {
+      case "json-ok":
+        return new Response(rpcResult(id, "mock search results"), {
+          headers: { "Content-Type": "application/json" },
+        });
+      case "sse-ok": {
+        const frame = `event: message\ndata: ${rpcResult(id, "mock sse results")}\n\n`;
+        return new Response(frame, { headers: { "Content-Type": "text/event-stream" } });
+      }
+      case "session-required": {
+        const sid = req.headers.get("mcp-session-id");
+        if (sid !== "mock-session-123") {
+          return new Response("Bad Request: no session", { status: 400 });
+        }
+        return new Response(rpcResult(id, "session-bound results"), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      case "http-500":
+        return new Response("Internal Server Error", { status: 500 });
+      case "tool-error":
+        return new Response(rpcResult(id, "fetch failed: 403 Forbidden", true), {
+          headers: { "Content-Type": "application/json" },
+        });
+      case "rpc-error":
+        return new Response(
+          JSON.stringify({ jsonrpc: "2.0", id, error: { code: -32602, message: "Unknown tool" } }),
+          { headers: { "Content-Type": "application/json" } }
+        );
+      case "hang":
+        await new Promise((r) => setTimeout(r, 10_000));
+        return new Response(rpcResult(id, "too late"), {
+          headers: { "Content-Type": "application/json" },
+        });
+    }
+  },
+});
+
+const MOCK_URL = `http://localhost:${server.port}/searxng/mcp`;
+
+beforeEach(() => {
+  _resetMcpClientState();
+  process.env.SEARXNG_MCP_URL = MOCK_URL;
+  process.env.MCP_AUTH = "test-token";
+  behavior = "json-ok";
+  sawAuthHeader = null;
+  initializeCount = 0;
+});
+
+afterAll(() => {
+  server.stop(true);
+  delete process.env.SEARXNG_MCP_URL;
+  delete process.env.MCP_AUTH;
+});
+
+describe("mcp-searxng-client", () => {
+  test("not configured → ok:false without any network call", async () => {
+    delete process.env.SEARXNG_MCP_URL;
+    expect(isMcpSearxngAvailable()).toBe(false);
+    const res = await callMcpTool("searxng_web_search", { query: "x" }, 1000);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain("not configured");
+  });
+
+  test("JSON response → ok:true with text, sends Bearer auth", async () => {
+    const res = await mcpWebSearch("docker compose", 3000);
+    expect(res).toEqual({ ok: true, text: "mock search results" });
+    expect(sawAuthHeader).toBe("Bearer test-token");
+  });
+
+  test("SSE response format is parsed", async () => {
+    behavior = "sse-ok";
+    const res = await callMcpTool("searxng_web_search", { query: "x" }, 3000);
+    expect(res).toEqual({ ok: true, text: "mock sse results" });
+  });
+
+  test("session-required: HTTP 400 triggers initialize handshake then retry succeeds", async () => {
+    behavior = "session-required";
+    const res = await callMcpTool("web_url_read", { url: "https://example.com" }, 5000);
+    expect(res).toEqual({ ok: true, text: "session-bound results" });
+    expect(initializeCount).toBe(1);
+  });
+
+  test("HTTP 500 → ok:false, never throws", async () => {
+    behavior = "http-500";
+    const res = await callMcpTool("searxng_web_search", { query: "x" }, 3000);
+    expect(res.ok).toBe(false);
+  });
+
+  test("tool result with isError → ok:false carrying the error text", async () => {
+    behavior = "tool-error";
+    const res = await mcpUrlRead("https://blocked.example.com", 3000);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain("403");
+  });
+
+  test("JSON-RPC error object → ok:false with message", async () => {
+    behavior = "rpc-error";
+    const res = await callMcpTool("nonexistent_tool", {}, 3000);
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.error).toContain("Unknown tool");
+  });
+
+  test("deadline: hung server → ok:false within budget, never throws", async () => {
+    behavior = "hang";
+    const started = Date.now();
+    const res = await callMcpTool("searxng_web_search", { query: "x" }, 500);
+    expect(res.ok).toBe(false);
+    expect(Date.now() - started).toBeLessThan(3000);
+  });
+});

--- a/packages/cli/src/handlers/shared/mcp-searxng-client.ts
+++ b/packages/cli/src/handlers/shared/mcp-searxng-client.ts
@@ -1,0 +1,241 @@
+/**
+ * Minimal MCP streamable-http client for the SearXNG MCP server.
+ *
+ * The cluster exposes the mcp-searxng server (ihor-sokoliuk/mcp-searxng)
+ * via a TBXark mcp-proxy in streamable-http mode, e.g.:
+ *   https://mcp-tools.myia.io/searxng/mcp
+ *
+ * This is a plain JSON-RPC-over-HTTP client — no MCP SDK, no stdio spawn.
+ * It exists so executeWebSearch/executeWebFetch can call the MCP tools
+ * (searxng_web_search, web_url_read) from the synchronous SSE-stream
+ * context with a strict deadline and graceful failure.
+ *
+ * HARD CONSTRAINT: nothing in this module may throw. Every entry point
+ * returns { ok: true, text } | { ok: false, error }. A failed web call
+ * must never crash a stream or block an agent turn.
+ */
+
+import { log } from "../../logger.js";
+
+// Env is read at call time (not module load) so tests and late-injected
+// container env can configure the client without import-order concerns.
+function mcpUrl(): string {
+  return process.env.SEARXNG_MCP_URL || "";
+}
+function mcpToken(): string {
+  return process.env.MCP_AUTH || process.env.SEARXNG_MCP_TOKEN || "";
+}
+
+/** Whether the MCP route is configured. When false, callers skip straight to their fallbacks. */
+export function isMcpSearxngAvailable(): boolean {
+  return !!mcpUrl();
+}
+
+export type McpToolResult = { ok: true; text: string } | { ok: false; error: string };
+
+/** Session ID negotiated via the initialize handshake, when the server requires one. */
+let sessionId: string | null = null;
+let nextRequestId = 1;
+
+function baseHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    Accept: "application/json, text/event-stream",
+  };
+  const token = mcpToken();
+  if (token) headers["Authorization"] = `Bearer ${token}`;
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  return headers;
+}
+
+/**
+ * Parse a streamable-http response body into the JSON-RPC response object.
+ * Servers may answer with application/json (single object) or
+ * text/event-stream (SSE frames whose data lines carry JSON-RPC messages).
+ */
+async function parseRpcResponse(response: Response, requestId: number): Promise<any> {
+  const contentType = response.headers.get("content-type") || "";
+
+  if (contentType.includes("text/event-stream")) {
+    const body = await response.text();
+    for (const line of body.split("\n")) {
+      if (!line.startsWith("data:")) continue;
+      const payload = line.slice(5).trim();
+      if (!payload || payload === "[DONE]") continue;
+      try {
+        const msg = JSON.parse(payload);
+        if (msg.id === requestId && (msg.result !== undefined || msg.error !== undefined)) {
+          return msg;
+        }
+      } catch {
+        // Non-JSON SSE data line — skip
+      }
+    }
+    throw new Error("no JSON-RPC response found in SSE body");
+  }
+
+  return await response.json();
+}
+
+/**
+ * Perform the MCP initialize handshake and cache the session ID.
+ * Returns true on success.
+ */
+async function initializeSession(deadlineMs: number): Promise<boolean> {
+  try {
+    const id = nextRequestId++;
+    const url = mcpUrl();
+    const response = await fetch(url, {
+      method: "POST",
+      signal: AbortSignal.timeout(deadlineMs),
+      headers: baseHeaders(),
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id,
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-03-26",
+          capabilities: {},
+          clientInfo: { name: "claudish", version: "1.0" },
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      log(`[MCP-SearXNG] initialize failed: HTTP ${response.status}`);
+      return false;
+    }
+
+    const sid = response.headers.get("mcp-session-id");
+    if (sid) sessionId = sid;
+
+    const msg = await parseRpcResponse(response, id);
+    if (msg.error) {
+      log(`[MCP-SearXNG] initialize error: ${JSON.stringify(msg.error)}`);
+      return false;
+    }
+
+    // Per spec, the client must send notifications/initialized after initialize.
+    // Fire-and-forget: some proxies don't require it, and a failure here is non-fatal.
+    fetch(url, {
+      method: "POST",
+      signal: AbortSignal.timeout(3000),
+      headers: baseHeaders(),
+      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized" }),
+    }).catch(() => {});
+
+    log(`[MCP-SearXNG] session initialized${sessionId ? ` (sid=${sessionId.slice(0, 8)}…)` : " (stateless)"}`);
+    return true;
+  } catch (err: any) {
+    log(`[MCP-SearXNG] initialize error: ${err.message}`);
+    return false;
+  }
+}
+
+/**
+ * Extract the text content from an MCP tools/call result.
+ * Result shape: { content: [{ type: "text", text: "..." }, ...], isError?: boolean }
+ */
+function extractResultText(result: any): McpToolResult {
+  const blocks = Array.isArray(result?.content) ? result.content : [];
+  const text = blocks
+    .filter((b: any) => b.type === "text" && typeof b.text === "string")
+    .map((b: any) => b.text)
+    .join("\n");
+
+  if (result?.isError) {
+    return { ok: false, error: text || "MCP tool returned an error with no message" };
+  }
+  if (!text) {
+    return { ok: false, error: "MCP tool returned empty content" };
+  }
+  return { ok: true, text };
+}
+
+async function postToolCall(name: string, args: Record<string, any>, deadlineMs: number): Promise<{ status: number; msg?: any }> {
+  const id = nextRequestId++;
+  const response = await fetch(mcpUrl(), {
+    method: "POST",
+    signal: AbortSignal.timeout(deadlineMs),
+    headers: baseHeaders(),
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: "tools/call",
+      params: { name, arguments: args },
+    }),
+  });
+
+  if (!response.ok) {
+    // Drain body so the connection can be reused
+    await response.text().catch(() => {});
+    return { status: response.status };
+  }
+
+  return { status: response.status, msg: await parseRpcResponse(response, id) };
+}
+
+/**
+ * Call an MCP tool on the SearXNG server. Non-throwing, deadline-bounded.
+ *
+ * Tries a direct tools/call first (many proxies are stateless). If the server
+ * rejects it in a way that suggests a missing session (HTTP 400/404, or a
+ * "session" JSON-RPC error), performs the initialize handshake once and retries.
+ */
+export async function callMcpTool(
+  name: string,
+  args: Record<string, any>,
+  deadlineMs: number
+): Promise<McpToolResult> {
+  if (!isMcpSearxngAvailable()) {
+    return { ok: false, error: "SEARXNG_MCP_URL not configured" };
+  }
+
+  const startedAt = Date.now();
+  try {
+    let { status, msg } = await postToolCall(name, args, deadlineMs);
+
+    const needsSession =
+      (status === 400 || status === 404) ||
+      (msg?.error && /session/i.test(String(msg.error.message || "")));
+
+    if (needsSession) {
+      sessionId = null;
+      const initialized = await initializeSession(Math.min(deadlineMs, 5000));
+      if (!initialized) {
+        return { ok: false, error: `MCP session init failed (after HTTP ${status})` };
+      }
+      ({ status, msg } = await postToolCall(name, args, deadlineMs));
+    }
+
+    if (!msg) {
+      return { ok: false, error: `MCP endpoint returned HTTP ${status}` };
+    }
+    if (msg.error) {
+      return { ok: false, error: `MCP error: ${msg.error.message || JSON.stringify(msg.error)}` };
+    }
+
+    const result = extractResultText(msg.result);
+    log(`[MCP-SearXNG] tools/call ${name} ${Date.now() - startedAt}ms ok=${result.ok}`);
+    return result;
+  } catch (err: any) {
+    log(`[MCP-SearXNG] tools/call ${name} ${Date.now() - startedAt}ms failed: ${err.message}`);
+    return { ok: false, error: err.message };
+  }
+}
+
+/** Search the web via the MCP searxng_web_search tool. */
+export async function mcpWebSearch(query: string, deadlineMs = 5000): Promise<McpToolResult> {
+  return callMcpTool("searxng_web_search", { query }, deadlineMs);
+}
+
+/** Read a URL via the MCP web_url_read tool (server-side fetch + markdown conversion). */
+export async function mcpUrlRead(url: string, deadlineMs = 12_000): Promise<McpToolResult> {
+  return callMcpTool("web_url_read", { url }, deadlineMs);
+}
+
+/** Test hook: reset module state between tests. */
+export function _resetMcpClientState(): void {
+  sessionId = null;
+  nextRequestId = 1;
+}

--- a/packages/cli/src/handlers/shared/response-capture.ts
+++ b/packages/cli/src/handlers/shared/response-capture.ts
@@ -1,0 +1,92 @@
+/**
+ * Response-side SSE capture (temporary diagnostic — gated by CLAUDISH_CAPTURE_DIR).
+ *
+ * Pairs with the request-body capture in fork/middleware/request-logger.ts so we
+ * can inspect the FULL request→response of a hung/blocked stream offline. Every
+ * stream parser (anthropic-sse, openai-sse, native passthrough) taps its outgoing
+ * bytes here. At stream close we write the accumulated SSE to a `resp-*.sse` file
+ * and emit a one-line stdout marker visible in `docker logs`.
+ *
+ * No-op when CLAUDISH_CAPTURE_DIR is unset, so this is invisible in normal operation.
+ *
+ * The stdout marker is the key real-time signal: if a `[Request]` line appears in
+ * docker logs but its matching `[resp ...]` marker never does, the stream hung
+ * server-side (the parser loop never reached close).
+ */
+
+export interface ResponseCapture {
+  /** Tap outgoing bytes (raw Uint8Array or a pre-encoded SSE string). */
+  tap(chunk: Uint8Array | string): void;
+  /** Record a lifecycle note (e.g. "message_stop", "synthetic-finalize", "error"). */
+  note(label: string): void;
+  /** Flush to disk + emit stdout marker. Idempotent. */
+  done(extra?: Record<string, unknown>): void;
+}
+
+const NOOP: ResponseCapture = {
+  tap() {},
+  note() {},
+  done() {},
+};
+
+/**
+ * Create a response capture for one stream. `label` identifies the parser
+ * (e.g. "anthropic", "openai", "native"). Returns a no-op when capture is off.
+ */
+export function createResponseCapture(label: string, model: string): ResponseCapture {
+  const captureDir = process.env.CLAUDISH_CAPTURE_DIR;
+  if (!captureDir) return NOOP;
+
+  const decoder = new TextDecoder();
+  let sse = "";
+  const notes: string[] = [];
+  let events = 0;
+  let finished = false;
+  const startedAt = Date.now();
+
+  // Correlate with the request counter from request-logger (shared globalThis.__capN).
+  const g = globalThis as Record<string, unknown>;
+  const reqN = (g.__capN as number) ?? 0;
+
+  return {
+    tap(chunk: Uint8Array | string) {
+      const text = typeof chunk === "string" ? chunk : decoder.decode(chunk, { stream: true });
+      sse += text;
+      // Count SSE events (data: lines) for a quick at-a-glance summary.
+      let idx = 0;
+      while ((idx = text.indexOf("\ndata:", idx)) !== -1) {
+        events++;
+        idx += 6;
+      }
+    },
+    note(noteLabel: string) {
+      notes.push(`+${Date.now() - startedAt}ms ${noteLabel}`);
+    },
+    done(extra?: Record<string, unknown>) {
+      if (finished) return;
+      finished = true;
+      try {
+        const fs = require("fs");
+        fs.mkdirSync(captureDir, { recursive: true });
+        const ts = new Date().toISOString().replace(/[:.]/g, "-");
+        const safeModel = String(model).replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 40);
+        const file = `${captureDir}/resp-${process.pid}-r${String(reqN).padStart(4, "0")}-${ts}-${label}-${safeModel}.sse`;
+        const header =
+          `# claudish response capture\n` +
+          `# parser=${label} model=${model} reqN=${reqN} pid=${process.pid}\n` +
+          `# elapsed_ms=${Date.now() - startedAt} events~=${events}\n` +
+          `# notes=${notes.join(" | ")}\n` +
+          (extra ? `# extra=${JSON.stringify(extra)}\n` : "") +
+          `# ${"=".repeat(60)}\n\n`;
+        fs.writeFileSync(file, header + sse);
+        const stopReason = extra?.stop_reason ?? "?";
+        const closed = extra?.closed ?? "?";
+        process.stdout.write(
+          `  [resp] ${label} model=${model} reqN=${reqN} events~=${events} bytes=${sse.length} closed=${closed} stop=${stopReason} ${Date.now() - startedAt}ms -> ${file}\n`
+        );
+      } catch (e) {
+        process.stdout.write(`  [resp] capture error: ${String(e)}\n`);
+      }
+    },
+  };
+}

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -69,6 +69,8 @@ export function createAnthropicPassthroughStream(
           let toolUseBlocks = 0;
           let stopReason: string | null = null;
           let sawMessageStop = false;
+          let sawMessageStart = false;
+          let suppressedServerTools = 0;
 
           // Thinking-block filtering state
           let insideThinkingBlock = false;
@@ -283,12 +285,29 @@ export function createAnthropicPassthroughStream(
                         `[AnthropicSSE] Text chunk: "${txt.substring(0, 30).replace(/\n/g, "\\n")}" (${txt.length} chars)`
                       );
                     }
-                    if (
-                      data.type === "content_block_start" &&
-                      data.content_block?.type === "tool_use"
-                    ) {
-                      toolUseBlocks++;
-                      log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
+                                        if (
+                                          data.type === "content_block_start" &&
+                                          data.content_block?.type === "tool_use"
+                                        ) {
+                                          toolUseBlocks++;
+                                          log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
+                                        }
+                                        // Suppress server_tool_use blocks (Z.AI built-in tools)
+                                        if (
+                                          data.type === "content_block_start" &&
+                                          data.content_block?.type === "server_tool_use"
+                                        ) {
+                                          suppressedServerTools++;
+                                          log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
+                                          continue;
+                                        }
+                                        if (data.type === "content_block_stop" && suppressedServerTools > 0) {
+                                          suppressedServerTools--;
+                                          continue;
+                                        }
+                                        if (data.type === "message_start") {
+                                          sawMessageStart = true;
+
                     }
                     if (data.type === "message_delta" && data.delta?.stop_reason) {
                       stopReason = data.delta.stop_reason;
@@ -337,6 +356,9 @@ export function createAnthropicPassthroughStream(
                   if (data.type === "message_delta" && data.delta?.stop_reason) {
                     stopReason = data.delta.stop_reason;
                   }
+                  if (data.type === "message_start") {
+                    sawMessageStart = true;
+                  }
                   if (data.type === "message_stop") {
                     sawMessageStop = true;
                   }
@@ -360,6 +382,25 @@ export function createAnthropicPassthroughStream(
           // reports "API returned an empty or malformed response (HTTP 200)".
           if (!isClosed && !sawMessageStop) {
             log(`[AnthropicSSE] Stream ended without message_stop (stopReason=${stopReason}) — emitting synthetic finalization`);
+            if (!sawMessageStart) {
+              const synthId = `msg_${Date.now()}`;
+              controller.enqueue(encoder.encode(
+                "event: message_start\n" +
+                `data: {"type":"message_start","message":{"id":"${synthId}","type":"message","role":"assistant","model":"${opts.modelName}","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":${inputTokens},"output_tokens":${outputTokens}}}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_start\n" +
+                `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_delta\n" +
+                `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"[Error: The model returned an empty response. Try compacting the conversation or reducing the context size.]"}}\n\n`
+              ));
+              controller.enqueue(encoder.encode(
+                "event: content_block_stop\n" +
+                `data: {"type":"content_block_stop","index":0}\n\n`
+              ));
+            }
             if (!stopReason) {
               controller.enqueue(encoder.encode(
                 "event: message_delta\n" +

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -79,7 +79,6 @@ export function createAnthropicPassthroughStream(
           let stopReason: string | null = null;
           let sawMessageStop = false;
           let sawMessageStart = false;
-          let suppressedServerTools = 0;
 
           // Thinking-block filtering state
           let insideThinkingBlock = false;
@@ -359,18 +358,17 @@ export function createAnthropicPassthroughStream(
                       toolUseBlocks++;
                       log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
                     }
-                    // Suppress server_tool_use blocks (Z.AI built-in tools)
+                    // Z.AI built-in tools (server_tool_use): pass through instead of suppressing.
+                    // Previous suppression caused index desync — the matching tool_result block
+                    // would arrive without its tool_use, breaking the stream for the client.
+                    // Claude Code handles server_tool_use natively. If the built-in tool errors
+                    // (e.g. file:// URI to analyze_image), the error comes back as tool_result
+                    // text and the model continues its turn naturally.
                     if (
                       data.type === "content_block_start" &&
                       data.content_block?.type === "server_tool_use"
                     ) {
-                      suppressedServerTools++;
-                      log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
-                      continue;
-                    }
-                    if (data.type === "content_block_stop" && suppressedServerTools > 0) {
-                      suppressedServerTools--;
-                      continue;
+                      log(`[AnthropicSSE] server_tool_use at index ${data.index}: ${data.content_block.name || "(unnamed)"}`);
                     }
                     if (data.type === "message_start") {
                       sawMessageStart = true;

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -102,6 +102,90 @@ export function createAnthropicPassthroughStream(
             if (idx > highestSeenIndex) highestSeenIndex = idx;
           };
 
+          // ── Graceful in-stream error finalization ─────────────────────
+          // Some anthropic-compat providers (Z.AI, MiniMax, Kimi) return HTTP 200
+          // and then inject an SSE error (e.g. Z.AI's [1302] rate limit) with NO
+          // valid message envelope. Forwarding a bare `event: error` makes Claude
+          // Code report "empty or malformed response (HTTP 200)" and crash the turn.
+          // Instead we ALWAYS emit a valid, terminal Claude message so the client
+          // ends the turn cleanly (no crash, no corruption):
+          //   - before any content → synthetic message_start + short notice + stop
+          //   - mid-stream         → close the open block + message_delta + stop
+          // ComposedHandler's peek/retry catches most start-of-stream rate limits
+          // before they reach here (it retries + falls back to a second provider);
+          // this is the last-resort safety net for whatever still slips through.
+          const finalizeWithError = (errMsg: string, path: string) => {
+            if (!isClosed) {
+              if (!sawMessageStart) {
+                const isRateLimit =
+                  /rate.?limit|\b1302\b|\b429\b|too many requests|overloaded/i.test(errMsg);
+                const notice = isRateLimit
+                  ? "[The model provider is rate limited right now. The proxy retried and exhausted fallback capacity — please try again in a moment.]"
+                  : `[Upstream provider error: ${errMsg}]`;
+                const synthId = `msg_${Date.now()}`;
+                controller.enqueue(
+                  encoder.encode(
+                    "event: message_start\n" +
+                      `data: {"type":"message_start","message":{"id":"${synthId}","type":"message","role":"assistant","model":"${opts.modelName}","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":0,"output_tokens":0}}}\n\n`
+                  )
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    "event: content_block_start\n" +
+                      `data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n`
+                  )
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    "event: content_block_delta\n" +
+                      `data: ${JSON.stringify({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text: notice } })}\n\n`
+                  )
+                );
+                controller.enqueue(
+                  encoder.encode(
+                    "event: content_block_stop\n" + `data: {"type":"content_block_stop","index":0}\n\n`
+                  )
+                );
+              } else if (highestSeenIndex >= 0) {
+                // Mid-stream: close whatever content block was open when the error hit,
+                // otherwise the client sees an unterminated block.
+                controller.enqueue(
+                  encoder.encode(
+                    "event: content_block_stop\n" +
+                      `data: {"type":"content_block_stop","index":${highestSeenIndex}}\n\n`
+                  )
+                );
+              }
+              controller.enqueue(
+                encoder.encode(
+                  "event: message_delta\n" +
+                    `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":0}}\n\n`
+                )
+              );
+              controller.enqueue(
+                encoder.encode("event: message_stop\n" + `data: {"type":"message_stop"}\n\n`)
+              );
+            }
+            isClosed = true;
+            if (pingInterval) {
+              clearInterval(pingInterval);
+              pingInterval = null;
+            }
+            cap.note(`in-stream-error->graceful: ${errMsg.slice(0, 80)}`);
+            cap.done({ closed: true, stop_reason: "error-graceful", path });
+            // Surface to stdout (visible without --debug) so a mid-stream burst
+            // that bypassed the start-of-stream peek is still observable live.
+            log(
+              `[RateLimit] safety-net finalized stream gracefully (${path}): ${errMsg.slice(0, 120)}`,
+              true
+            );
+            try {
+              controller.close();
+            } catch {
+              // already closed
+            }
+          };
+
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
@@ -125,22 +209,7 @@ export function createAnthropicPassthroughStream(
                   if (data.error) {
                     const errMsg = data.error.message || JSON.stringify(data.error);
                     log(`[AnthropicSSE] In-stream error detected: ${errMsg}`);
-                    if (!isClosed) {
-                      controller.enqueue(encoder.encode(
-                        `event: error\ndata: ${JSON.stringify({
-                          type: "error",
-                          error: { type: "api_error", message: errMsg },
-                        })}\n\n`
-                      ));
-                      isClosed = true;
-                      if (pingInterval) {
-                        clearInterval(pingInterval);
-                        pingInterval = null;
-                      }
-                      cap.note("in-stream-error(filtered)");
-                      cap.done({ closed: true, stop_reason: "error", path: "in-stream-error-filtered" });
-                      controller.close();
-                    }
+                    finalizeWithError(errMsg, "in-stream-error-filtered");
                     return; // stop processing further lines
                   }
 
@@ -220,22 +289,7 @@ export function createAnthropicPassthroughStream(
                     if (data.error) {
                       const errMsg = data.error.message || JSON.stringify(data.error);
                       log(`[AnthropicSSE] In-stream error detected: ${errMsg}`);
-                      if (!isClosed) {
-                        controller.enqueue(encoder.encode(
-                          `event: error\ndata: ${JSON.stringify({
-                            type: "error",
-                            error: { type: "api_error", message: errMsg },
-                          })}\n\n`
-                        ));
-                        isClosed = true;
-                        if (pingInterval) {
-                          clearInterval(pingInterval);
-                          pingInterval = null;
-                        }
-                        cap.note("in-stream-error");
-                        cap.done({ closed: true, stop_reason: "error", path: "in-stream-error" });
-                        controller.close();
-                      }
+                      finalizeWithError(errMsg, "in-stream-error");
                       return; // stop processing further lines
                     }
 
@@ -298,29 +352,28 @@ export function createAnthropicPassthroughStream(
                         `[AnthropicSSE] Text chunk: "${txt.substring(0, 30).replace(/\n/g, "\\n")}" (${txt.length} chars)`
                       );
                     }
-                                        if (
-                                          data.type === "content_block_start" &&
-                                          data.content_block?.type === "tool_use"
-                                        ) {
-                                          toolUseBlocks++;
-                                          log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
-                                        }
-                                        // Suppress server_tool_use blocks (Z.AI built-in tools)
-                                        if (
-                                          data.type === "content_block_start" &&
-                                          data.content_block?.type === "server_tool_use"
-                                        ) {
-                                          suppressedServerTools++;
-                                          log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
-                                          continue;
-                                        }
-                                        if (data.type === "content_block_stop" && suppressedServerTools > 0) {
-                                          suppressedServerTools--;
-                                          continue;
-                                        }
-                                        if (data.type === "message_start") {
-                                          sawMessageStart = true;
-
+                    if (
+                      data.type === "content_block_start" &&
+                      data.content_block?.type === "tool_use"
+                    ) {
+                      toolUseBlocks++;
+                      log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
+                    }
+                    // Suppress server_tool_use blocks (Z.AI built-in tools)
+                    if (
+                      data.type === "content_block_start" &&
+                      data.content_block?.type === "server_tool_use"
+                    ) {
+                      suppressedServerTools++;
+                      log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}`);
+                      continue;
+                    }
+                    if (data.type === "content_block_stop" && suppressedServerTools > 0) {
+                      suppressedServerTools--;
+                      continue;
+                    }
+                    if (data.type === "message_start") {
+                      sawMessageStart = true;
                     }
                     if (data.type === "message_delta" && data.delta?.stop_reason) {
                       stopReason = data.delta.stop_reason;
@@ -335,7 +388,15 @@ export function createAnthropicPassthroughStream(
                     }
                   }
                 } else {
-                  // Non-data lines (event: lines, blank lines) — pass through
+                  // Non-data lines (event: lines, blank lines).
+                  // Suppress a bare `event: error` line: the matching `data:` line
+                  // that follows carries the payload and triggers finalizeWithError().
+                  // Forwarding `event: error` verbatim is itself what makes Claude Code
+                  // report "empty or malformed response (HTTP 200)" and crash, and it
+                  // produced the double `event: error` seen in production captures.
+                  if (line.trimStart().startsWith("event: error")) {
+                    continue;
+                  }
                   if (!isClosed) {
                     controller.enqueue(encoder.encode(line + "\n"));
                   }

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -68,6 +68,7 @@ export function createAnthropicPassthroughStream(
           let textChunks = 0;
           let toolUseBlocks = 0;
           let stopReason: string | null = null;
+          let sawMessageStop = false;
 
           // Thinking-block filtering state
           let insideThinkingBlock = false;
@@ -292,6 +293,9 @@ export function createAnthropicPassthroughStream(
                     if (data.type === "message_delta" && data.delta?.stop_reason) {
                       stopReason = data.delta.stop_reason;
                     }
+                    if (data.type === "message_stop") {
+                      sawMessageStop = true;
+                    }
                   } catch {
                     // Unparseable data line — pass through
                     if (!isClosed) {
@@ -333,6 +337,9 @@ export function createAnthropicPassthroughStream(
                   if (data.type === "message_delta" && data.delta?.stop_reason) {
                     stopReason = data.delta.stop_reason;
                   }
+                  if (data.type === "message_stop") {
+                    sawMessageStop = true;
+                  }
                 } catch {}
               }
             }
@@ -351,12 +358,14 @@ export function createAnthropicPassthroughStream(
           // message_stop, emit it ourselves. Claude Code requires
           // message_stop as the terminal event — without it, the client
           // reports "API returned an empty or malformed response (HTTP 200)".
-          if (!isClosed && !stopReason) {
-            log(`[AnthropicSSE] Stream ended without message_stop — emitting synthetic finalization`);
-            controller.enqueue(encoder.encode(
-              "event: message_delta\n" +
-              `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":${outputTokens}}}\n\n`
-            ));
+          if (!isClosed && !sawMessageStop) {
+            log(`[AnthropicSSE] Stream ended without message_stop (stopReason=${stopReason}) — emitting synthetic finalization`);
+            if (!stopReason) {
+              controller.enqueue(encoder.encode(
+                "event: message_delta\n" +
+                `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":${outputTokens}}}\n\n`
+              ));
+            }
             controller.enqueue(encoder.encode(
               "event: message_stop\n" +
               `data: {"type":"message_stop"}\n\n`

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -88,6 +88,10 @@ export function createAnthropicPassthroughStream(
           // Content block index tracking — detect out-of-range indices
           // that would cause "Content block not found" on the client side.
           let highestSeenIndex = -1;
+          // Track whether the last content block is still open (started but not stopped).
+          // Without this, finalizeWithError() may emit a duplicate content_block_stop
+          // for a block that the provider already closed, causing "Content block not found".
+          let lastBlockOpen = false;
           const clampIndex = (idx: number, context: string): number => {
             if (idx > highestSeenIndex + 1) {
               log(
@@ -145,9 +149,12 @@ export function createAnthropicPassthroughStream(
                     "event: content_block_stop\n" + `data: {"type":"content_block_stop","index":0}\n\n`
                   )
                 );
-              } else if (highestSeenIndex >= 0) {
+              } else if (highestSeenIndex >= 0 && lastBlockOpen) {
                 // Mid-stream: close whatever content block was open when the error hit,
                 // otherwise the client sees an unterminated block.
+                // Only emit if the block is actually still open — if the provider
+                // already sent a content_block_stop, a duplicate would cause
+                // "Content block not found" on the client.
                 controller.enqueue(
                   encoder.encode(
                     "event: content_block_stop\n" +
@@ -219,6 +226,7 @@ export function createAnthropicPassthroughStream(
                   ) {
                     insideThinkingBlock = true;
                     thinkingBlocksSuppressed++;
+                    // Thinking blocks are suppressed — don't count them as open.
                     log(`[AnthropicSSE] Filtering thinking block at index ${data.index}`);
                     continue; // suppress this line
                   }
@@ -241,6 +249,9 @@ export function createAnthropicPassthroughStream(
                     const reindexed = data.index - thinkingBlocksSuppressed;
                     const clamped = clampIndex(reindexed, `${data.type} (filtered, orig=${data.index})`);
                     trackIndex(clamped);
+                    // Track block open/close state for finalizeWithError
+                    if (data.type === "content_block_start") lastBlockOpen = true;
+                    if (data.type === "content_block_stop") lastBlockOpen = false;
                     const modifiedLine =
                       "data: " + JSON.stringify({ ...data, index: clamped });
 
@@ -254,8 +265,10 @@ export function createAnthropicPassthroughStream(
                     if (typeof data.index === "number") {
                       if (data.type === "content_block_start") {
                         trackIndex(data.index);
+                        lastBlockOpen = true;
                       } else {
                         const clamped = clampIndex(data.index, `${data.type} (unfiltered)`);
+                        if (data.type === "content_block_stop") lastBlockOpen = false;
                         if (clamped !== data.index) {
                           const modifiedLine =
                             "data: " + JSON.stringify({ ...data, index: clamped });
@@ -295,6 +308,7 @@ export function createAnthropicPassthroughStream(
                     // No error — check index bounds before passing through
                     if (typeof data.index === "number") {
                       if (data.type === "content_block_start") {
+                        lastBlockOpen = true;
                         // z.ai sometimes sends content_block_start with an index
                         // that jumps (e.g., 0 → 2, skipping 1). This causes
                         // "Content block not found" on the client. Remap to
@@ -316,6 +330,7 @@ export function createAnthropicPassthroughStream(
                         trackIndex(expected);
                       } else {
                         // delta / stop — clamp to highestSeenIndex
+                        if (data.type === "content_block_stop") lastBlockOpen = false;
                         const clamped = clampIndex(data.index, `${data.type} (passthrough)`);
                         if (clamped !== data.index) {
                           const modified = { ...data, index: clamped };

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -12,6 +12,7 @@
 import type { Context } from "hono";
 import { log } from "../../../logger.js";
 import type { BaseAPIFormat } from "../../../adapters/base-api-format.js";
+import { createResponseCapture } from "../response-capture.js";
 
 interface AnthropicPassthroughOpts {
   modelName: string;
@@ -41,9 +42,17 @@ export function createAnthropicPassthroughStream(
 
   const filterThinking = opts.adapter?.shouldFilterThinking() ?? false;
 
+  const cap = createResponseCapture("anthropic", opts.modelName);
+
   return c.body(
     new ReadableStream({
       async start(controller) {
+        // Diagnostic tap: mirror every outgoing byte into the response capture.
+        const _origEnqueue = controller.enqueue.bind(controller);
+        controller.enqueue = ((chunk: any) => {
+          cap.tap(chunk);
+          return _origEnqueue(chunk);
+        }) as typeof controller.enqueue;
         const sendPing = () => {
           if (!isClosed) {
             controller.enqueue(encoder.encode("event: ping\ndata: {\"type\":\"ping\"}\n\n"));
@@ -128,6 +137,8 @@ export function createAnthropicPassthroughStream(
                         clearInterval(pingInterval);
                         pingInterval = null;
                       }
+                      cap.note("in-stream-error(filtered)");
+                      cap.done({ closed: true, stop_reason: "error", path: "in-stream-error-filtered" });
                       controller.close();
                     }
                     return; // stop processing further lines
@@ -221,6 +232,8 @@ export function createAnthropicPassthroughStream(
                           clearInterval(pingInterval);
                           pingInterval = null;
                         }
+                        cap.note("in-stream-error");
+                        cap.done({ closed: true, stop_reason: "error", path: "in-stream-error" });
                         controller.close();
                       }
                       return; // stop processing further lines
@@ -371,6 +384,7 @@ export function createAnthropicPassthroughStream(
             `[AnthropicSSE] Stream complete for ${opts.modelName}: ${totalLines} lines, ${textChunks} text chunks, ${toolUseBlocks} tool_use blocks, stop_reason=${stopReason}` +
               (filterThinking ? `, filtered ${thinkingBlocksSuppressed} thinking blocks` : "")
           );
+          cap.note(`upstream-done sawMessageStop=${sawMessageStop} stop_reason=${stopReason} toolUse=${toolUseBlocks}`);
 
           if (opts.onTokenUpdate) {
             opts.onTokenUpdate(inputTokens, outputTokens);
@@ -419,21 +433,30 @@ export function createAnthropicPassthroughStream(
               clearInterval(pingInterval);
               pingInterval = null;
             }
+            cap.done({ closed: true, stop_reason: stopReason, sawMessageStop, path: "normal" });
             controller.close();
+          } else {
+            cap.done({ closed: true, stop_reason: stopReason, sawMessageStop, path: "already-closed" });
           }
         } catch (e) {
           log(`[AnthropicSSE] Stream error: ${e}`);
+          cap.note(`stream-exception ${String(e)}`);
           if (!isClosed) {
             isClosed = true;
             if (pingInterval) {
               clearInterval(pingInterval);
               pingInterval = null;
             }
+            cap.done({ closed: true, stop_reason: "exception", path: "catch", error: String(e) });
             controller.close();
+          } else {
+            cap.done({ closed: true, stop_reason: "exception", path: "catch-already-closed", error: String(e) });
           }
         }
       },
-      cancel() {
+      cancel(reason?: unknown) {
+        cap.note(`client-cancel ${reason !== undefined ? String(reason) : ""}`);
+        cap.done({ closed: false, stop_reason: "client-cancel", path: "cancel" });
         isClosed = true;
         if (pingInterval) {
           clearInterval(pingInterval);

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -68,6 +68,29 @@ export function createAnthropicPassthroughStream(
           }
         }, 1000);
 
+        // ── Shared content-block index tracking state ──────────────────
+        // DECLARED HERE (in start() scope, not inside the inner try block) so that
+        // handleServerToolResult's closure and the read loop share the SAME binding.
+        // Previously highestSeenIndex was declared inside the inner try{} block while
+        // handleServerToolResult (which writes it at line ~109) lived in the outer scope —
+        // two different block scopes → ReferenceError: highestSeenIndex is not defined
+        // whenever a real server_tool_use block fired the handler, crashing the proxy
+        // (observed live: po-2025 "Content block not found" freeze).
+        let highestSeenIndex = -1;
+        let lastBlockOpen = false;
+        const clampIndex = (idx: number, context: string): number => {
+          if (idx > highestSeenIndex + 1) {
+            log(
+              `[AnthropicSSE] Index jump detected: ${idx} but expected <=${highestSeenIndex + 1} (${context}) — clamping to ${highestSeenIndex + 1}`
+            );
+            return highestSeenIndex + 1;
+          }
+          return idx;
+        };
+        const trackIndex = (idx: number) => {
+          if (idx > highestSeenIndex) highestSeenIndex = idx;
+        };
+
         // Execute a suppressed server_tool_use (webReader) and inject the result
         // as a text block. Non-blocking — errors degrade to a short notice.
         const handleServerToolResult = async (
@@ -138,25 +161,8 @@ export function createAnthropicPassthroughStream(
           let serverToolInput = "";
           let serverToolsSuppressed = 0;
 
-          // Content block index tracking — detect out-of-range indices
-          // that would cause "Content block not found" on the client side.
-          let highestSeenIndex = -1;
-          // Track whether the last content block is still open (started but not stopped).
-          // Without this, finalizeWithError() may emit a duplicate content_block_stop
-          // for a block that the provider already closed, causing "Content block not found".
-          let lastBlockOpen = false;
-          const clampIndex = (idx: number, context: string): number => {
-            if (idx > highestSeenIndex + 1) {
-              log(
-                `[AnthropicSSE] Index jump detected: ${idx} but expected <=${highestSeenIndex + 1} (${context}) — clamping to ${highestSeenIndex + 1}`
-              );
-              return highestSeenIndex + 1;
-            }
-            return idx;
-          };
-          const trackIndex = (idx: number) => {
-            if (idx > highestSeenIndex) highestSeenIndex = idx;
-          };
+          // (highestSeenIndex / lastBlockOpen / clampIndex / trackIndex declared
+          //  earlier in start() scope — shared with handleServerToolResult's closure.)
 
           // ── Graceful in-stream error finalization ─────────────────────
           // Some anthropic-compat providers (Z.AI, MiniMax, Kimi) return HTTP 200
@@ -367,6 +373,44 @@ export function createAnthropicPassthroughStream(
                       return; // stop processing further lines
                     }
 
+                    // ── server_tool_use suppression ──────────────────────────────
+                    // MUST run BEFORE the index-remap/passthrough logic below.
+                    // Z.AI built-in tools (webReader, web_search_preview) emit
+                    // server_tool_use blocks that Claude Code doesn't understand:
+                    //   "Unsupported content type: server_tool_use" + "Content block not found"
+                    // We suppress the entire block lifecycle (start → deltas → stop),
+                    // execute web fetches ourselves, and inject results as text.
+                    // (Ordering matters: without this guard first, the start event
+                    //  would already be enqueued by the passthrough below before the
+                    //  suppression flag is set — leaking the unsupported block type.)
+                    if (
+                      data.type === "content_block_start" &&
+                      data.content_block?.type === "server_tool_use"
+                    ) {
+                      insideServerToolBlock = true;
+                      serverToolName = data.content_block.name || "(unnamed)";
+                      serverToolInput = "";
+                      serverToolsSuppressed++;
+                      log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}: ${serverToolName}`);
+                      continue; // drop this start event
+                    }
+                    if (insideServerToolBlock) {
+                      // Accumulate input_json_delta inside the suppressed block
+                      if (data.type === "content_block_delta" && data.delta?.type === "input_json_delta") {
+                        serverToolInput += data.delta.partial_json || "";
+                      }
+                      // On stop: block is complete — execute and inject result
+                      if (data.type === "content_block_stop") {
+                        insideServerToolBlock = false;
+                        log(`[AnthropicSSE] server_tool_use "${serverToolName}" complete, input=${serverToolInput.length} chars`);
+                        // Fire-and-forget: execute the web fetch and inject as text
+                        handleServerToolResult(serverToolName, serverToolInput, highestSeenIndex);
+                        serverToolName = "";
+                        serverToolInput = "";
+                      }
+                      continue; // drop all events inside the suppressed block
+                    }
+
                     // No error — check index bounds before passing through
                     if (typeof data.index === "number") {
                       if (data.type === "content_block_start") {
@@ -434,39 +478,6 @@ export function createAnthropicPassthroughStream(
                     ) {
                       toolUseBlocks++;
                       log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
-                    }
-                    // ── server_tool_use suppression ──────────────────────────────
-                    // Z.AI built-in tools (webReader, web_search_preview) emit
-                    // server_tool_use blocks that Claude Code doesn't understand:
-                    //   "Unsupported content type: server_tool_use" + "Content block not found"
-                    // We suppress the entire block lifecycle (start → deltas → stop),
-                    // execute web fetches ourselves, and inject results as text.
-                    if (
-                      data.type === "content_block_start" &&
-                      data.content_block?.type === "server_tool_use"
-                    ) {
-                      insideServerToolBlock = true;
-                      serverToolName = data.content_block.name || "(unnamed)";
-                      serverToolInput = "";
-                      serverToolsSuppressed++;
-                      log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}: ${serverToolName}`);
-                      continue; // drop this start event
-                    }
-                    if (insideServerToolBlock) {
-                      // Accumulate input_json_delta inside the suppressed block
-                      if (data.type === "content_block_delta" && data.delta?.type === "input_json_delta") {
-                        serverToolInput += data.delta.partial_json || "";
-                      }
-                      // On stop: block is complete — execute and inject result
-                      if (data.type === "content_block_stop") {
-                        insideServerToolBlock = false;
-                        log(`[AnthropicSSE] server_tool_use "${serverToolName}" complete, input=${serverToolInput.length} chars`);
-                        // Fire-and-forget: execute the web fetch and inject as text
-                        handleServerToolResult(serverToolName, serverToolInput, highestSeenIndex);
-                        serverToolName = "";
-                        serverToolInput = "";
-                      }
-                      continue; // drop all events inside the suppressed block
                     }
                     if (data.type === "message_start") {
                       sawMessageStart = true;

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -245,6 +245,13 @@ export function createAnthropicPassthroughStream(
             }
           };
 
+          // Wrap the read loop so a mid-stream upstream socket close (Z.AI / GLM
+          // Coding connection reset) is caught HERE — where finalizeWithError is
+          // in scope — instead of escaping to the outer catch which can only do a
+          // bare controller.close() with NO terminal message_stop. Without that
+          // terminal event, Claude Code reports "socket connection was closed
+          // unexpectedly" and freezes the turn. See never-hang-priority.
+          try {
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
@@ -528,6 +535,18 @@ export function createAnthropicPassthroughStream(
                 } catch {}
               }
             }
+          }
+          } catch (readErr) {
+            // Upstream socket closed mid-stream (Z.AI / GLM Coding connection
+            // reset). finalizeWithError() emits the terminal message_stop so the
+            // client ends the turn cleanly instead of freezing. In scope here
+            // because finalizeWithError is declared above in the same outer try.
+            log(
+              `[AnthropicSSE] Upstream read error for ${opts.modelName}: ${String(readErr).slice(0, 200)} — finalizing gracefully`,
+              true
+            );
+            finalizeWithError(`upstream read error: ${String(readErr)}`, "reader-exception");
+            return; // skip normal finalization — already terminated
           }
 
           log(

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -74,6 +74,22 @@ export function createAnthropicPassthroughStream(
           /** How many thinking blocks have been suppressed so far. */
           let thinkingBlocksSuppressed = 0;
 
+          // Content block index tracking — detect out-of-range indices
+          // that would cause "Content block not found" on the client side.
+          let highestSeenIndex = -1;
+          const clampIndex = (idx: number, context: string): number => {
+            if (idx > highestSeenIndex + 1) {
+              log(
+                `[AnthropicSSE] Index jump detected: ${idx} but expected <=${highestSeenIndex + 1} (${context}) — clamping to ${highestSeenIndex + 1}`
+              );
+              return highestSeenIndex + 1;
+            }
+            return idx;
+          };
+          const trackIndex = (idx: number) => {
+            if (idx > highestSeenIndex) highestSeenIndex = idx;
+          };
+
           while (true) {
             const { done, value } = await reader.read();
             if (done) break;
@@ -141,8 +157,10 @@ export function createAnthropicPassthroughStream(
                   // After suppressing N thinking blocks, subtract N from the index
                   if (typeof data.index === "number" && thinkingBlocksSuppressed > 0) {
                     const reindexed = data.index - thinkingBlocksSuppressed;
+                    const clamped = clampIndex(reindexed, `${data.type} (filtered, orig=${data.index})`);
+                    trackIndex(clamped);
                     const modifiedLine =
-                      "data: " + JSON.stringify({ ...data, index: reindexed });
+                      "data: " + JSON.stringify({ ...data, index: clamped });
 
                     if (!isClosed) {
                       controller.enqueue(encoder.encode(modifiedLine + "\n"));
@@ -150,7 +168,23 @@ export function createAnthropicPassthroughStream(
 
                     // Still do usage tracking below with the ORIGINAL data
                   } else {
-                    // No filtering needed — pass through as-is
+                    // No filtering needed — track and pass through
+                    if (typeof data.index === "number") {
+                      if (data.type === "content_block_start") {
+                        trackIndex(data.index);
+                      } else {
+                        const clamped = clampIndex(data.index, `${data.type} (unfiltered)`);
+                        if (clamped !== data.index) {
+                          const modifiedLine =
+                            "data: " + JSON.stringify({ ...data, index: clamped });
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode(modifiedLine + "\n"));
+                          }
+                          // Skip original enqueue below
+                          continue;
+                        }
+                      }
+                    }
                     if (!isClosed) {
                       controller.enqueue(encoder.encode(line + "\n"));
                     }
@@ -189,9 +223,47 @@ export function createAnthropicPassthroughStream(
                       return; // stop processing further lines
                     }
 
-                    // No error — pass through the line
-                    if (!isClosed) {
-                      controller.enqueue(encoder.encode(line + "\n"));
+                    // No error — check index bounds before passing through
+                    if (typeof data.index === "number") {
+                      if (data.type === "content_block_start") {
+                        // z.ai sometimes sends content_block_start with an index
+                        // that jumps (e.g., 0 → 2, skipping 1). This causes
+                        // "Content block not found" on the client. Remap to
+                        // sequential indices to keep the client happy.
+                        const expected = highestSeenIndex + 1;
+                        if (data.index !== expected) {
+                          log(
+                            `[AnthropicSSE] content_block_start index ${data.index} remapped to ${expected} (model=${opts.modelName})`
+                          );
+                          const remapped = { ...data, index: expected };
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode("data: " + JSON.stringify(remapped) + "\n"));
+                          }
+                        } else {
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode(line + "\n"));
+                          }
+                        }
+                        trackIndex(expected);
+                      } else {
+                        // delta / stop — clamp to highestSeenIndex
+                        const clamped = clampIndex(data.index, `${data.type} (passthrough)`);
+                        if (clamped !== data.index) {
+                          const modified = { ...data, index: clamped };
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode("data: " + JSON.stringify(modified) + "\n"));
+                          }
+                        } else {
+                          if (!isClosed) {
+                            controller.enqueue(encoder.encode(line + "\n"));
+                          }
+                        }
+                      }
+                    } else {
+                      // No index field — pass through as-is
+                      if (!isClosed) {
+                        controller.enqueue(encoder.encode(line + "\n"));
+                      }
                     }
 
                     // Usage/debug tracking
@@ -273,6 +345,22 @@ export function createAnthropicPassthroughStream(
 
           if (opts.onTokenUpdate) {
             opts.onTokenUpdate(inputTokens, outputTokens);
+          }
+
+          // Finalization: if the upstream stream ended without sending
+          // message_stop, emit it ourselves. Claude Code requires
+          // message_stop as the terminal event — without it, the client
+          // reports "API returned an empty or malformed response (HTTP 200)".
+          if (!isClosed && !stopReason) {
+            log(`[AnthropicSSE] Stream ended without message_stop — emitting synthetic finalization`);
+            controller.enqueue(encoder.encode(
+              "event: message_delta\n" +
+              `data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":${outputTokens}}}\n\n`
+            ));
+            controller.enqueue(encoder.encode(
+              "event: message_stop\n" +
+              `data: {"type":"message_stop"}\n\n`
+            ));
           }
 
           if (!isClosed) {

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -13,6 +13,7 @@ import type { Context } from "hono";
 import { log } from "../../../logger.js";
 import type { BaseAPIFormat } from "../../../adapters/base-api-format.js";
 import { createResponseCapture } from "../response-capture.js";
+import { executeWebFetch } from "../web-search-executor.js";
 
 interface AnthropicPassthroughOpts {
   modelName: string;
@@ -67,6 +68,48 @@ export function createAnthropicPassthroughStream(
           }
         }, 1000);
 
+        // Execute a suppressed server_tool_use (webReader) and inject the result
+        // as a text block. Non-blocking — errors degrade to a short notice.
+        const handleServerToolResult = async (
+          toolName: string,
+          rawInput: string,
+          currentHighestIdx: number,
+        ) => {
+          const textIdx = currentHighestIdx + 1;
+          let resultText: string;
+          try {
+            const input = JSON.parse(rawInput || "{}");
+            const url = input.url;
+            if (url && (toolName === "webReader" || toolName === "web_search_preview")) {
+              log(`[AnthropicSSE] Executing suppressed server_tool_use webReader for ${url}`);
+              const result = await executeWebFetch(url);
+              resultText = result.ok
+                ? result.text
+                : `[Web fetch for ${url} failed: ${result.error}]`;
+            } else {
+              resultText = `[Server tool "${toolName}" was executed by the provider (result not available locally).]`;
+            }
+          } catch {
+            resultText = `[Server tool "${toolName}" was executed by the provider (result not available locally).]`;
+          }
+          // Truncate very long results to avoid blowing up the context
+          if (resultText.length > 8000) {
+            resultText = resultText.slice(0, 8000) + "\n[...truncated]";
+          }
+          if (!isClosed) {
+            controller.enqueue(encoder.encode(
+              `event: content_block_start\ndata: ${JSON.stringify({ type: "content_block_start", index: textIdx, content_block: { type: "text", text: "" } })}\n\n`
+            ));
+            controller.enqueue(encoder.encode(
+              `event: content_block_delta\ndata: ${JSON.stringify({ type: "content_block_delta", index: textIdx, delta: { type: "text_delta", text: resultText } })}\n\n`
+            ));
+            controller.enqueue(encoder.encode(
+              `event: content_block_stop\ndata: ${JSON.stringify({ type: "content_block_stop", index: textIdx })}\n\n`
+            ));
+            highestSeenIndex = textIdx;
+          }
+        };
+
         try {
           const reader = response.body!.getReader();
           let buffer = "";
@@ -84,6 +127,16 @@ export function createAnthropicPassthroughStream(
           let insideThinkingBlock = false;
           /** How many thinking blocks have been suppressed so far. */
           let thinkingBlocksSuppressed = 0;
+
+          // server_tool_use suppression state.
+          // Z.AI built-in tools (webReader, web_search) emit server_tool_use blocks
+          // that Claude Code doesn't support — "Unsupported content type: server_tool_use"
+          // followed by "Content block not found" (index desync). Suppress them and
+          // execute web fetches ourselves, injecting results as text blocks.
+          let insideServerToolBlock = false;
+          let serverToolName = "";
+          let serverToolInput = "";
+          let serverToolsSuppressed = 0;
 
           // Content block index tracking — detect out-of-range indices
           // that would cause "Content block not found" on the client side.
@@ -244,9 +297,11 @@ export function createAnthropicPassthroughStream(
                   }
 
                   // Re-index non-thinking content blocks
-                  // After suppressing N thinking blocks, subtract N from the index
-                  if (typeof data.index === "number" && thinkingBlocksSuppressed > 0) {
-                    const reindexed = data.index - thinkingBlocksSuppressed;
+                  // After suppressing N thinking blocks + M server_tool_use blocks,
+                  // subtract N+M from the index to keep it sequential.
+                  const totalSuppressed = thinkingBlocksSuppressed + serverToolsSuppressed;
+                  if (typeof data.index === "number" && totalSuppressed > 0) {
+                    const reindexed = data.index - totalSuppressed;
                     const clamped = clampIndex(reindexed, `${data.type} (filtered, orig=${data.index})`);
                     trackIndex(clamped);
                     // Track block open/close state for finalizeWithError
@@ -373,17 +428,38 @@ export function createAnthropicPassthroughStream(
                       toolUseBlocks++;
                       log(`[AnthropicSSE] Tool use: ${data.content_block.name}`);
                     }
-                    // Z.AI built-in tools (server_tool_use): pass through instead of suppressing.
-                    // Previous suppression caused index desync — the matching tool_result block
-                    // would arrive without its tool_use, breaking the stream for the client.
-                    // Claude Code handles server_tool_use natively. If the built-in tool errors
-                    // (e.g. file:// URI to analyze_image), the error comes back as tool_result
-                    // text and the model continues its turn naturally.
+                    // ── server_tool_use suppression ──────────────────────────────
+                    // Z.AI built-in tools (webReader, web_search_preview) emit
+                    // server_tool_use blocks that Claude Code doesn't understand:
+                    //   "Unsupported content type: server_tool_use" + "Content block not found"
+                    // We suppress the entire block lifecycle (start → deltas → stop),
+                    // execute web fetches ourselves, and inject results as text.
                     if (
                       data.type === "content_block_start" &&
                       data.content_block?.type === "server_tool_use"
                     ) {
-                      log(`[AnthropicSSE] server_tool_use at index ${data.index}: ${data.content_block.name || "(unnamed)"}`);
+                      insideServerToolBlock = true;
+                      serverToolName = data.content_block.name || "(unnamed)";
+                      serverToolInput = "";
+                      serverToolsSuppressed++;
+                      log(`[AnthropicSSE] Suppressing server_tool_use block at index ${data.index}: ${serverToolName}`);
+                      continue; // drop this start event
+                    }
+                    if (insideServerToolBlock) {
+                      // Accumulate input_json_delta inside the suppressed block
+                      if (data.type === "content_block_delta" && data.delta?.type === "input_json_delta") {
+                        serverToolInput += data.delta.partial_json || "";
+                      }
+                      // On stop: block is complete — execute and inject result
+                      if (data.type === "content_block_stop") {
+                        insideServerToolBlock = false;
+                        log(`[AnthropicSSE] server_tool_use "${serverToolName}" complete, input=${serverToolInput.length} chars`);
+                        // Fire-and-forget: execute the web fetch and inject as text
+                        handleServerToolResult(serverToolName, serverToolInput, highestSeenIndex);
+                        serverToolName = "";
+                        serverToolInput = "";
+                      }
+                      continue; // drop all events inside the suppressed block
                     }
                     if (data.type === "message_start") {
                       sawMessageStart = true;

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -482,7 +482,7 @@ export function createAnthropicPassthroughStream(
               ));
               controller.enqueue(encoder.encode(
                 "event: content_block_delta\n" +
-                `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"[Error: The model returned an empty response. Try compacting the conversation or reducing the context size.]"}}\n\n`
+                `data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"[Error: The model returned an empty response. This is usually transient — a momentary provider load or rate limit, NOT a context-size problem. Please retry. If it recurs repeatedly on a very large conversation, then try /compact.]"}}\n\n`
               ));
               controller.enqueue(encoder.encode(
                 "event: content_block_stop\n" +

--- a/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
@@ -77,56 +77,81 @@ export function createGeminiSseStream(
         if (finalized) return;
         finalized = true;
 
-        if (thinkingStarted) {
-          send("content_block_stop", { type: "content_block_stop", index: thinkingIdx });
-        }
-        if (textStarted) {
-          send("content_block_stop", { type: "content_block_stop", index: textIdx });
-        }
-        for (const t of toolCalls.values()) {
-          if (t.started && !t.closed) {
-            send("content_block_stop", { type: "content_block_stop", index: t.blockIndex });
-            t.closed = true;
+        // HARD never-hang invariant: the cleanup in `finally` (clearInterval +
+        // controller.close) MUST run on every exit path, including a throw mid-body
+        // (e.g. middleware afterStreamComplete rejecting). A re-entrancy guard alone
+        // is not enough: the outer catch re-calls finalize(), which no-ops because
+        // `finalized` is already true — leaving the first call's cleanup undone and
+        // the ping interval leaking forever (= hung stream). See never-hang-priority.
+        try {
+          if (thinkingStarted) {
+            send("content_block_stop", { type: "content_block_stop", index: thinkingIdx });
           }
-        }
-
-        if (opts.middlewareManager) {
-          await opts.middlewareManager.afterStreamComplete(opts.modelName, new Map());
-        }
-
-        const inputTokens = usage?.promptTokenCount || 0;
-        const outputTokens = usage?.candidatesTokenCount || 0;
-
-        if (usage) {
-          log(`[GeminiSSE] Usage: prompt=${inputTokens}, completion=${outputTokens}`);
-        }
-
-        if (opts.onTokenUpdate) {
-          opts.onTokenUpdate(inputTokens, outputTokens);
-        }
-
-        if (reason === "error") {
-          log(`[GeminiSSE] Stream error: ${err}`);
-          send("error", { type: "error", error: { type: "api_error", message: err } });
-        } else {
-          const hasToolCalls = toolCalls.size > 0;
-          send("message_delta", {
-            type: "message_delta",
-            delta: { stop_reason: hasToolCalls ? "tool_use" : "end_turn", stop_sequence: null },
-            usage: { input_tokens: inputTokens, output_tokens: outputTokens },
-          });
-          send("message_stop", { type: "message_stop" });
-        }
-
-        if (!isClosed) {
-          isClosed = true;
-          if (pingInterval) {
-            clearInterval(pingInterval);
-            pingInterval = null;
+          if (textStarted) {
+            send("content_block_stop", { type: "content_block_stop", index: textIdx });
           }
+          for (const t of toolCalls.values()) {
+            if (t.started && !t.closed) {
+              send("content_block_stop", { type: "content_block_stop", index: t.blockIndex });
+              t.closed = true;
+            }
+          }
+
+          if (opts.middlewareManager) {
+            try {
+              await opts.middlewareManager.afterStreamComplete(opts.modelName, new Map());
+            } catch (mwErr) {
+              log(`[GeminiSSE] afterStreamComplete threw (ignored): ${mwErr}`);
+            }
+          }
+
+          const inputTokens = usage?.promptTokenCount || 0;
+          const outputTokens = usage?.candidatesTokenCount || 0;
+
+          if (usage) {
+            log(`[GeminiSSE] Usage: prompt=${inputTokens}, completion=${outputTokens}`);
+          }
+
+          if (opts.onTokenUpdate) {
+            try {
+              opts.onTokenUpdate(inputTokens, outputTokens);
+            } catch {}
+          }
+
+          if (reason === "error") {
+            log(`[GeminiSSE] Stream error: ${err}`);
+            send("error", { type: "error", error: { type: "api_error", message: err } });
+          } else {
+            const hasToolCalls = toolCalls.size > 0;
+            send("message_delta", {
+              type: "message_delta",
+              delta: { stop_reason: hasToolCalls ? "tool_use" : "end_turn", stop_sequence: null },
+              usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+            });
+            send("message_stop", { type: "message_stop" });
+          }
+        } catch (finalizeErr) {
+          // Last-ditch terminal pair so the client never hangs waiting for the end.
+          log(`[GeminiSSE] finalize() body threw: ${finalizeErr}`);
           try {
-            controller.close();
+            send("message_delta", {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn", stop_sequence: null },
+              usage: { input_tokens: 0, output_tokens: 0 },
+            });
+            send("message_stop", { type: "message_stop" });
           } catch {}
+        } finally {
+          if (!isClosed) {
+            isClosed = true;
+            if (pingInterval) {
+              clearInterval(pingInterval);
+              pingInterval = null;
+            }
+            try {
+              controller.close();
+            } catch {}
+          }
         }
       };
 

--- a/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
@@ -62,7 +62,7 @@ export function createGeminiSseStream(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });
@@ -113,7 +113,7 @@ export function createGeminiSseStream(
           send("message_delta", {
             type: "message_delta",
             delta: { stop_reason: hasToolCalls ? "tool_use" : "end_turn", stop_sequence: null },
-            usage: { output_tokens: outputTokens },
+            usage: { input_tokens: inputTokens, output_tokens: outputTokens },
           });
           send("message_stop", { type: "message_stop" });
         }

--- a/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
@@ -50,7 +50,7 @@ export function createOllamaJsonlStream(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });
@@ -75,7 +75,7 @@ export function createOllamaJsonlStream(
           send("message_delta", {
             type: "message_delta",
             delta: { stop_reason: "end_turn", stop_sequence: null },
-            usage: { output_tokens: completionTokens },
+            usage: { input_tokens: promptTokens, output_tokens: completionTokens },
           });
           send("message_stop", { type: "message_stop" });
         }

--- a/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
@@ -35,6 +35,7 @@ export function createOllamaJsonlStream(
 
       const msgId = `msg_${Date.now()}_${Math.random().toString(36).slice(2)}`;
       let textStarted = false;
+      let finalized = false;
       let promptTokens = 0;
       let completionTokens = 0;
       let lastActivity = Date.now();
@@ -63,36 +64,58 @@ export function createOllamaJsonlStream(
       }, 1000);
 
       const finalize = (reason: string, err?: string) => {
-        if (isClosed) return;
+        if (finalized) return;
+        finalized = true;
 
-        if (textStarted) {
-          send("content_block_stop", { type: "content_block_stop", index: 0 });
-        }
-
-        if (reason === "error") {
-          send("error", { type: "error", error: { type: "api_error", message: err } });
-        } else {
-          send("message_delta", {
-            type: "message_delta",
-            delta: { stop_reason: "end_turn", stop_sequence: null },
-            usage: { input_tokens: promptTokens, output_tokens: completionTokens },
-          });
-          send("message_stop", { type: "message_stop" });
-        }
-
-        if (opts.onTokenUpdate) {
-          opts.onTokenUpdate(promptTokens, completionTokens);
-        }
-
-        if (!isClosed) {
-          isClosed = true;
-          if (pingInterval) {
-            clearInterval(pingInterval);
-            pingInterval = null;
+        // HARD never-hang invariant: cleanup in `finally` (clearInterval +
+        // controller.close) MUST run on every exit path, including a throw from a
+        // send() mid-body. The previous guard set isClosed only AFTER the sends, so
+        // a throw before that line left isClosed=false; the outer catch re-called
+        // finalize() and could throw again, leaving the ping interval leaking
+        // forever (= hung stream). See never-hang-priority.
+        try {
+          if (textStarted) {
+            send("content_block_stop", { type: "content_block_stop", index: 0 });
           }
+
+          if (reason === "error") {
+            send("error", { type: "error", error: { type: "api_error", message: err } });
+          } else {
+            send("message_delta", {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn", stop_sequence: null },
+              usage: { input_tokens: promptTokens, output_tokens: completionTokens },
+            });
+            send("message_stop", { type: "message_stop" });
+          }
+
+          if (opts.onTokenUpdate) {
+            try {
+              opts.onTokenUpdate(promptTokens, completionTokens);
+            } catch {}
+          }
+        } catch (finalizeErr) {
+          // Last-ditch terminal pair so the client never hangs waiting for the end.
+          log(`[OllamaJSONL] finalize() body threw: ${finalizeErr}`);
           try {
-            controller.close();
+            send("message_delta", {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn", stop_sequence: null },
+              usage: { input_tokens: 0, output_tokens: 0 },
+            });
+            send("message_stop", { type: "message_stop" });
           } catch {}
+        } finally {
+          if (!isClosed) {
+            isClosed = true;
+            if (pingInterval) {
+              clearInterval(pingInterval);
+              pingInterval = null;
+            }
+            try {
+              controller.close();
+            } catch {}
+          }
         }
       };
 

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
@@ -66,7 +66,7 @@ export function createResponsesStreamHandler(
           model: opts.modelName,
           stop_reason: null,
           stop_sequence: null,
-          usage: { input_tokens: 100, output_tokens: 1 },
+          usage: { input_tokens: 0, output_tokens: 0 },
         },
       });
       send("ping", { type: "ping" });

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -420,14 +420,61 @@ export function createStreamingResponseHandler(
             await middlewareManager.afterStreamComplete(target, streamMetadata);
           }
 
+          // Determine whether the stream produced any usable content
+          const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started && !t.suppressed);
+          const hasContent = state.textStarted || state.reasoningStarted || hasStructuredTools || textToolCalls.length > 0;
+
           if (reason === "error") {
-            send("error", { type: "error", error: { type: "api_error", message: err } });
+            // Socket close, network error, or other fetch failure mid-stream.
+            // Previously we sent event: error, but Claude Code surfaces raw SSE error
+            // events as "API Error: <message>" without closing the turn cleanly.
+            // Instead, close any open blocks and inject the error as a text block
+            // so the turn ends gracefully with end_turn.
+            log(`[Stream] Stream error from ${target}: ${err}`);
+            logStderr(`[Stream] Stream error from ${target}: ${err?.substring(0, 120)}`);
+
+            // Close reasoning if still open
+            if (state.reasoningStarted) {
+              send("content_block_stop", { type: "content_block_stop", index: state.reasoningIdx });
+              state.reasoningStarted = false;
+            }
+            // Close text if still open
+            if (state.textStarted) {
+              send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
+              state.textStarted = false;
+            }
+
+            // Inject error as a text block (or replace if no content was produced)
+            const isSocketClose = /socket.*closed|connection was closed|ECONNRESET/i.test(err || "");
+            const errorNotice = isSocketClose
+              ? `[The connection to the model provider was interrupted. This is usually temporary — please retry.]`
+              : `[Upstream stream error: ${(err || "unknown").substring(0, 200)}]`;
+            const errorIdx = state.curIdx++;
+            send("content_block_start", {
+              type: "content_block_start",
+              index: errorIdx,
+              content_block: { type: "text", text: "" },
+            });
+            send("content_block_delta", {
+              type: "content_block_delta",
+              index: errorIdx,
+              delta: { type: "text_delta", text: errorNotice },
+            });
+            send("content_block_stop", { type: "content_block_stop", index: errorIdx });
+
+            send("message_delta", {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn", stop_sequence: null },
+              usage: {
+                input_tokens: state.usage?.prompt_tokens || 0,
+                output_tokens: state.usage?.completion_tokens || 0,
+              },
+            });
+            send("message_stop", { type: "message_stop" });
           } else {
             // Ensure at least one content block exists — some providers (z.ai, GLM)
             // return empty responses (finish_reason without content). The Anthropic
             // SDK treats messages with content:[] as malformed.
-            const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started && !t.suppressed);
-            const hasContent = state.textStarted || state.reasoningStarted || hasStructuredTools || textToolCalls.length > 0;
             if (!hasContent) {
               // Inject a text content block with the error message.
               // Previously we sent event: error, but Claude Code does not handle

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -222,7 +222,18 @@ export function createStreamingResponseHandler(
         const finalize = async (reason: string, err?: string) => {
           if (state.finalized) return;
           state.finalized = true;
-          const toolCount = Array.from(state.tools.values()).filter(t => t.started && !t.suppressed).length;
+          // Hang-guard: the body below performs awaits and send()s that can throw
+          // (a controller errored by a client-disconnect race, a callback failure).
+          // If a throw escaped, the outer read-loop catch would re-call finalize() —
+          // now a no-op (finalized=true) — leaving the stream with no message_stop
+          // and a leaked ping interval: a hung HTTP 200 the client reports as "empty
+          // or malformed response", and an agent blocked forever (the worst proxy
+          // failure mode). The try/catch/finally GUARANTEES terminal events +
+          // controller.close() + clearInterval(ping) on every exit path.
+          let terminalSent = false;
+          let toolCount = 0;
+          try {
+          toolCount = Array.from(state.tools.values()).filter(t => t.started && !t.suppressed).length;
           log(`[Stream] reason=${reason} model=${target} text=${state.textStarted} tools=${toolCount} text_len=${state.accumulatedText.length} err=${err ?? "none"}`);
           logStderr(`[Stream] ${target} ${reason} text_len=${state.accumulatedText.length} tools=${toolCount}`);
 
@@ -422,9 +433,21 @@ export function createStreamingResponseHandler(
             await middlewareManager.afterStreamComplete(target, streamMetadata);
           }
 
-          // Determine whether the stream produced any usable content
+          // Determine whether the stream produced any usable content.
           const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started && !t.suppressed);
-          const hasContent = state.textStarted || state.reasoningStarted || hasStructuredTools || textToolCalls.length > 0;
+          // A suppressed web-search tool that reached `closed` emitted its SearXNG
+          // result as a real text block (see the suppression path) — that IS content,
+          // even though the tool is suppressed and never set textStarted. Likewise the
+          // GLM <searchWeb> SearXNG injection. Counting these prevents a spurious
+          // "[Error: empty response]" being appended after valid search results.
+          const hasSuppressedWebText = Array.from(state.tools.values()).some((t) => t.suppressed && t.closed);
+          const hasContent =
+            state.textStarted ||
+            state.reasoningStarted ||
+            hasStructuredTools ||
+            textToolCalls.length > 0 ||
+            hasSuppressedWebText ||
+            searchWebResults !== null;
 
           if (reason === "error") {
             // Socket close, network error, or other fetch failure mid-stream.
@@ -473,6 +496,7 @@ export function createStreamingResponseHandler(
               },
             });
             send("message_stop", { type: "message_stop" });
+            terminalSent = true;
           } else {
             // Ensure at least one content block exists — some providers (z.ai, GLM)
             // return empty responses (finish_reason without content). The Anthropic
@@ -534,6 +558,7 @@ export function createStreamingResponseHandler(
               },
             });
             send("message_stop", { type: "message_stop" });
+            terminalSent = true;
           }
 
           // Update token counts - use actual usage if available, otherwise estimate
@@ -554,15 +579,44 @@ export function createStreamingResponseHandler(
             }
           }
 
-          if (!isClosed) {
-            try {
-              controller.enqueue(encoder.encode("data: [DONE]\n\n\n"));
-            } catch (e) {}
-            controller.close();
-            isClosed = true;
-            if (ping) clearInterval(ping);
-            cap.note(`close reason=${reason}`);
-            cap.done({ closed: true, reason, tools: toolCount, text_len: state.accumulatedText.length, err: err ?? null });
+          } catch (finalizeErr) {
+            // finalize() body threw before completing (controller enqueue raced a
+            // disconnect, a callback failed, etc.). Force terminal events so the
+            // client never hangs on an un-terminated 200.
+            logStderr(
+              `[Stream] finalize() threw for ${target}: ${String(finalizeErr).slice(0, 160)} — forcing terminal events`
+            );
+            if (!terminalSent) {
+              try {
+                send("message_delta", {
+                  type: "message_delta",
+                  delta: { stop_reason: "end_turn", stop_sequence: null },
+                  usage: {
+                    input_tokens: state.usage?.prompt_tokens || 0,
+                    output_tokens: state.usage?.completion_tokens || 0,
+                  },
+                });
+                send("message_stop", { type: "message_stop" });
+                terminalSent = true;
+              } catch {}
+            }
+          } finally {
+            // ALWAYS terminate the HTTP stream and free the ping timer, on every
+            // exit path (success, empty, error, or a throw inside finalize).
+            if (!isClosed) {
+              try {
+                controller.enqueue(encoder.encode("data: [DONE]\n\n\n"));
+              } catch {}
+              try {
+                controller.close();
+              } catch {}
+              isClosed = true;
+              if (ping) clearInterval(ping);
+              try {
+                cap.note(`close reason=${reason}`);
+                cap.done({ closed: true, reason, tools: toolCount, text_len: state.accumulatedText.length, err: err ?? null });
+              } catch {}
+            }
           }
         };
 

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -261,6 +261,19 @@ export function createStreamingResponseHandler(
             state.accumulatedText = cleanedText;
           }
 
+          // Close any open reasoning/text blocks BEFORE emitting new blocks below.
+          // If we don't, new tool_use blocks (higher indices) get fully opened/closed
+          // before the reasoning block (lower index) is stopped — the Anthropic client
+          // rejects this out-of-order lifecycle as "Content block not found".
+          if (state.reasoningStarted) {
+            send("content_block_stop", { type: "content_block_stop", index: state.reasoningIdx });
+            state.reasoningStarted = false;
+          }
+          if (state.textStarted) {
+            send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
+            state.textStarted = false;
+          }
+
           // Check for text-based tool calls before finalizing
           // Some models (like Qwen) output tool calls as text instead of structured tool_calls
           const textToolCalls = extractToolCallsFromText(state.accumulatedText);
@@ -269,12 +282,6 @@ export function createStreamingResponseHandler(
             log(
               `[Streaming] Found ${textToolCalls.length} text-based tool call(s), converting to structured format`
             );
-
-            // Close any open text block first
-            if (state.textStarted) {
-              send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
-              state.textStarted = false;
-            }
 
             // Send each extracted tool call as a proper tool_use block
             for (const tc of textToolCalls) {
@@ -293,13 +300,6 @@ export function createStreamingResponseHandler(
               });
               send("content_block_stop", { type: "content_block_stop", index: toolIdx });
             }
-          }
-
-          if (state.reasoningStarted) {
-            send("content_block_stop", { type: "content_block_stop", index: state.reasoningIdx });
-          }
-          if (state.textStarted) {
-            send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
           }
 
           // GLM <searchWeb> remapped to the client's WebSearch tool —
@@ -825,6 +825,29 @@ export function createStreamingResponseHandler(
                             t.closed = true;
                             continue;
                           }
+
+                          // Non-buffered and never started — emit repaired tool at a new index
+                          const fallbackIdx = state.curIdx++;
+                          const fallbackId = `tool_repaired_${Date.now()}_${fallbackIdx}`;
+                          log(
+                            `[Streaming] Emitting repaired tool ${t.name} (non-buffered, not started) at fallback index ${fallbackIdx}`
+                          );
+                          send("content_block_start", {
+                            type: "content_block_start",
+                            index: fallbackIdx,
+                            content_block: { type: "tool_use", id: fallbackId, name: t.name },
+                          });
+                          send("content_block_delta", {
+                            type: "content_block_delta",
+                            index: fallbackIdx,
+                            delta: { type: "input_json_delta", partial_json: repairedJson },
+                          });
+                          send("content_block_stop", {
+                            type: "content_block_stop",
+                            index: fallbackIdx,
+                          });
+                          t.closed = true;
+                          continue;
                         }
 
                         if (!validation.valid) {
@@ -832,6 +855,14 @@ export function createStreamingResponseHandler(
                           log(
                             `[Streaming] Tool call ${t.name} validation failed: ${validation.missingParams.join(", ")}`
                           );
+                          // Close the original tool block FIRST (lower index) so that
+                          // the error text block (higher index) doesn't open/close out of order.
+                          if (t.started && !t.buffered && !t.closed) {
+                            send("content_block_stop", {
+                              type: "content_block_stop",
+                              index: t.blockIndex,
+                            });
+                          }
                           const errorIdx = t.buffered ? t.blockIndex : state.curIdx++;
                           const errorMsg = `\n\n⚠️ Tool call "${t.name}" failed: missing required parameters: ${validation.missingParams.join(", ")}. Local models sometimes generate incomplete tool calls. Please try again or use a model with better tool support.`;
                           send("content_block_start", {
@@ -848,13 +879,6 @@ export function createStreamingResponseHandler(
                             type: "content_block_stop",
                             index: errorIdx,
                           });
-                          // Close the invalid tool if it was already started
-                          if (t.started && !t.buffered) {
-                            send("content_block_stop", {
-                              type: "content_block_stop",
-                              index: t.blockIndex,
-                            });
-                          }
                           t.closed = true;
                           continue;
                         }

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -42,8 +42,22 @@ export interface ToolState {
   started: boolean; // Whether content_block_start has been sent
   closed: boolean;
   suppressed: boolean; // Web search tools — drop from stream, replace with text
+  remapped: boolean; // Web search tools re-emitted as the client's WebSearch tool_use
   arguments: string; // Accumulated JSON arguments string
   buffered: boolean; // Whether we're buffering args until tool call completes
+}
+
+/**
+ * Whether the client declared a WebSearch tool in this request.
+ * When it did, provider-side web search calls (web_search tool calls or GLM
+ * <searchWeb> tags) are remapped to a synthetic WebSearch tool_use with
+ * stop_reason "tool_use" — the client then runs its own WebSearch, gets the
+ * results as a tool_result, and the agentic loop CONTINUES. Suppressing the
+ * call and injecting results as text ends the turn (stop_reason end_turn),
+ * which stalls the agent on raw search results (CoursIA incident 2026-06-10).
+ */
+function clientDeclaresWebSearch(toolSchemas?: any[]): boolean {
+  return !!toolSchemas?.some((s) => s?.name === "WebSearch");
 }
 
 /**
@@ -143,6 +157,45 @@ export function createStreamingResponseHandler(
         const msgId = `msg_${Date.now()}_${Math.random().toString(36).slice(2)}`;
         const state = createStreamingState();
 
+        // Emit a synthetic WebSearch tool_use block. Used to remap provider
+        // web search calls (web_search tool calls, GLM <searchWeb> tags) to
+        // the client's own WebSearch tool so the agentic loop continues
+        // (stop_reason "tool_use") instead of ending the turn on raw results.
+        const emitWebSearchToolUse = (query: string, t?: ToolState) => {
+          const blockIndex = t?.blockIndex ?? state.curIdx++;
+          const id = t?.id ?? `tool_websearch_${Date.now()}_${blockIndex}`;
+          send("content_block_start", {
+            type: "content_block_start",
+            index: blockIndex,
+            content_block: { type: "tool_use", id, name: "WebSearch" },
+          });
+          send("content_block_delta", {
+            type: "content_block_delta",
+            index: blockIndex,
+            delta: { type: "input_json_delta", partial_json: JSON.stringify({ query }) },
+          });
+          send("content_block_stop", { type: "content_block_stop", index: blockIndex });
+          if (t) {
+            t.started = true;
+            t.closed = true;
+          } else {
+            // Register so hasStructuredTools counts it → stop_reason "tool_use".
+            // Negative key avoids collisions with provider tool_call indices.
+            state.tools.set(-(blockIndex + 1), {
+              id,
+              name: "WebSearch",
+              blockIndex,
+              started: true,
+              closed: true,
+              suppressed: false,
+              remapped: true,
+              arguments: JSON.stringify({ query }),
+              buffered: false,
+            });
+          }
+          log(`[Stream] Remapped provider web search → WebSearch tool_use (query="${query}")`);
+        };
+
         send("message_start", {
           type: "message_start",
           message: {
@@ -183,17 +236,25 @@ export function createStreamingResponseHandler(
           // These must be intercepted before text-based tool call extraction, since we want to
           // execute SearXNG and replace the search tags with results, not pass them through.
           let searchWebResults: string | null = null;
+          let pendingSearchRemap: string | null = null;
           let cleanedText = state.accumulatedText;
           const searchWebMatch = state.accumulatedText.match(/<searchWeb>\s*<query>([\s\S]*?)<\/query>\s*<\/searchWeb>/i);
           if (searchWebMatch) {
             const searchQuery = searchWebMatch[1].trim();
-            log(`[Stream] GLM searchWeb detected: "${searchQuery}" — intercepting via SearXNG`);
-            if (searchQuery && SEARXNG_AVAILABLE) {
-              searchWebResults = await executeWebSearch(searchQuery);
+            if (searchQuery && clientDeclaresWebSearch(toolSchemas)) {
+              // Remap to the client's WebSearch tool — emitted as a tool_use
+              // block after the text blocks close, keeping the agent loop alive.
+              log(`[Stream] GLM searchWeb detected: "${searchQuery}" — remapping to client WebSearch tool_use`);
+              pendingSearchRemap = searchQuery;
             } else {
-              searchWebResults = searchQuery
-                ? `[Web search for "${searchQuery}" could not be executed. SearXNG is not configured.]`
-                : `[Web search was requested but no query was provided.]`;
+              log(`[Stream] GLM searchWeb detected: "${searchQuery}" — intercepting via SearXNG`);
+              if (searchQuery && SEARXNG_AVAILABLE) {
+                searchWebResults = await executeWebSearch(searchQuery);
+              } else {
+                searchWebResults = searchQuery
+                  ? `[Web search for "${searchQuery}" could not be executed. SearXNG is not configured.]`
+                  : `[Web search was requested but no query was provided.]`;
+              }
             }
             // Remove the search tags from accumulated text so they don't appear in output
             cleanedText = state.accumulatedText.replace(/<searchWeb>[\s\S]*?<\/searchWeb>/i, "").trim();
@@ -241,6 +302,12 @@ export function createStreamingResponseHandler(
             send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
           }
 
+          // GLM <searchWeb> remapped to the client's WebSearch tool —
+          // emitted as a tool_use block so stop_reason becomes "tool_use".
+          if (pendingSearchRemap) {
+            emitWebSearchToolUse(pendingSearchRemap);
+          }
+
           // Inject SearXNG results if we intercepted GLM <searchWeb> tags.
           // Sent as a separate text block after the (now-cleaned) model output.
           if (searchWebResults) {
@@ -256,6 +323,20 @@ export function createStreamingResponseHandler(
               delta: { type: "text_delta", text: searchWebResults },
             });
             send("content_block_stop", { type: "content_block_stop", index: srchIdx });
+          }
+
+          // Remapped web search tools that never saw finish_reason="tool_calls"
+          // (e.g. the provider ended with "stop") — emit them now so the
+          // query isn't silently dropped and stop_reason becomes "tool_use".
+          for (const t of Array.from(state.tools.values())) {
+            if (t.remapped && !t.closed) {
+              const query = extractSearchQuery(t.arguments);
+              if (query) {
+                emitWebSearchToolUse(query, t);
+              } else {
+                t.closed = true;
+              }
+            }
           }
 
           // Handle buffered-but-unsent structured tool calls.
@@ -583,8 +664,9 @@ export function createStreamingResponseHandler(
                           const rawName = tc.function.name;
                           const restoredName = toolNameMap?.get(rawName) || rawName;
                           const isWebSearch = isWebSearchToolCall(restoredName);
+                          const remapToWebSearch = isWebSearch && clientDeclaresWebSearch(toolSchemas);
                           if (isWebSearch) {
-                            log(`[Stream] Web search tool call detected: "${restoredName}" — intercepting via SearXNG (available=${SEARXNG_AVAILABLE})`);
+                            log(`[Stream] Web search tool call detected: "${restoredName}" — ${remapToWebSearch ? "remapping to client WebSearch tool_use" : `intercepting via SearXNG (available=${SEARXNG_AVAILABLE})`}`);
                           }
                           t = {
                             id: tc.id || `tool_${Date.now()}_${idx}`,
@@ -592,16 +674,16 @@ export function createStreamingResponseHandler(
                             blockIndex: state.curIdx++,
                             started: false,
                             closed: false,
-                            suppressed: isWebSearch,
+                            suppressed: isWebSearch && !remapToWebSearch,
+                            remapped: remapToWebSearch,
                             arguments: "", // Initialize arguments accumulator
                             buffered: !!toolSchemas && toolSchemas.length > 0 && !isWebSearch,
                           };
                           state.tools.set(idx, t);
                         }
-                        // Skip suppressed tools entirely
-                        if (t.suppressed) continue;
-                        // Only send content_block_start immediately if NOT buffering
-                        if (!t.started && !t.buffered) {
+                        // Only send content_block_start immediately if NOT buffering.
+                        // Suppressed and remapped tools never stream their blocks live.
+                        if (!t.started && !t.buffered && !t.suppressed && !t.remapped) {
                           send("content_block_start", {
                             type: "content_block_start",
                             index: t.blockIndex,
@@ -610,11 +692,12 @@ export function createStreamingResponseHandler(
                           t.started = true;
                         }
                       }
-                      if (tc.function?.arguments && t && !t.suppressed) {
-                        // Always accumulate arguments
+                      if (tc.function?.arguments && t) {
+                        // Always accumulate arguments — suppressed/remapped tools
+                        // need them too (extractSearchQuery reads the query later).
                         t.arguments += tc.function.arguments;
-                        // Only stream immediately if NOT buffering
-                        if (!t.buffered) {
+                        // Only stream immediately if NOT buffering/suppressed/remapped
+                        if (!t.buffered && !t.suppressed && !t.remapped) {
                           send("content_block_delta", {
                             type: "content_block_delta",
                             index: t.blockIndex,
@@ -631,6 +714,20 @@ export function createStreamingResponseHandler(
 
                 if (chunk.choices?.[0]?.finish_reason === "tool_calls") {
                   for (const t of Array.from(state.tools.values())) {
+                    if (t.remapped) {
+                      if (!t.closed) {
+                        const query = extractSearchQuery(t.arguments);
+                        if (query) {
+                          emitWebSearchToolUse(query, t);
+                        } else {
+                          // No usable query — degrade to the suppression path
+                          // (text injection below) rather than emit a broken tool_use.
+                          t.remapped = false;
+                          t.suppressed = true;
+                        }
+                      }
+                      if (t.closed) continue;
+                    }
                     if (t.suppressed) {
                       // Execute web search via SearXNG and inject results
                       if (!t.closed) {

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -348,18 +348,25 @@ export function createStreamingResponseHandler(
             const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started && !t.suppressed);
             const hasContent = state.textStarted || state.reasoningStarted || hasStructuredTools || textToolCalls.length > 0;
             if (!hasContent) {
-              // Send a proper Anthropic error event so the SDK triggers its retry logic.
-              // Injecting fake text would be silently accepted but not trigger recovery.
+              // Inject a text content block with the error message.
+              // Previously we sent event: error, but Claude Code does not handle
+              // raw error events in-stream — it reports "empty or malformed response".
+              // A content block with the error text is properly parsed and surfaced.
               const emptyMsg = `The model returned an empty response. This usually happens when the conversation context is too large. Try compacting the conversation or reducing the context size.`;
-              send("error", {
-                type: "error",
-                error: {
-                  type: "api_error",
-                  message: emptyMsg,
-                },
+              const blockIdx = state.curIdx++;
+              send("content_block_start", {
+                type: "content_block_start",
+                index: blockIdx,
+                content_block: { type: "text", text: "" },
               });
-              logStderr(`[Stream] EMPTY RESPONSE from ${target} — sent api_error to client (context overflow?)`);
-              log(`[Stream] Empty response from provider (context overflow?) — sent api_error event`);
+              send("content_block_delta", {
+                type: "content_block_delta",
+                index: blockIdx,
+                delta: { type: "text_delta", text: `[Error: ${emptyMsg}]` },
+              });
+              send("content_block_stop", { type: "content_block_stop", index: blockIdx });
+              logStderr(`[Stream] EMPTY RESPONSE from ${target} — injected error text block (context overflow?)`);
+              log(`[Stream] Empty response from provider (context overflow?) — injected error text block`);
             }
 
             // Set stop_reason based on whether we sent ANY tool calls (text-based or structured)

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -8,14 +8,17 @@
  */
 
 import type { Context } from "hono";
-import { log } from "../../../logger.js";
+import { log, logStderr } from "../../../logger.js";
+
+const SEARXNG_AVAILABLE = !!process.env.SEARXNG_URL;
 import {
   validateAndRepairToolCall,
   inferMissingParameters,
   extractToolCallsFromText,
   type ToolSchema,
 } from "../tool-call-recovery.js";
-import { isWebSearchToolCall, warnWebSearchUnsupported } from "../web-search-detector.js";
+import { isWebSearchToolCall } from "../web-search-detector.js";
+import { executeWebSearch, extractSearchQuery } from "../web-search-executor.js";
 
 export interface StreamingState {
   usage: any;
@@ -37,6 +40,7 @@ export interface ToolState {
   blockIndex: number;
   started: boolean; // Whether content_block_start has been sent
   closed: boolean;
+  suppressed: boolean; // Web search tools — drop from stream, replace with text
   arguments: string; // Accumulated JSON arguments string
   buffered: boolean; // Whether we're buffering args until tool call completes
 }
@@ -152,6 +156,9 @@ export function createStreamingResponseHandler(
         const finalize = async (reason: string, err?: string) => {
           if (state.finalized) return;
           state.finalized = true;
+          const toolCount = Array.from(state.tools.values()).filter(t => t.started && !t.suppressed).length;
+          log(`[Stream] reason=${reason} model=${opts.modelName} text=${state.textStarted} tools=${toolCount} text_len=${state.accumulatedText.length} err=${err ?? "none"}`);
+          logStderr(`[Stream] ${opts.modelName} ${reason} text_len=${state.accumulatedText.length} tools=${toolCount}`);
 
           // Debug: Log accumulated text for analysis
           if (state.accumulatedText.length > 0) {
@@ -159,6 +166,27 @@ export function createStreamingResponseHandler(
             log(
               `[Streaming] Accumulated text (${state.accumulatedText.length} chars): ${preview}...`
             );
+          }
+
+          // Check for text-based web search tags (GLM emits <searchWeb><query>...</query></searchWeb>)
+          // These must be intercepted before text-based tool call extraction, since we want to
+          // execute SearXNG and replace the search tags with results, not pass them through.
+          let searchWebResults: string | null = null;
+          let cleanedText = state.accumulatedText;
+          const searchWebMatch = state.accumulatedText.match(/<searchWeb>\s*<query>([\s\S]*?)<\/query>\s*<\/searchWeb>/i);
+          if (searchWebMatch) {
+            const searchQuery = searchWebMatch[1].trim();
+            log(`[Stream] GLM searchWeb detected: "${searchQuery}" — intercepting via SearXNG`);
+            if (searchQuery && SEARXNG_AVAILABLE) {
+              searchWebResults = await executeWebSearch(searchQuery);
+            } else {
+              searchWebResults = searchQuery
+                ? `[Web search for "${searchQuery}" could not be executed. SearXNG is not configured.]`
+                : `[Web search was requested but no query was provided.]`;
+            }
+            // Remove the search tags from accumulated text so they don't appear in output
+            cleanedText = state.accumulatedText.replace(/<searchWeb>[\s\S]*?<\/searchWeb>/i, "").trim();
+            state.accumulatedText = cleanedText;
           }
 
           // Check for text-based tool calls before finalizing
@@ -200,6 +228,23 @@ export function createStreamingResponseHandler(
           }
           if (state.textStarted) {
             send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
+          }
+
+          // Inject SearXNG results if we intercepted GLM <searchWeb> tags.
+          // Sent as a separate text block after the (now-cleaned) model output.
+          if (searchWebResults) {
+            const srchIdx = state.curIdx++;
+            send("content_block_start", {
+              type: "content_block_start",
+              index: srchIdx,
+              content_block: { type: "text", text: "" },
+            });
+            send("content_block_delta", {
+              type: "content_block_delta",
+              index: srchIdx,
+              delta: { type: "text_delta", text: searchWebResults },
+            });
+            send("content_block_stop", { type: "content_block_stop", index: srchIdx });
           }
 
           // Handle buffered-but-unsent structured tool calls.
@@ -286,8 +331,27 @@ export function createStreamingResponseHandler(
           if (reason === "error") {
             send("error", { type: "error", error: { type: "api_error", message: err } });
           } else {
+            // Ensure at least one content block exists — some providers (z.ai, GLM)
+            // return empty responses (finish_reason without content). The Anthropic
+            // SDK treats messages with content:[] as malformed.
+            const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started && !t.suppressed);
+            const hasContent = state.textStarted || state.reasoningStarted || hasStructuredTools || textToolCalls.length > 0;
+            if (!hasContent) {
+              // Send a proper Anthropic error event so the SDK triggers its retry logic.
+              // Injecting fake text would be silently accepted but not trigger recovery.
+              const emptyMsg = `The model returned an empty response. This usually happens when the conversation context is too large. Try compacting the conversation or reducing the context size.`;
+              send("error", {
+                type: "error",
+                error: {
+                  type: "api_error",
+                  message: emptyMsg,
+                },
+              });
+              logStderr(`[Stream] EMPTY RESPONSE from ${opts.modelName} — sent api_error to client (context overflow?)`);
+              log(`[Stream] Empty response from provider (context overflow?) — sent api_error event`);
+            }
+
             // Set stop_reason based on whether we sent ANY tool calls (text-based or structured)
-            const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started);
             const stopReason =
               textToolCalls.length > 0 || hasStructuredTools ? "tool_use" : "end_turn";
             send("message_delta", {
@@ -498,20 +562,24 @@ export function createStreamingResponseHandler(
                           // Restore truncated tool name to original if mapping exists
                           const rawName = tc.function.name;
                           const restoredName = toolNameMap?.get(rawName) || rawName;
+                          const isWebSearch = isWebSearchToolCall(restoredName);
+                          if (isWebSearch) {
+                            log(`[Stream] Web search tool call detected: "${restoredName}" — intercepting via SearXNG (available=${SEARXNG_AVAILABLE})`);
+                          }
                           t = {
                             id: tc.id || `tool_${Date.now()}_${idx}`,
                             name: restoredName,
                             blockIndex: state.curIdx++,
                             started: false,
                             closed: false,
+                            suppressed: isWebSearch,
                             arguments: "", // Initialize arguments accumulator
-                            buffered: !!toolSchemas && toolSchemas.length > 0, // Buffer if we have schemas to validate
+                            buffered: !!toolSchemas && toolSchemas.length > 0 && !isWebSearch,
                           };
                           state.tools.set(idx, t);
-                          if (isWebSearchToolCall(restoredName)) {
-                            warnWebSearchUnsupported(restoredName, target);
-                          }
                         }
+                        // Skip suppressed tools entirely
+                        if (t.suppressed) continue;
                         // Only send content_block_start immediately if NOT buffering
                         if (!t.started && !t.buffered) {
                           send("content_block_start", {
@@ -522,7 +590,7 @@ export function createStreamingResponseHandler(
                           t.started = true;
                         }
                       }
-                      if (tc.function?.arguments && t) {
+                      if (tc.function?.arguments && t && !t.suppressed) {
                         // Always accumulate arguments
                         t.arguments += tc.function.arguments;
                         // Only stream immediately if NOT buffering
@@ -543,6 +611,36 @@ export function createStreamingResponseHandler(
 
                 if (chunk.choices?.[0]?.finish_reason === "tool_calls") {
                   for (const t of Array.from(state.tools.values())) {
+                    if (t.suppressed) {
+                      // Execute web search via SearXNG and inject results
+                      if (!t.closed) {
+                        const query = extractSearchQuery(t.arguments);
+                        let resultText: string;
+                        if (query && SEARXNG_AVAILABLE) {
+                          resultText = await executeWebSearch(query);
+                        } else {
+                          resultText = query
+                            ? `[Web search for "${query}" could not be executed. The search service (SearXNG) is not configured. Set SEARXNG_URL env var to enable.]`
+                            : `[Web search was requested but no query was provided.]`;
+                        }
+                        send("content_block_start", {
+                          type: "content_block_start",
+                          index: t.blockIndex,
+                          content_block: { type: "text", text: "" },
+                        });
+                        send("content_block_delta", {
+                          type: "content_block_delta",
+                          index: t.blockIndex,
+                          delta: { type: "text_delta", text: resultText },
+                        });
+                        send("content_block_stop", {
+                          type: "content_block_stop",
+                          index: t.blockIndex,
+                        });
+                        t.closed = true;
+                      }
+                      continue;
+                    }
                     if (!t.closed) {
                       // Validate and potentially repair tool arguments
                       if (toolSchemas && toolSchemas.length > 0) {

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -278,6 +278,15 @@ export function createStreamingResponseHandler(
           // If we don't, new tool_use blocks (higher indices) get fully opened/closed
           // before the reasoning block (lower index) is stopped — the Anthropic client
           // rejects this out-of-order lifecycle as "Content block not found".
+          //
+          // Snapshot BEFORE clearing the flags: hasContent (below) must know whether
+          // text/reasoning was EVER produced, not whether a block is still open.
+          // Reading state.textStarted after this close block made hasContent always
+          // false for pure-text responses — a spurious "[Error: empty response …
+          // try /compact]" was appended after every valid text answer (cluster-wide
+          // false-compact incident, 2026-06-12).
+          const producedText = state.textStarted;
+          const producedReasoning = state.reasoningStarted;
           if (state.reasoningStarted) {
             send("content_block_stop", { type: "content_block_stop", index: state.reasoningIdx });
             state.reasoningStarted = false;
@@ -442,8 +451,9 @@ export function createStreamingResponseHandler(
           // "[Error: empty response]" being appended after valid search results.
           const hasSuppressedWebText = Array.from(state.tools.values()).some((t) => t.suppressed && t.closed);
           const hasContent =
-            state.textStarted ||
-            state.reasoningStarted ||
+            producedText ||
+            producedReasoning ||
+            state.accumulatedText.length > 0 ||
             hasStructuredTools ||
             textToolCalls.length > 0 ||
             hasSuppressedWebText ||

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -138,7 +138,7 @@ export function createStreamingResponseHandler(
             model: target,
             stop_reason: null,
             stop_sequence: null,
-            usage: { input_tokens: 100, output_tokens: 1 },
+            usage: { input_tokens: 0, output_tokens: 0 },
           },
         });
         send("ping", { type: "ping" });
@@ -293,7 +293,10 @@ export function createStreamingResponseHandler(
             send("message_delta", {
               type: "message_delta",
               delta: { stop_reason: stopReason, stop_sequence: null },
-              usage: { output_tokens: state.usage?.completion_tokens || 0 },
+              usage: {
+                input_tokens: state.usage?.prompt_tokens || 0,
+                output_tokens: state.usage?.completion_tokens || 0,
+              },
             });
             send("message_stop", { type: "message_stop" });
           }
@@ -312,7 +315,7 @@ export function createStreamingResponseHandler(
               log(
                 `[Streaming] No usage data from provider, estimating: ~${estimatedOutputTokens} output tokens`
               );
-              onTokenUpdate(100, estimatedOutputTokens); // Use 100 as placeholder for input
+              onTokenUpdate(0, estimatedOutputTokens);
             }
           }
 

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -19,6 +19,7 @@ import {
 } from "../tool-call-recovery.js";
 import { isWebSearchToolCall } from "../web-search-detector.js";
 import { executeWebSearch, extractSearchQuery } from "../web-search-executor.js";
+import { createResponseCapture } from "../response-capture.js";
 
 export interface StreamingState {
   usage: any;
@@ -120,9 +121,19 @@ export function createStreamingResponseHandler(
   const decoder = new TextDecoder();
   const streamMetadata = new Map<string, any>();
 
+  const cap = createResponseCapture("openai", target);
+
   return c.body(
     new ReadableStream({
       async start(controller) {
+        // Diagnostic tap (no-op unless CLAUDISH_CAPTURE_DIR set): mirror every
+        // outgoing byte to the response capture so a hung stream is visible offline.
+        const _origEnqueue = controller.enqueue.bind(controller);
+        controller.enqueue = ((chunk: any) => {
+          cap.tap(chunk);
+          return _origEnqueue(chunk);
+        }) as any;
+
         const send = (e: string, d: any) => {
           if (!isClosed) {
             controller.enqueue(encoder.encode(`event: ${e}\ndata: ${JSON.stringify(d)}\n\n`));
@@ -157,8 +168,8 @@ export function createStreamingResponseHandler(
           if (state.finalized) return;
           state.finalized = true;
           const toolCount = Array.from(state.tools.values()).filter(t => t.started && !t.suppressed).length;
-          log(`[Stream] reason=${reason} model=${opts.modelName} text=${state.textStarted} tools=${toolCount} text_len=${state.accumulatedText.length} err=${err ?? "none"}`);
-          logStderr(`[Stream] ${opts.modelName} ${reason} text_len=${state.accumulatedText.length} tools=${toolCount}`);
+          log(`[Stream] reason=${reason} model=${target} text=${state.textStarted} tools=${toolCount} text_len=${state.accumulatedText.length} err=${err ?? "none"}`);
+          logStderr(`[Stream] ${target} ${reason} text_len=${state.accumulatedText.length} tools=${toolCount}`);
 
           // Debug: Log accumulated text for analysis
           if (state.accumulatedText.length > 0) {
@@ -347,7 +358,7 @@ export function createStreamingResponseHandler(
                   message: emptyMsg,
                 },
               });
-              logStderr(`[Stream] EMPTY RESPONSE from ${opts.modelName} — sent api_error to client (context overflow?)`);
+              logStderr(`[Stream] EMPTY RESPONSE from ${target} — sent api_error to client (context overflow?)`);
               log(`[Stream] Empty response from provider (context overflow?) — sent api_error event`);
             }
 
@@ -390,6 +401,8 @@ export function createStreamingResponseHandler(
             controller.close();
             isClosed = true;
             if (ping) clearInterval(ping);
+            cap.note(`close reason=${reason}`);
+            cap.done({ closed: true, reason, tools: toolCount, text_len: state.accumulatedText.length, err: err ?? null });
           }
         };
 

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -33,6 +33,7 @@ export interface StreamingState {
   toolIds: Set<string>;
   lastActivity: number;
   accumulatedText: string; // Accumulated text for potential tool call extraction
+  lastFinishReason: string | null; // Last finish_reason seen (stop/length/content_filter) — diagnoses empty responses
 }
 
 export interface ToolState {
@@ -112,6 +113,7 @@ export function createStreamingState(): StreamingState {
     toolIds: new Set(),
     lastActivity: Date.now(),
     accumulatedText: "",
+    lastFinishReason: null,
   };
 }
 
@@ -480,7 +482,25 @@ export function createStreamingResponseHandler(
               // Previously we sent event: error, but Claude Code does not handle
               // raw error events in-stream — it reports "empty or malformed response".
               // A content block with the error text is properly parsed and surfaced.
-              const emptyMsg = `The model returned an empty response. This usually happens when the conversation context is too large. Try compacting the conversation or reducing the context size.`;
+              //
+              // Cause classification (was: always blamed "context too large"):
+              //   - finish_reason "length"        → genuine context/max_tokens overflow → compact
+              //   - finish_reason "content_filter"→ provider content filter → not a context issue
+              //   - otherwise (stop/null)         → almost always transient (provider load /
+              //                                       momentary rate limit) → RETRY, do NOT compact
+              // The old blanket "compact" message pushed agents into a destructive /compact on
+              // transient empties (the majority — sub-agents with tiny contexts), discarding
+              // context mid-task. Lead with "transient, retry"; mention compact only when the
+              // cause is actually length/overflow.
+              const fr = state.lastFinishReason;
+              const promptTokens = state.usage?.prompt_tokens ?? 0;
+              const isOverflow = fr === "length" || promptTokens > 100_000;
+              const emptyMsg =
+                fr === "content_filter"
+                  ? `The model's response was filtered by the provider's content policy. This is usually transient — please retry, or rephrase the request.`
+                  : isOverflow
+                    ? `The model returned an empty response and the conversation context is very large (finish_reason: ${fr || "stop"}, ~${promptTokens} input tokens). Try /compact to reduce the context size, or retry.`
+                    : `The model returned an empty response (finish_reason: ${fr || "stop"}). This is usually transient — a momentary provider load or rate limit, NOT a context-size problem. Please retry. If it recurs repeatedly, then try /compact.`;
               const blockIdx = state.curIdx++;
               send("content_block_start", {
                 type: "content_block_start",
@@ -493,8 +513,13 @@ export function createStreamingResponseHandler(
                 delta: { type: "text_delta", text: `[Error: ${emptyMsg}]` },
               });
               send("content_block_stop", { type: "content_block_stop", index: blockIdx });
-              logStderr(`[Stream] EMPTY RESPONSE from ${target} — injected error text block (context overflow?)`);
-              log(`[Stream] Empty response from provider (context overflow?) — injected error text block`);
+              const cls = fr === "content_filter" ? "content-filter" : isOverflow ? "overflow" : "transient";
+              logStderr(
+                `[Stream] EMPTY RESPONSE from ${target} — finish_reason=${fr || "null"} prompt_tokens=${promptTokens} → ${cls} (injected ${cls} message)`
+              );
+              log(
+                `[Stream] Empty response from provider (finish_reason=${fr || "null"}, prompt_tokens=${promptTokens}) — classified as ${cls}, injected guidance`
+              );
             }
 
             // Set stop_reason based on whether we sent ANY tool calls (text-based or structured)
@@ -572,6 +597,13 @@ export function createStreamingResponseHandler(
 
                 const delta = chunk.choices?.[0]?.delta;
                 const finishReason = chunk.choices?.[0]?.finish_reason;
+
+                // Track the last non-null finish_reason so the empty-response
+                // fallback (finalize) can diagnose the cause instead of guessing
+                // "context overflow" for every empty response.
+                if (finishReason) {
+                  state.lastFinishReason = finishReason;
+                }
 
                 // Debug: Log chunk details for troubleshooting early termination
                 if (delta?.content || finishReason) {

--- a/packages/cli/src/handlers/shared/stream-peek.test.ts
+++ b/packages/cli/src/handlers/shared/stream-peek.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from "bun:test";
+import { peekStreamStart } from "./stream-peek.js";
+
+function sseResponse(chunks: string[], status = 200): Response {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const ch of chunks) controller.enqueue(encoder.encode(ch));
+      controller.close();
+    },
+  });
+  return new Response(stream as any, { status });
+}
+
+async function readAll(response: Response): Promise<string> {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let out = "";
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value, { stream: true });
+  }
+  return out;
+}
+
+const MESSAGE_START =
+  'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_1","type":"message","role":"assistant","model":"glm-5.1","content":[],"stop_reason":null,"usage":{"input_tokens":1,"output_tokens":1}}}\n\n';
+const CONTENT =
+  'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n' +
+  'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n';
+
+describe("peekStreamStart", () => {
+  test("classifies a message_start as healthy and hands the FULL stream downstream", async () => {
+    const res = sseResponse([MESSAGE_START + CONTENT]);
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("healthy");
+    // branch B must carry the entire stream — prefix included — not just what
+    // came after the peek.
+    const body = await readAll(peeked.response);
+    expect(body).toContain("message_start");
+    expect(body).toContain("Hello");
+  });
+
+  test("reads past leading ping/comment lines before deciding healthy", async () => {
+    const res = sseResponse(['event: ping\ndata: {"type":"ping"}\n\n', MESSAGE_START + CONTENT]);
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("healthy");
+    const body = await readAll(peeked.response);
+    expect(body).toContain("ping");
+    expect(body).toContain("Hello");
+  });
+
+  test("classifies a [1302] start-of-stream error as rate-limit", async () => {
+    const res = sseResponse([
+      'event: error\ndata: {"error":{"code":"1302","message":"Your account has reached its rate limit"}}\n\n',
+    ]);
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("rate-limit");
+    expect(peeked.detail).toContain("rate limit");
+  });
+
+  test("classifies a non-rate-limit in-stream error as other-error and still hands the stream downstream", async () => {
+    const res = sseResponse([
+      'event: error\ndata: {"error":{"code":"5000","message":"internal boom"}}\n\n',
+    ]);
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("other-error");
+    expect(peeked.detail).toContain("internal boom");
+    // other-error flows to the parser (its graceful finalizer surfaces it).
+    const body = await readAll(peeked.response);
+    expect(body).toContain("internal boom");
+  });
+
+  test("fails open (healthy) when the response has no body", async () => {
+    const res = new Response(null, { status: 200 });
+    const peeked = await peekStreamStart(res);
+
+    expect(peeked.cls).toBe("healthy");
+    expect(peeked.response).toBe(res); // original, untouched
+  });
+});

--- a/packages/cli/src/handlers/shared/stream-peek.ts
+++ b/packages/cli/src/handlers/shared/stream-peek.ts
@@ -1,0 +1,195 @@
+/**
+ * Stream start peek — classify the first bytes of an SSE response without
+ * consuming the stream the parser will later read.
+ *
+ * Motivation: Z.AI (anthropic-sse transport) frequently delivers its burst /
+ * RPM limit as **HTTP 200** followed by an in-stream SSE error ([1302]) that
+ * carries no message envelope. That is invisible to `response.ok` and to
+ * FallbackHandler (both key off HTTP status), so it used to flow straight to
+ * the client as a bare error and crash the turn. By peeking the first bytes we
+ * can detect the rate-limit before handing the body to the parser, temporize
+ * (retry the same provider — the sustained quota has headroom, only the
+ * instantaneous burst limit is hit), and on persistence fall back to the next
+ * provider in the chain.
+ *
+ * Mechanism: `ReadableStream.tee()` splits the body into two independent
+ * branches. We sniff branch A and hand branch B (a pristine, full copy
+ * including the prefix we read) downstream. Tee buffers internally, so no bytes
+ * are lost for branch B even though we consumed branch A.
+ *
+ * Timing: the rate-limit errors we target arrive in 0-4ms. A short bounded
+ * window therefore catches them while leaving slow-but-healthy responses (a
+ * big-context cache-miss can have a multi-second TTFB) to proceed untouched.
+ *
+ * Fail-open: any unexpected condition (no body, tee unsupported, read error,
+ * timeout) resolves to "healthy" with a usable Response, so this never makes
+ * things worse than the parser-level safety net already guarantees.
+ */
+
+export type StreamStartClass = "healthy" | "rate-limit" | "other-error";
+
+export interface PeekResult {
+  cls: StreamStartClass;
+  /**
+   * Response to hand downstream.
+   * - healthy / other-error: a tee'd branch carrying the FULL original stream
+   *   (prefix included). Always use this — the original body is locked by tee().
+   * - rate-limit: the original Response (its body is already cancelled and must
+   *   not be read; the caller retries or falls back instead).
+   */
+  response: Response;
+  /** Best-effort human-readable error message extracted from the sniffed bytes. */
+  detail?: string;
+}
+
+export interface PeekOptions {
+  /**
+   * Max time to wait for the first classifiable bytes before assuming healthy.
+   * Rate-limit errors arrive in 0-4ms, so the default is generous.
+   */
+  timeoutMs?: number;
+  /** Max bytes to sniff before giving up and assuming healthy. */
+  maxSniffBytes?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 2000;
+const DEFAULT_MAX_SNIFF_BYTES = 64 * 1024;
+
+/** Extract the first `"message":"..."` value from sniffed SSE text. */
+function extractErrMsg(sniff: string): string | undefined {
+  const m = sniff.match(/"message"\s*:\s*"((?:[^"\\]|\\.)*)"/);
+  if (!m) return undefined;
+  try {
+    return JSON.parse(`"${m[1]}"`);
+  } catch {
+    return m[1];
+  }
+}
+
+const RATE_LIMIT_RE = /rate.?limit|\b1302\b|\b1305\b|\b429\b|too many requests|overloaded|quota/i;
+
+/**
+ * Classify what we've sniffed so far. Returns null when the bytes are still
+ * ambiguous (need to read more), a concrete class once we can decide.
+ */
+function classifyPartial(sniff: string): { cls: StreamStartClass; detail?: string } | null {
+  // A message envelope means the provider is streaming a real answer — healthy.
+  if (/"type"\s*:\s*"message_start"/.test(sniff) || /(^|\n)event:\s*message_start/.test(sniff)) {
+    return { cls: "healthy" };
+  }
+  // Any content delta before an error likewise means a real answer is flowing.
+  if (/"type"\s*:\s*"content_block_start"/.test(sniff)) {
+    return { cls: "healthy" };
+  }
+  // Error signatures: an `event: error`, a top-level error type, or an error object.
+  const hasError =
+    /(^|\n)event:\s*error/.test(sniff) ||
+    /"type"\s*:\s*"error"/.test(sniff) ||
+    /"error"\s*:\s*\{/.test(sniff);
+  if (hasError) {
+    const detail = extractErrMsg(sniff);
+    const isRateLimit = RATE_LIMIT_RE.test(sniff);
+    return { cls: isRateLimit ? "rate-limit" : "other-error", detail };
+  }
+  return null;
+}
+
+/**
+ * Peek the start of an SSE response and classify it without disturbing the
+ * stream handed downstream. See module docs for the full rationale.
+ */
+export async function peekStreamStart(
+  response: Response,
+  opts: PeekOptions = {}
+): Promise<PeekResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxSniffBytes = opts.maxSniffBytes ?? DEFAULT_MAX_SNIFF_BYTES;
+
+  if (!response.body) {
+    return { cls: "healthy", response };
+  }
+
+  // Typed as `any`: `response.body.tee()` returns Node's stream/web
+  // ReadableStream, which is a distinct declaration from the global DOM
+  // ReadableStream and won't unify across the two type roots. The branches are
+  // only used locally (getReader / new Response), so erasing the type here is
+  // safe and avoids a cross-lib cast.
+  let branchA: any;
+  let branchB: any;
+  try {
+    [branchA, branchB] = response.body.tee();
+  } catch {
+    // tee() unsupported or failed — original body untouched, fail open.
+    return { cls: "healthy", response };
+  }
+
+  const reader = branchA.getReader();
+  const decoder = new TextDecoder();
+  let sniff = "";
+  let cls: StreamStartClass | null = null;
+  let detail: string | undefined;
+
+  const deadline = Date.now() + timeoutMs;
+  try {
+    while (cls === null) {
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        cls = "healthy";
+        break;
+      }
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeout = new Promise<"timeout">((resolve) => {
+        timer = setTimeout(() => resolve("timeout"), remaining);
+      });
+      let res: { done?: boolean; value?: any } | "timeout";
+      try {
+        res = await Promise.race([reader.read(), timeout]);
+      } finally {
+        if (timer) clearTimeout(timer);
+      }
+      if (res === "timeout") {
+        cls = "healthy";
+        break;
+      }
+      if (res.done) {
+        // Stream ended within the window — classify whatever we saw.
+        cls = classifyPartial(sniff)?.cls ?? "healthy";
+        detail = classifyPartial(sniff)?.detail;
+        break;
+      }
+      if (res.value) {
+        sniff += decoder.decode(res.value, { stream: true });
+      }
+      const partial = classifyPartial(sniff);
+      if (partial) {
+        cls = partial.cls;
+        detail = partial.detail;
+        break;
+      }
+      if (sniff.length > maxSniffBytes) {
+        cls = "healthy";
+        break;
+      }
+    }
+  } catch {
+    cls = "healthy"; // read error — fail open
+  } finally {
+    reader.cancel().catch(() => {});
+  }
+
+  if (cls === "rate-limit") {
+    // Caller will retry / fall back — discard the unused full-stream branch.
+    branchB.cancel().catch(() => {});
+    return { cls, response, detail };
+  }
+
+  // healthy OR other-error: hand the FULL stream (branch B) downstream. An
+  // other-error still flows to the parser, whose graceful finalizer surfaces it
+  // as a clean terminal message rather than a crash.
+  const downstream = new Response(branchB, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+  return { cls, response: downstream, detail };
+}

--- a/packages/cli/src/handlers/shared/web-search-executor.ts
+++ b/packages/cli/src/handlers/shared/web-search-executor.ts
@@ -4,15 +4,21 @@
  *
  * When a provider model requests web_search, claudish:
  * 1. Extracts the search query from tool arguments
- * 2. Calls the local SearXNG instance
+ * 2. Calls the SearXNG MCP server (when SEARXNG_MCP_URL is set),
+ *    falling back to the direct SearXNG HTTP API
  * 3. Returns formatted results as a text block in the stream
  *
- * IMPORTANT: executeWebSearchSync must not block the SSE stream.
- * It races SearXNG against a 3-second deadline and returns a
- * fallback message immediately if SearXNG is unreachable.
+ * Fallback chains (HARD constraint: a failed search/fetch must NEVER
+ * stop the agent — every path ends in well-formed text, never a throw):
+ *   search: MCP searxng_web_search → direct HTTP /search → error text
+ *   fetch:  MCP web_url_read → MCP via r.jina.ai prefix → direct HTTP → error text
+ *
+ * IMPORTANT: these executors must not block the SSE stream.
+ * Every network call is bounded by a strict deadline.
  */
 
 import { log } from "../../logger.js";
+import { isMcpSearxngAvailable, mcpWebSearch, mcpUrlRead } from "./mcp-searxng-client.js";
 
 const SEARXNG_URL = process.env.SEARXNG_URL || "http://search.myia.io";
 
@@ -53,10 +59,19 @@ async function fetchFromSearXNG(query: string, maxResults = 5): Promise<SearchRe
 }
 
 /**
- * Stream-safe web search: races SearXNG against a short deadline.
+ * Stream-safe web search: MCP searxng_web_search first (when configured),
+ * then the direct SearXNG HTTP API, each bounded by a deadline.
  * Returns formatted results text, never throws, never blocks > deadline.
  */
 export async function executeWebSearch(query: string, deadlineMs = 3000): Promise<string> {
+  if (isMcpSearxngAvailable()) {
+    const mcp = await mcpWebSearch(query, Math.max(deadlineMs, 5000));
+    if (mcp.ok) {
+      return `[Web search results for "${query}"]\n\n${mcp.text}`;
+    }
+    log(`[WebSearch] MCP route failed (${mcp.error}), falling back to direct HTTP`);
+  }
+
   try {
     const results = await Promise.race([
       fetchFromSearXNG(query),
@@ -111,11 +126,47 @@ const MAX_FETCH_BYTES = 500_000;
 const MAX_HTML_INPUT_CHARS = 100_000;
 
 /**
- * Fetch a URL and convert HTML to readable text.
+ * Fetch a URL with graceful degradation. Never throws.
+ *
+ * Chain: MCP web_url_read (server-side fetch + markdown) → MCP web_url_read
+ * with the r.jina.ai reader prefix (bypasses 403s on bot-hostile hosts) →
+ * direct streaming HTTP fetch → error text.
+ */
+export async function executeWebFetch(url: string, deadlineMs = 10_000): Promise<string> {
+  if (isMcpSearxngAvailable()) {
+    const direct = await mcpUrlRead(url, 12_000);
+    if (direct.ok && isUsefulFetchResult(direct.text)) {
+      return truncateContent(direct.text, 15000);
+    }
+    log(`[WebFetch] MCP web_url_read failed for "${url}" (${direct.ok ? "low-content result" : direct.error}), trying r.jina.ai prefix`);
+
+    const viaJina = await mcpUrlRead(`https://r.jina.ai/${url}`, 12_000);
+    if (viaJina.ok && isUsefulFetchResult(viaJina.text)) {
+      return truncateContent(viaJina.text, 15000);
+    }
+    log(`[WebFetch] MCP via r.jina.ai failed for "${url}" (${viaJina.ok ? "low-content result" : viaJina.error}), falling back to direct HTTP`);
+  }
+
+  return fetchViaHttp(url, deadlineMs);
+}
+
+/**
+ * Heuristic: an MCP fetch result that is empty or a bare error/denial page
+ * should trigger the next fallback instead of being returned to the model.
+ */
+function isUsefulFetchResult(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length < 50) return false;
+  if (/^(error|403|404|access denied|forbidden)/i.test(trimmed) && trimmed.length < 300) return false;
+  return true;
+}
+
+/**
+ * Direct HTTP fetch of a URL with HTML → readable text conversion.
  * Uses streaming with a byte cap to avoid loading multi-MB pages into memory,
  * and pre-truncates HTML before regex to prevent event-loop blocking.
  */
-export async function executeWebFetch(url: string, deadlineMs = 10_000): Promise<string> {
+async function fetchViaHttp(url: string, deadlineMs = 10_000): Promise<string> {
   try {
     log(`[WebFetch] Fetching: "${url}"`);
     const response = await fetch(url, {

--- a/packages/cli/src/handlers/shared/web-search-executor.ts
+++ b/packages/cli/src/handlers/shared/web-search-executor.ts
@@ -1,0 +1,114 @@
+/**
+ * Web search executor — intercepts web_search tool calls from providers
+ * (z.ai, GLM) and executes them via SearXNG.
+ *
+ * When a provider model requests web_search, claudish:
+ * 1. Extracts the search query from tool arguments
+ * 2. Calls the local SearXNG instance
+ * 3. Returns formatted results as a text block in the stream
+ *
+ * IMPORTANT: executeWebSearchSync must not block the SSE stream.
+ * It races SearXNG against a 3-second deadline and returns a
+ * fallback message immediately if SearXNG is unreachable.
+ */
+
+import { log } from "../../logger.js";
+
+const SEARXNG_URL = process.env.SEARXNG_URL || "http://search.myia.io";
+
+export interface SearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/**
+ * Execute a web search via SearXNG. Non-throwing.
+ */
+async function fetchFromSearXNG(query: string, maxResults = 5): Promise<SearchResult[]> {
+  const url = `${SEARXNG_URL}/search?q=${encodeURIComponent(query)}&format=json&categories=general`;
+  log(`[WebSearch] Executing: "${query}" via ${SEARXNG_URL}`);
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(5000),
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    log(`[WebSearch] SearXNG returned HTTP ${response.status}`);
+    return [];
+  }
+
+  const data = (await response.json()) as any;
+  const results: SearchResult[] = (data.results || [])
+    .slice(0, maxResults)
+    .map((r: any) => ({
+      title: r.title || "",
+      url: r.url || "",
+      snippet: r.content || r.description || "",
+    }));
+
+  log(`[WebSearch] Got ${results.length} results for "${query}"`);
+  return results;
+}
+
+/**
+ * Stream-safe web search: races SearXNG against a short deadline.
+ * Returns formatted results text, never throws, never blocks > deadline.
+ */
+export async function executeWebSearch(query: string, deadlineMs = 3000): Promise<string> {
+  try {
+    const results = await Promise.race([
+      fetchFromSearXNG(query),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), deadlineMs)),
+    ]);
+
+    if (results === null) {
+      log(`[WebSearch] Timed out after ${deadlineMs}ms for "${query}"`);
+      return `[Web search for "${query}" timed out. SearXNG did not respond within ${deadlineMs / 1000}s.]`;
+    }
+
+    return formatSearchResults(query, results);
+  } catch (err: any) {
+    log(`[WebSearch] Error: ${err.message}`);
+    return `[Web search for "${query}" failed: ${err.message}]`;
+  }
+}
+
+/**
+ * Format search results as a text block for injection into the stream.
+ */
+export function formatSearchResults(query: string, results: SearchResult[]): string {
+  if (results.length === 0) {
+    return `[Web search for "${query}" returned no results. The search service may be unavailable.]`;
+  }
+
+  const lines = [`[Web search results for "${query}"]\n`];
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    lines.push(`${i + 1}. **${r.title}**`);
+    lines.push(`   ${r.url}`);
+    if (r.snippet) {
+      lines.push(`   ${r.snippet}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Extract the search query from a web_search tool call's arguments JSON.
+ */
+export function extractSearchQuery(argsJson: string): string {
+  try {
+    const args = JSON.parse(argsJson);
+    return args.query || args.q || args.search_query || args.keyword || "";
+  } catch {
+    // If args aren't valid JSON, try to extract from raw string
+    const match = argsJson.match(/"query"\s*:\s*"([^"]+)"/);
+    if (match) return match[1];
+    const match2 = argsJson.match(/"q"\s*:\s*"([^"]+)"/);
+    if (match2) return match2[1];
+    return "";
+  }
+}

--- a/packages/cli/src/handlers/shared/web-search-executor.ts
+++ b/packages/cli/src/handlers/shared/web-search-executor.ts
@@ -236,7 +236,8 @@ async function fetchViaHttp(url: string, deadlineMs = 10_000): Promise<string> {
 
 /**
  * Basic HTML → plain text conversion.
- * Strips tags, decodes common entities, normalizes whitespace.
+ * Strips tags, decodes entities, normalizes whitespace.
+ * Enhanced: extracts main content when possible, removes navigation chrome.
  */
 function htmlToText(html: string): string {
   let text = html;
@@ -245,9 +246,30 @@ function htmlToText(html: string): string {
   text = text.replace(/<script[\s\S]*?<\/script>/gi, "");
   text = text.replace(/<style[\s\S]*?<\/style>/gi, "");
 
+  // Remove SVG blocks (common in GitHub navigation chrome)
+  text = text.replace(/<svg[\s\S]*?<\/svg>/gi, "");
+  text = text.replace(/<path\b[^>]*>/gi, "");
+
+  // Try to extract main content area before stripping tags.
+  // Many sites (GitHub, docs) use <main>, <article>, or role="main".
+  const mainContent =
+    text.match(/<main[^>]*>([\s\S]*?)<\/main>/i)?.[1] ||
+    text.match(/<article[^>]*>([\s\S]*?)<\/article>/i)?.[1] ||
+    text.match(/<[^>]+role=["']main["'][^>]*>([\s\S]*?)<\/\w+>/i)?.[1];
+  if (mainContent && mainContent.length > 200) {
+    text = mainContent;
+  }
+
+  // Remove <nav>, <header>, <footer> blocks (navigation chrome)
+  text = text.replace(/<nav[\s\S]*?<\/nav>/gi, "");
+  text = text.replace(/<header[\s\S]*?<\/header>/gi, "");
+  text = text.replace(/<footer[\s\S]*?<\/footer>/gi, "");
+
   // Convert common block elements to newlines
   text = text.replace(/<\/(p|div|h[1-6]|li|br|tr|blockquote)>/gi, "\n");
   text = text.replace(/<br\s*\/?>/gi, "\n");
+  // Add newlines before headings for better readability
+  text = text.replace(/<h[1-6][^>]*>/gi, "\n\n");
 
   // Remove all remaining HTML tags
   text = text.replace(/<[^>]+>/g, "");
@@ -266,6 +288,96 @@ function htmlToText(html: string): string {
   text = text.replace(/[ \t]+/g, " ");
 
   return text.trim();
+}
+
+/**
+ * Heuristic: detect low-quality web content that is mostly navigation chrome
+ * rather than useful page content. Used to decide whether to re-fetch via MCP
+ * or at least clean up the content.
+ */
+export function isLowQualityWebContent(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length < 100) return false;
+
+  // Known navigation chrome markers (GitHub, docs sites, etc.)
+  const chromeMarkers = [
+    "Skip to content",
+    "Navigation Menu",
+    "Toggle navigation",
+    "Appearance settings",
+    "Sign in",
+    "PlatformAI",
+    "DEVELOPER WORKFLOWS",
+    "APPLICATION SECURITY",
+    "EXPLORE BY TOPIC",
+    "SUPPORT & SERVICES",
+  ];
+  const chromeHits = chromeMarkers.filter(m => trimmed.includes(m)).length;
+  if (chromeHits >= 3) return true;
+
+  // SVG path data (indicates raw HTML rendering artifacts)
+  if (/M\d+\.\d+ \d+\.\d+[a-z]\d+/.test(trimmed)) return true;
+
+  // High ratio of markdown links to text — many `[text](url)` patterns
+  const linkCount = (trimmed.match(/\[([^\]]{1,50})\]\([^)]+\)/g) || []).length;
+  const lineCount = trimmed.split("\n").filter(l => l.trim().length > 0).length;
+  if (linkCount > 20 && linkCount / lineCount > 0.4) return true;
+
+  return false;
+}
+
+/**
+ * Extract the original URL from web content that Claude Code fetched.
+ * Looks for the first identifiable URL pattern in the content.
+ */
+export function extractUrlFromWebContent(text: string): string | null {
+  // Try to find a URL in the first 500 chars (often near the title)
+  const head = text.substring(0, 500);
+
+  // GitHub pattern: the title line often contains the repo URL
+  const githubMatch = head.match(/github\.com\/[\w.-]+\/[\w.-]+/);
+  if (githubMatch) return `https://${githubMatch[0]}`;
+
+  // Generic URL: first http(s) link
+  const urlMatch = head.match(/https?:\/\/[^\s)\]"']+/);
+  if (urlMatch) return urlMatch[0];
+
+  // Search entire content for a markdown link that looks like the page URL
+  const mdLink = text.match(/\]\((https?:\/\/[^\s)]+)\)/);
+  if (mdLink) return mdLink[1];
+
+  return null;
+}
+
+/**
+ * Clean raw web content that arrived as poorly-converted HTML/markdown.
+ * Strips navigation chrome, normalizes structure, keeps only useful text.
+ */
+export function cleanRawWebContent(text: string): string {
+  let cleaned = text;
+
+  // Remove common navigation chrome sections (markdown form)
+  // GitHub-specific: the long navigation block at the top
+  cleaned = cleaned.replace(/Skip to content[\s\S]*?(?=##|\n[A-Z][a-z])/i, "");
+
+  // Remove SVG path data lines
+  cleaned = cleaned.replace(/^[ \t]*M\d+\.\d+.*$/gm, "");
+
+  // Remove lines that are just navigation links (short lines with markdown links)
+  const lines = cleaned.split("\n");
+  const filtered = lines.filter(line => {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return true;
+    if (trimmed.length < 3) return false;
+    if (/^\[.+\]\(.*\)$/.test(trimmed) && trimmed.length < 60) return false;
+    if (/^-{3,}$/.test(trimmed)) return false;
+    return true;
+  });
+
+  cleaned = filtered.join("\n");
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n");
+
+  return truncateContent(cleaned.trim(), 15000);
 }
 
 /**

--- a/packages/cli/src/handlers/shared/web-search-executor.ts
+++ b/packages/cli/src/handlers/shared/web-search-executor.ts
@@ -97,6 +97,135 @@ export function formatSearchResults(query: string, results: SearchResult[]): str
 }
 
 /**
+ * Maximum bytes to download from a URL. Prevents multi-MB pages from
+ * consuming memory and blocking the event loop during regex processing.
+ * 500 KB is plenty for text extraction — we only keep 15K chars of output.
+ */
+const MAX_FETCH_BYTES = 500_000;
+
+/**
+ * Maximum HTML input size for regex-based htmlToText(). If the downloaded
+ * HTML exceeds this, it is pre-truncated. Since we only keep 15K chars of
+ * output, 100K chars of input HTML is more than sufficient.
+ */
+const MAX_HTML_INPUT_CHARS = 100_000;
+
+/**
+ * Fetch a URL and convert HTML to readable text.
+ * Uses streaming with a byte cap to avoid loading multi-MB pages into memory,
+ * and pre-truncates HTML before regex to prevent event-loop blocking.
+ */
+export async function executeWebFetch(url: string, deadlineMs = 10_000): Promise<string> {
+  try {
+    log(`[WebFetch] Fetching: "${url}"`);
+    const response = await fetch(url, {
+      signal: AbortSignal.timeout(deadlineMs),
+      headers: {
+        "User-Agent": "Mozilla/5.0 (compatible; Claudish/1.0)",
+        Accept: "text/html,application/xhtml+xml,text/plain,*/*",
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+
+    // Stream the response body with a byte cap to avoid loading
+    // multi-MB pages (e.g. HuggingFace model cards) into memory.
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    let truncated = false;
+    const reader = response.body!.getReader();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        chunks.push(value);
+        totalBytes += value.length;
+        if (totalBytes > MAX_FETCH_BYTES) {
+          log(`[WebFetch] Body exceeded ${MAX_FETCH_BYTES} bytes after ${totalBytes} bytes, truncating download`);
+          truncated = true;
+          break;
+        }
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    // Decode collected chunks
+    const decoder = new TextDecoder();
+    let body = chunks.map(c => decoder.decode(c, { stream: true })).join("") + decoder.decode();
+
+    // If it's already plain text or JSON, return as-is (truncated)
+    if (contentType.includes("text/plain") || contentType.includes("application/json")) {
+      return truncateContent(body, 15000);
+    }
+
+    // HTML content — pre-truncate before regex to prevent CPU spikes,
+    // then strip tags and decode entities
+    if (contentType.includes("text/html") || body.trimStart().startsWith("<")) {
+      if (body.length > MAX_HTML_INPUT_CHARS) {
+        log(`[WebFetch] Pre-truncating HTML: ${body.length} → ${MAX_HTML_INPUT_CHARS} chars before regex`);
+        body = body.slice(0, MAX_HTML_INPUT_CHARS);
+      }
+      const text = htmlToText(body);
+      log(`[WebFetch] Converted HTML to text: ${body.length} → ${text.length} chars${truncated ? " (download truncated)" : ""}`);
+      return truncateContent(text, 15000);
+    }
+
+    // Unknown content type — return truncated raw text
+    return truncateContent(body, 15000);
+  } catch (err: any) {
+    log(`[WebFetch] Error fetching "${url}": ${err.message}`);
+    return `[Web fetch for "${url}" failed: ${err.message}]`;
+  }
+}
+
+/**
+ * Basic HTML → plain text conversion.
+ * Strips tags, decodes common entities, normalizes whitespace.
+ */
+function htmlToText(html: string): string {
+  let text = html;
+
+  // Remove script and style blocks entirely
+  text = text.replace(/<script[\s\S]*?<\/script>/gi, "");
+  text = text.replace(/<style[\s\S]*?<\/style>/gi, "");
+
+  // Convert common block elements to newlines
+  text = text.replace(/<\/(p|div|h[1-6]|li|br|tr|blockquote)>/gi, "\n");
+  text = text.replace(/<br\s*\/?>/gi, "\n");
+
+  // Remove all remaining HTML tags
+  text = text.replace(/<[^>]+>/g, "");
+
+  // Decode common HTML entities
+  text = text.replace(/&amp;/g, "&");
+  text = text.replace(/&lt;/g, "<");
+  text = text.replace(/&gt;/g, ">");
+  text = text.replace(/&quot;/g, '"');
+  text = text.replace(/&#39;/g, "'");
+  text = text.replace(/&nbsp;/g, " ");
+
+  // Collapse excessive whitespace (3+ newlines → 2)
+  text = text.replace(/\n{3,}/g, "\n\n");
+  // Collapse excessive spaces
+  text = text.replace(/[ \t]+/g, " ");
+
+  return text.trim();
+}
+
+/**
+ * Truncate content to a maximum length, adding an ellipsis if truncated.
+ */
+function truncateContent(text: string, maxLen: number): string {
+  if (text.length <= maxLen) return text;
+  return text.slice(0, maxLen) + `\n\n[... content truncated at ${maxLen} chars. Original length: ${text.length} chars]`;
+}
+
+/**
  * Extract the search query from a web_search tool call's arguments JSON.
  */
 export function extractSearchQuery(argsJson: string): string {

--- a/packages/cli/src/model-catalog.test.ts
+++ b/packages/cli/src/model-catalog.test.ts
@@ -23,9 +23,13 @@ import { GLMModelDialect } from "./adapters/glm-model-dialect.js";
 import { DialectManager } from "./adapters/dialect-manager.js";
 import { AnthropicAPIFormat } from "./adapters/anthropic-api-format.js";
 
-const MINIMAX_API_KEY = process.env.MINIMAX_CODING_API_KEY || process.env.MINIMAX_API_KEY;
+const MINIMAX_CODING_KEY = process.env.MINIMAX_CODING_API_KEY;
+const MINIMAX_REGULAR_KEY = process.env.MINIMAX_API_KEY;
+const MINIMAX_API_KEY = MINIMAX_CODING_KEY || MINIMAX_REGULAR_KEY;
 const SKIP_REAL_API = !MINIMAX_API_KEY;
-const MINIMAX_API_BASE = "https://api.minimax.io/anthropic/v1/messages";
+const MINIMAX_API_BASE = MINIMAX_CODING_KEY
+  ? "https://api.minimax.io/anthropic/v1/messages"
+  : "https://api.minimaxi.com/anthropic/v1/messages";
 
 // ─── Mock slim-cache seeding ─────────────────────────────────────────────────
 

--- a/packages/cli/src/profile-config.ts
+++ b/packages/cli/src/profile-config.ts
@@ -142,6 +142,8 @@ export interface ClaudishProfileConfig {
    * Validation of entries happens at the consumption site (Phase 3) via Zod, not here.
    */
   customEndpoints?: Record<string, unknown>;
+  /** Proxy authentication key — clients must send x-proxy-key matching this value */
+  proxyKey?: string;
 }
 
 /**
@@ -219,6 +221,9 @@ export function loadConfig(): ClaudishProfileConfig {
     }
     if (config.customEndpoints !== undefined) {
       merged.customEndpoints = config.customEndpoints;
+    }
+    if (config.proxyKey !== undefined) {
+      merged.proxyKey = config.proxyKey;
     }
     return merged;
   } catch (error) {

--- a/packages/cli/src/providers/custom-endpoints-loader.ts
+++ b/packages/cli/src/providers/custom-endpoints-loader.ts
@@ -163,7 +163,7 @@ function buildSimpleHandler(
       headers: ctx.provider.headers,
       authScheme: "bearer",
     };
-    const transport = new OpenAIProviderTransport(remoteProvider, finalModel, apiKey);
+    const transport = new OpenAIProviderTransport(remoteProvider, finalModel, apiKey, ep.maxConcurrency);
     const adapter = new OpenAIAPIFormat(finalModel);
     return new ComposedHandler(transport, ctx.targetModel, finalModel, ctx.port, {
       adapter,
@@ -182,7 +182,7 @@ function buildSimpleHandler(
     headers: ctx.provider.headers,
     authScheme: ctx.provider.authScheme ?? "x-api-key",
   };
-  const transport = new AnthropicProviderTransport(remoteProvider, apiKey);
+  const transport = new AnthropicProviderTransport(remoteProvider, apiKey, ep.maxConcurrency);
   const adapter = new AnthropicAPIFormat(finalModel, ctx.provider.name);
   return new ComposedHandler(transport, ctx.targetModel, finalModel, ctx.port, {
     adapter,
@@ -218,7 +218,7 @@ function buildComplexHandler(
         headers: ep.headers,
         authScheme: ep.authScheme ?? "bearer",
       };
-      const transport = new OpenAIProviderTransport(remoteProvider, finalModel, apiKey);
+      const transport = new OpenAIProviderTransport(remoteProvider, finalModel, apiKey, ep.maxConcurrency);
       const adapter = new OpenAIAPIFormat(finalModel);
       return new ComposedHandler(transport, ctx.targetModel, finalModel, ctx.port, {
         adapter,
@@ -236,7 +236,7 @@ function buildComplexHandler(
         headers: ep.headers,
         authScheme: ep.authScheme ?? "x-api-key",
       };
-      const transport = new AnthropicProviderTransport(remoteProvider, apiKey);
+      const transport = new AnthropicProviderTransport(remoteProvider, apiKey, ep.maxConcurrency);
       const adapter = new AnthropicAPIFormat(finalModel, ctx.provider.name);
       return new ComposedHandler(transport, ctx.targetModel, finalModel, ctx.port, {
         adapter,

--- a/packages/cli/src/providers/provider-definitions.test.ts
+++ b/packages/cli/src/providers/provider-definitions.test.ts
@@ -294,6 +294,16 @@ describe("getEffectiveBaseUrl", () => {
     const def = getProviderByName("openrouter")!;
     expect(getEffectiveBaseUrl(def)).toBe("https://openrouter.ai");
   });
+
+  test("minimax (mm@) default baseUrl is minimaxi.com, not minimax.io", () => {
+    const def = getProviderByName("minimax")!;
+    expect(def.baseUrl).toBe("https://api.minimaxi.com");
+  });
+
+  test("minimax-coding (mmc@) default baseUrl remains minimax.io", () => {
+    const def = getProviderByName("minimax-coding")!;
+    expect(def.baseUrl).toBe("https://api.minimax.io");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/src/providers/provider-definitions.ts
+++ b/packages/cli/src/providers/provider-definitions.ts
@@ -229,7 +229,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     name: "minimax",
     displayName: "MiniMax",
     transport: "anthropic",
-    baseUrl: "https://api.minimax.io",
+    baseUrl: "https://api.minimaxi.com",
     baseUrlEnvVars: ["MINIMAX_BASE_URL"],
     apiPath: "/anthropic/v1/messages",
     apiKeyEnvVar: "MINIMAX_API_KEY",

--- a/packages/cli/src/providers/routing-rules.test.ts
+++ b/packages/cli/src/providers/routing-rules.test.ts
@@ -17,12 +17,57 @@ import {
   buildRoutingChain,
   loadRoutingRules,
   mergeRoutingRules,
+  normalizeGlmSlug,
   route,
 } from "./routing-rules.js";
 import { DEFAULT_ROUTING_RULES } from "./default-routing-rules.js";
 import { PROVIDER_SHORTCUTS } from "./model-parser.js";
 import { PROVIDER_TO_PREFIX, DISPLAY_NAMES } from "./auto-route.js";
 import type { RoutingRules } from "../profile-config.js";
+
+// ---------------------------------------------------------------------------
+// normalizeGlmSlug — tolerate dash-slugified GLM version names
+// ---------------------------------------------------------------------------
+
+describe("normalizeGlmSlug", () => {
+  test("rewrites slugified glm versions to canonical dotted form", () => {
+    expect(normalizeGlmSlug("glm-5-2")).toBe("glm-5.2");
+    expect(normalizeGlmSlug("glm-4-6")).toBe("glm-4.6");
+    expect(normalizeGlmSlug("glm-4-5")).toBe("glm-4.5");
+  });
+
+  test("preserves a trailing suffix after the version", () => {
+    expect(normalizeGlmSlug("glm-4-5-air")).toBe("glm-4.5-air");
+    expect(normalizeGlmSlug("glm-4-5-airx")).toBe("glm-4.5-airx");
+  });
+
+  test("leaves already-dotted names untouched", () => {
+    expect(normalizeGlmSlug("glm-5.2")).toBe("glm-5.2");
+    expect(normalizeGlmSlug("glm-4.5-air")).toBe("glm-4.5-air");
+  });
+
+  test("does not touch non-GLM models or dash-native names", () => {
+    // dash-native open-model id (version dot would be wrong) — left as-is
+    expect(normalizeGlmSlug("glm-4-9b")).toBe("glm-4-9b");
+    expect(normalizeGlmSlug("glm-4-flash")).toBe("glm-4-flash");
+    // unrelated families must never be rewritten
+    expect(normalizeGlmSlug("claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(normalizeGlmSlug("qwen3.6-35b-a3b")).toBe("qwen3.6-35b-a3b");
+    expect(normalizeGlmSlug("gpt-4o")).toBe("gpt-4o");
+  });
+});
+
+describe("route — GLM slug tolerance", () => {
+  test("slugified glm-5-2 routes identically to canonical glm-5.2", () => {
+    const rules: RoutingRules = { "glm-5.2": ["openrouter"] };
+    const slug = route("glm-5-2", rules);
+    const canonical = route("glm-5.2", rules);
+    // The dash form must resolve to the exact same plan as the dotted form —
+    // proving the slug no longer misses the canonical rule. (Relative assertion
+    // so it holds regardless of which credentials the test env happens to have.)
+    expect(slug).toEqual(canonical);
+  });
+});
 
 // ---------------------------------------------------------------------------
 // matchRoutingRule — pattern matching

--- a/packages/cli/src/providers/routing-rules.ts
+++ b/packages/cli/src/providers/routing-rules.ts
@@ -12,6 +12,7 @@ import {
   isProviderAvailable,
 } from "./provider-definitions.js";
 import { buildCredentialHint } from "./routing-hints.js";
+import { getRuntimeProviders } from "./runtime-providers.js";
 
 /**
  * Pure merge — defaults < global < local. Exposed for testability so callers
@@ -185,6 +186,10 @@ export type RoutePlan =
  */
 function hasCredentialsForProvider(provider: string): boolean {
   if (isLocalTransport(provider)) return true;
+
+  // Custom endpoints registered at runtime always have credentials —
+  // the loader validates apiKey presence before registration.
+  if (getRuntimeProviders().has(provider)) return true;
 
   if (provider === "native-anthropic") {
     return !!process.env.ANTHROPIC_API_KEY || !!process.env.ANTHROPIC_AUTH_TOKEN;

--- a/packages/cli/src/providers/routing-rules.ts
+++ b/packages/cli/src/providers/routing-rules.ts
@@ -309,6 +309,31 @@ function routeBare(
 }
 
 /**
+ * Normalize a slugified GLM version name back to its canonical dotted form.
+ *
+ * Some clients derive the wire model id from a URL/registry slug and replace
+ * the version dot with a dash: `glm-5.2` → `glm-5-2`, `glm-4.6` → `glm-4-6`,
+ * `glm-4.5-air` → `glm-4-5-air`. Routing rules key on the canonical dotted
+ * name (`glm-5.2` → `gc@glm-5.2`), so without this the slug matches no GLM rule
+ * and fails with a confusing "Unknown Model" 400 from the provider.
+ *
+ * Narrow and anchored by design: only `glm-<digits>-<digits>` (optionally
+ * followed by `-suffix`) is rewritten. Already-dotted names (`glm-5.2`),
+ * dash-native open-model names (`glm-4-9b`), and every non-GLM model are left
+ * exactly as-is — the regex simply doesn't match them.
+ *
+ * Cluster context (2026-06-25): added to unblock the Hermes bot (po-2026),
+ * whose model registry slugified `glm-5.2` into `glm-5-2` before POSTing to the
+ * proxy's `/v1/messages`.
+ */
+export function normalizeGlmSlug(model: string): string {
+  return model.replace(
+    /^glm-(\d+)-(\d+)(-.*)?$/i,
+    (_m, major, minor, suffix) => `glm-${major}.${minor}${suffix ?? ""}`
+  );
+}
+
+/**
  * Resolve a model name to a provider chain.
  *
  * Two paths:
@@ -331,9 +356,12 @@ export function route(
   defaultProviderOverride?: string
 ): RoutePlan {
   const parsed = parseModelSpec(modelSpec);
+  // Tolerate slugified GLM version names (e.g. a client that turns "glm-5.2"
+  // into "glm-5-2") so they match the canonical routing rule instead of failing.
+  const model = normalizeGlmSlug(parsed.model);
 
   if (parsed.isExplicitProvider) {
-    return routeExplicit(modelSpec, parsed.model, parsed.provider);
+    return routeExplicit(modelSpec, model, parsed.provider);
   }
 
   const rules = rulesOverride ?? loadRoutingRules();
@@ -347,5 +375,5 @@ export function route(
       : rulesOverride !== undefined
         ? undefined
         : loadConfig().defaultProvider;
-  return routeBare(parsed.model, parsed.provider, rules, defaultProvider);
+  return routeBare(model, parsed.provider, rules, defaultProvider);
 }

--- a/packages/cli/src/providers/transport/anthropic-compat.test.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.test.ts
@@ -11,10 +11,10 @@
 // and is not part of the Anthropic public API spec — Kimi rejects it with HTTP 400.
 // Fix: stripUnsupportedContentTypes() filters tool_reference from tool_result content arrays.
 
-import { describe, it, expect } from "bun:test";
-import { AnthropicCompatProvider } from "./anthropic-compat.js";
+import { describe, it, test, expect } from "bun:test";
+import { AnthropicCompatProvider, AnthropicProviderTransport } from "./anthropic-compat.js";
 import { AnthropicAPIFormat } from "../../adapters/anthropic-api-format.js";
-import type { RemoteProvider } from "../../../handlers/shared/remote-provider-types.js";
+import type { RemoteProvider } from "../../handlers/shared/remote-provider-types.js";
 
 const TEST_API_KEY = "test-key-abc123";
 
@@ -71,6 +71,45 @@ describe("AnthropicCompatProvider.getHeaders()", () => {
     expect(headers["x-api-key"]).toBe(TEST_API_KEY);
     expect(headers["Authorization"]).toBeUndefined();
     expect(headers["anthropic-version"]).toBe("2023-06-01");
+  });
+});
+
+describe("AnthropicProviderTransport.enqueueRequest 429 retry (+ jitter)", () => {
+  const provider: RemoteProvider = {
+    name: "zai",
+    baseUrl: "https://api.z.ai",
+    apiPath: "/anthropic/v1/messages",
+    apiKeyEnvVar: "ZAI_API_KEY",
+    prefixes: ["zai@"],
+  };
+
+  test("retries on HTTP 429 then returns the eventual success", async () => {
+    const transport = new AnthropicProviderTransport(provider, "test-key");
+    let callCount = 0;
+
+    const response = await transport.enqueueRequest(() => {
+      callCount++;
+      if (callCount <= 2) {
+        return Promise.resolve(new Response('{"error":"rate limited"}', { status: 429 }));
+      }
+      return Promise.resolve(new Response('{"ok":true}', { status: 200 }));
+    });
+
+    expect(response.status).toBe(200);
+    expect(callCount).toBe(3); // 2 retries + 1 success
+  }, 15000); // 2s + 4s backoff (+ up to 2s jitter)
+
+  test("does not retry non-429 responses", async () => {
+    const transport = new AnthropicProviderTransport(provider, "test-key");
+    let callCount = 0;
+
+    const response = await transport.enqueueRequest(() => {
+      callCount++;
+      return Promise.resolve(new Response('{"error":"bad request"}', { status: 400 }));
+    });
+
+    expect(response.status).toBe(400);
+    expect(callCount).toBe(1); // No retry
   });
 });
 

--- a/packages/cli/src/providers/transport/anthropic-compat.test.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.test.ts
@@ -22,7 +22,7 @@ describe("AnthropicCompatProvider.getHeaders()", () => {
   it("returns Authorization: Bearer header when authScheme is 'bearer'", async () => {
     const provider: RemoteProvider = {
       name: "minimax",
-      baseUrl: "https://api.minimax.io",
+      baseUrl: "https://api.minimaxi.com",
       apiPath: "/anthropic/v1/messages",
       apiKeyEnvVar: "MINIMAX_API_KEY",
       prefixes: ["mm@", "mmax@"],

--- a/packages/cli/src/providers/transport/anthropic-compat.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import { homedir } from "node:os";
 import type { ProviderTransport, StreamFormat } from "./types.js";
 import type { RemoteProvider } from "../../handlers/shared/remote-provider-types.js";
+import { LocalModelQueue } from "../../handlers/shared/local-queue.js";
 import { log } from "../../logger.js";
 import { KimiOAuth } from "../../auth/kimi-oauth.js";
 
@@ -21,12 +22,20 @@ export class AnthropicProviderTransport implements ProviderTransport {
 
   private provider: RemoteProvider;
   private apiKey: string;
+  private maxConcurrency?: number;
 
-  constructor(provider: RemoteProvider, apiKey: string) {
+  constructor(provider: RemoteProvider, apiKey: string, maxConcurrency?: number) {
     this.provider = provider;
     this.apiKey = apiKey;
     this.name = provider.name;
+    this.maxConcurrency = maxConcurrency;
     this.displayName = AnthropicProviderTransport.formatDisplayName(provider.name);
+
+    if (this.maxConcurrency !== undefined) {
+      log(
+        `[${this.displayName}] Concurrency: ${this.maxConcurrency === 0 ? "unlimited" : this.maxConcurrency}`
+      );
+    }
   }
 
   getEndpoint(): string {
@@ -93,37 +102,47 @@ export class AnthropicProviderTransport implements ProviderTransport {
    * Response status alone.
    */
   async enqueueRequest(fetchFn: () => Promise<Response>): Promise<Response> {
-    const maxRetries = 5;
-    let lastResponse: Response | null = null;
+    const runWith429Retry = async (): Promise<Response> => {
+      const maxRetries = 5;
+      let lastResponse: Response | null = null;
 
-    for (let attempt = 0; attempt <= maxRetries; attempt++) {
-      const response = await fetchFn();
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        const response = await fetchFn();
 
-      if (response.status === 429 && attempt < maxRetries) {
-        lastResponse = response;
-        const retryAfter = response.headers.get("Retry-After");
-        let delayMs: number;
-        if (retryAfter && !Number.isNaN(Number(retryAfter))) {
-          delayMs = Math.min(Number(retryAfter) * 1000, 30000);
-        } else {
-          // Exponential backoff: 2s, 4s, 8s, 16s, 30s (capped)
-          delayMs = Math.min(2000 * Math.pow(2, attempt), 30000);
+        if (response.status === 429 && attempt < maxRetries) {
+          lastResponse = response;
+          const retryAfter = response.headers.get("Retry-After");
+          let delayMs: number;
+          if (retryAfter && !Number.isNaN(Number(retryAfter))) {
+            delayMs = Math.min(Number(retryAfter) * 1000, 30000);
+          } else {
+            // Exponential backoff: 2s, 4s, 8s, 16s, 30s (capped)
+            delayMs = Math.min(2000 * Math.pow(2, attempt), 30000);
+          }
+          // Jitter: spread cluster-wide synchronized retries off the same boundary.
+          const jitterMs = Math.floor(Math.random() * 1000);
+          const totalMs = delayMs + jitterMs;
+          log(
+            `[${this.displayName}] 429 rate limited, retry ${attempt + 1}/${maxRetries} in ${(totalMs / 1000).toFixed(1)}s`
+          );
+          await new Promise((resolve) => setTimeout(resolve, totalMs));
+          continue;
         }
-        // Jitter: spread cluster-wide synchronized retries off the same boundary.
-        const jitterMs = Math.floor(Math.random() * 1000);
-        const totalMs = delayMs + jitterMs;
-        log(
-          `[${this.displayName}] 429 rate limited, retry ${attempt + 1}/${maxRetries} in ${(totalMs / 1000).toFixed(1)}s`
-        );
-        await new Promise((resolve) => setTimeout(resolve, totalMs));
-        continue;
+
+        return response;
       }
 
-      return response;
-    }
+      // All retries exhausted — return the last 429 response
+      return lastResponse!;
+    };
 
-    // All retries exhausted — return the last 429 response
-    return lastResponse!;
+    // Capacity-limited backend — serialize through the queue so parallel large
+    // prefills can't wedge the engine. See OpenAIProviderTransport for the
+    // same pattern. Unset maxConcurrency = unbounded (unchanged behavior).
+    if (this.maxConcurrency !== undefined && LocalModelQueue.isEnabled()) {
+      return LocalModelQueue.getInstance().enqueue(runWith429Retry, this.name, this.maxConcurrency);
+    }
+    return runWith429Retry();
   }
 
   private static formatDisplayName(name: string): string {

--- a/packages/cli/src/providers/transport/anthropic-compat.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.ts
@@ -76,6 +76,56 @@ export class AnthropicProviderTransport implements ProviderTransport {
     return headers;
   }
 
+  /**
+   * Retry HTTP 429 responses with jittered exponential backoff.
+   *
+   * The anthropic-compat providers (Z.AI, MiniMax, Kimi) previously had NO
+   * transport-level retry at all — a bare 429 propagated straight up. This
+   * mirrors OpenAIProviderTransport's retry but ADDS jitter: the whole cluster
+   * shares a single key per provider, so without jitter every machine retries
+   * on the same 2s/4s/8s boundary and re-collides on the burst limit. The
+   * jitter spreads those retries out.
+   *
+   * Note: this only covers errors the provider returns as an HTTP 429. Z.AI's
+   * burst limit is frequently delivered as HTTP 200 + an in-stream SSE error
+   * ([1302]); that variant is handled one layer up in ComposedHandler (peek +
+   * backoff-retry + cross-provider fallback), since it isn't visible from the
+   * Response status alone.
+   */
+  async enqueueRequest(fetchFn: () => Promise<Response>): Promise<Response> {
+    const maxRetries = 5;
+    let lastResponse: Response | null = null;
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      const response = await fetchFn();
+
+      if (response.status === 429 && attempt < maxRetries) {
+        lastResponse = response;
+        const retryAfter = response.headers.get("Retry-After");
+        let delayMs: number;
+        if (retryAfter && !Number.isNaN(Number(retryAfter))) {
+          delayMs = Math.min(Number(retryAfter) * 1000, 30000);
+        } else {
+          // Exponential backoff: 2s, 4s, 8s, 16s, 30s (capped)
+          delayMs = Math.min(2000 * Math.pow(2, attempt), 30000);
+        }
+        // Jitter: spread cluster-wide synchronized retries off the same boundary.
+        const jitterMs = Math.floor(Math.random() * 1000);
+        const totalMs = delayMs + jitterMs;
+        log(
+          `[${this.displayName}] 429 rate limited, retry ${attempt + 1}/${maxRetries} in ${(totalMs / 1000).toFixed(1)}s`
+        );
+        await new Promise((resolve) => setTimeout(resolve, totalMs));
+        continue;
+      }
+
+      return response;
+    }
+
+    // All retries exhausted — return the last 429 response
+    return lastResponse!;
+  }
+
   private static formatDisplayName(name: string): string {
     const map: Record<string, string> = {
       minimax: "MiniMax",

--- a/packages/cli/src/providers/transport/openai.ts
+++ b/packages/cli/src/providers/transport/openai.ts
@@ -8,6 +8,7 @@
 
 import type { ProviderTransport, StreamFormat } from "./types.js";
 import type { RemoteProvider } from "../../handlers/shared/remote-provider-types.js";
+import { LocalModelQueue } from "../../handlers/shared/local-queue.js";
 import { log } from "../../logger.js";
 
 export class OpenAIProviderTransport implements ProviderTransport {
@@ -18,18 +19,31 @@ export class OpenAIProviderTransport implements ProviderTransport {
   protected provider: RemoteProvider;
   private apiKey: string;
   private modelName: string;
+  private maxConcurrency?: number;
 
-  constructor(provider: RemoteProvider, modelName: string, apiKey: string) {
+  constructor(
+    provider: RemoteProvider,
+    modelName: string,
+    apiKey: string,
+    maxConcurrency?: number
+  ) {
     this.provider = provider;
     this.modelName = modelName;
     this.apiKey = apiKey;
     this.name = provider.name;
+    this.maxConcurrency = maxConcurrency;
     this.displayName = OpenAIProviderTransport.formatDisplayName(provider.name);
 
     // Codex models use the Responses API which has a different streaming format
     this.streamFormat = modelName.toLowerCase().includes("codex")
       ? "openai-responses-sse"
       : "openai-sse";
+
+    if (this.maxConcurrency !== undefined) {
+      log(
+        `[${this.displayName}] Concurrency: ${this.maxConcurrency === 0 ? "unlimited" : this.maxConcurrency}`
+      );
+    }
   }
 
   getEndpoint(): string {
@@ -50,49 +64,65 @@ export class OpenAIProviderTransport implements ProviderTransport {
   /**
    * Override fetch with 30-second timeout, 429 retry with exponential backoff,
    * and detailed error handling.
+   *
+   * If `maxConcurrency` is set (capacity-limited backends, e.g. a single-GPU
+   * vLLM server), the whole fetch+retry unit is run through LocalModelQueue so
+   * at most N requests are in flight to the backend at once. This prevents
+   * parallel large prefills from wedging the engine. Unset = unbounded (the
+   * default, unchanged behavior for every standard remote provider).
    */
   async enqueueRequest(fetchFn: () => Promise<Response>): Promise<Response> {
-    const maxRetries = 5;
-    let lastResponse: Response | null = null;
+    const runWith429Retry = async (): Promise<Response> => {
+      const maxRetries = 5;
+      let lastResponse: Response | null = null;
 
-    for (let attempt = 0; attempt <= maxRetries; attempt++) {
-      try {
-        const response = await fetchFn();
+      for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+          const response = await fetchFn();
 
-        if (response.status === 429 && attempt < maxRetries) {
-          lastResponse = response;
-          // Parse Retry-After header if present
-          const retryAfter = response.headers.get("Retry-After");
-          let delayMs: number;
-          if (retryAfter && !Number.isNaN(Number(retryAfter))) {
-            delayMs = Math.min(Number(retryAfter) * 1000, 30000);
-          } else {
-            // Exponential backoff: 2s, 4s, 8s, 16s, 30s
-            delayMs = Math.min(2000 * Math.pow(2, attempt), 30000);
+          if (response.status === 429 && attempt < maxRetries) {
+            lastResponse = response;
+            // Parse Retry-After header if present
+            const retryAfter = response.headers.get("Retry-After");
+            let delayMs: number;
+            if (retryAfter && !Number.isNaN(Number(retryAfter))) {
+              delayMs = Math.min(Number(retryAfter) * 1000, 30000);
+            } else {
+              // Exponential backoff: 2s, 4s, 8s, 16s, 30s
+              delayMs = Math.min(2000 * Math.pow(2, attempt), 30000);
+            }
+            log(
+              `[${this.displayName}] 429 rate limited, retry ${attempt + 1}/${maxRetries} in ${(delayMs / 1000).toFixed(1)}s`
+            );
+            await new Promise((resolve) => setTimeout(resolve, delayMs));
+            continue;
           }
-          log(
-            `[${this.displayName}] 429 rate limited, retry ${attempt + 1}/${maxRetries} in ${(delayMs / 1000).toFixed(1)}s`
-          );
-          await new Promise((resolve) => setTimeout(resolve, delayMs));
-          continue;
-        }
 
-        return response;
-      } catch (fetchError: any) {
-        if (fetchError.name === "AbortError") {
-          log(`[${this.displayName}] Request timed out after 30s`);
-          throw new OpenAITimeoutError(this.provider.baseUrl);
+          return response;
+        } catch (fetchError: any) {
+          if (fetchError.name === "AbortError") {
+            log(`[${this.displayName}] Request timed out after 30s`);
+            throw new OpenAITimeoutError(this.provider.baseUrl);
+          }
+          if (fetchError.cause?.code === "UND_ERR_CONNECT_TIMEOUT") {
+            log(`[${this.displayName}] Connection timeout: ${fetchError.message}`);
+            throw new OpenAIConnectionError(this.provider.baseUrl, fetchError.cause?.code);
+          }
+          throw fetchError;
         }
-        if (fetchError.cause?.code === "UND_ERR_CONNECT_TIMEOUT") {
-          log(`[${this.displayName}] Connection timeout: ${fetchError.message}`);
-          throw new OpenAIConnectionError(this.provider.baseUrl, fetchError.cause?.code);
-        }
-        throw fetchError;
       }
-    }
 
-    // All retries exhausted — return the last 429 response
-    return lastResponse!;
+      // All retries exhausted — return the last 429 response
+      return lastResponse!;
+    };
+
+    // Capacity-limited backend (e.g. single-GPU vLLM) — serialize through the
+    // queue so parallel large prefills can't wedge the engine. The 429 retry
+    // unit above is a single queued item: at most maxConcurrency are in flight.
+    if (this.maxConcurrency !== undefined && LocalModelQueue.isEnabled()) {
+      return LocalModelQueue.getInstance().enqueue(runWith429Retry, this.name, this.maxConcurrency);
+    }
+    return runWith429Retry();
   }
 
   static formatDisplayName(name: string): string {

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -499,6 +499,53 @@ export async function createProxyServer(
   );
   app.get("/health", (c) => c.json({ status: "ok" }));
 
+  // Model discovery endpoint — Claude Code queries /v1/models when
+  // CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 is set. Returns all
+  // routable models from config.json routing rules + custom endpoints.
+  app.get("/v1/models", (c) => {
+    const cfg = loadConfig();
+    const seen = new Set<string>();
+    const models: { id: string; display_name: string; created_at: string }[] = [];
+
+    // From routing rules — each key is a model name
+    if (cfg.routing) {
+      for (const modelName of Object.keys(cfg.routing)) {
+        if (!seen.has(modelName)) {
+          seen.add(modelName);
+          models.push({
+            id: modelName,
+            display_name: modelName,
+            created_at: "2026-01-01T00:00:00Z",
+          });
+        }
+      }
+    }
+
+    // From custom endpoints — each declared model
+    if (cfg.customEndpoints) {
+      for (const [, ep] of Object.entries(cfg.customEndpoints)) {
+        const endpoint = ep as { models?: string[] };
+        if (endpoint.models) {
+          for (const m of endpoint.models) {
+            if (!seen.has(m)) {
+              seen.add(m);
+              models.push({
+                id: m,
+                display_name: m,
+                created_at: "2026-01-01T00:00:00Z",
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return c.json({
+      object: "list",
+      data: models,
+    });
+  });
+
   // Token counting
   app.post("/v1/messages/count_tokens", async (c) => {
     try {

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -183,6 +183,99 @@ function buildTextResponse(model: string, text: string, streaming: boolean): Res
   });
 }
 
+/**
+ * Build an assistant response with web tool results as text blocks.
+ *
+ * IMPORTANT: We must NOT use tool_result blocks here. In the Anthropic API,
+ * tool_result blocks are only valid in messages with role: "user". Returning
+ * them in an assistant message (role: "assistant") causes the client to store
+ * malformed conversation history, leading to 400 errors on subsequent requests:
+ *   "tool_result blocks can only be in user messages"
+ *
+ * Instead, we inject the search/fetch results as a text block in a normal
+ * assistant response — the same approach used by openai-sse.ts suppression.
+ */
+function buildToolResultResponse(model: string, toolResults: any[], streaming: boolean): Response {
+  const encoder = new TextEncoder();
+  const send = (event: string, data: any) =>
+    encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+
+  // Combine all tool results into a single text block
+  const combinedText = toolResults.map((tr) => tr.content).join("\n\n");
+
+  if (!streaming) {
+    return new Response(JSON.stringify({
+      id: `msg_webtools_${Date.now()}`,
+      type: "message",
+      role: "assistant",
+      model,
+      content: [{ type: "text", text: combinedText }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }), {
+      headers: {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+      },
+    });
+  }
+
+  // Streaming SSE response — emit results as a text content block
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(send("message_start", {
+        type: "message_start",
+        message: {
+          id: `msg_webtools_${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      }));
+
+      controller.enqueue(send("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }));
+
+      controller.enqueue(send("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: combinedText },
+      }));
+
+      controller.enqueue(send("content_block_stop", {
+        type: "content_block_stop",
+        index: 0,
+      }));
+
+      controller.enqueue(send("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { input_tokens: 0, output_tokens: 0 },
+      }));
+
+      controller.enqueue(send("message_stop", { type: "message_stop" }));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "anthropic-version": "2023-06-01",
+    },
+  });
+}
+
 export interface ProxyServerOptions {
   summarizeTools?: boolean; // Summarize tool descriptions for local models
   quiet?: boolean; // Suppress informational stderr output (e.g., [Auto-route])

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -33,6 +33,7 @@ import { wrapAnthropicError } from "./handlers/shared/anthropic-error.js";
 import { route, loadRoutingRules } from "./providers/routing-rules.js";
 import { createHandlerForProvider } from "./providers/provider-profiles.js";
 import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
+import { getRuntimeProviders } from "./providers/runtime-providers.js";
 import { loadConfig } from "./profile-config.js";
 
 export interface ProxyServerOptions {
@@ -41,6 +42,7 @@ export interface ProxyServerOptions {
   isInteractive?: boolean; // Whether the current session is interactive (gates consent prompt)
   advisorModels?: string[]; // Advisor models from --advisor flag
   advisorCollector?: string | null; // Collector model (null = no synthesis)
+  hostname?: string; // Bind address (default: "127.0.0.1", use "0.0.0.0" for Docker)
 }
 
 export async function createProxyServer(
@@ -233,7 +235,9 @@ export async function createProxyServer(
       resolution.wasAutoRouted && resolution.fullModelId ? resolution.fullModelId : targetModel;
 
     // If resolver says use direct-api and key is available, create handler
-    if (resolution.category === "direct-api" && resolution.apiKeyAvailable) {
+    // Custom endpoints registered at runtime always have credentials (resolved from config)
+    const isRuntimeProvider = getRuntimeProviders().has(resolution.parsed?.provider ?? "");
+    if (resolution.category === "direct-api" && (resolution.apiKeyAvailable || isRuntimeProvider)) {
       const resolved = resolveRemoteProvider(resolveTarget);
       if (!resolved) return null;
 
@@ -459,6 +463,31 @@ export async function createProxyServer(
   const app = new Hono();
   app.use("*", cors());
 
+  // Proxy auth: validate standard Anthropic auth headers against the proxy key.
+  // Claude Code sends ANTHROPIC_AUTH_TOKEN as "authorization: Bearer <token>" or
+  // "x-api-key: <token>". We check all three headers so the proxy key doubles as
+  // the auth token — no custom headers needed.
+  // Health/status endpoints are exempt for Docker healthcheck compatibility.
+  const proxyKey = process.env.CLAUDISH_PROXY_KEY || loadConfig().proxyKey;
+  if (proxyKey) {
+    app.use("/v1/*", async (c, next) => {
+      const authHeader = c.req.header("authorization");
+      const apiKeyHeader = c.req.header("x-api-key");
+      const proxyKeyHeader = c.req.header("x-proxy-key");
+
+      const bearerToken = authHeader?.startsWith("Bearer ")
+        ? authHeader.slice(7)
+        : authHeader;
+
+      const provided = proxyKeyHeader || apiKeyHeader || bearerToken;
+      if (!provided || provided !== proxyKey) {
+        return c.json(wrapAnthropicError(401, "invalid proxy authentication"), 401);
+      }
+      await next();
+    });
+    log("[Proxy] Authentication enabled (proxy key required via authorization/x-api-key/x-proxy-key)");
+  }
+
   app.get("/", (c) =>
     c.json({
       status: "ok",
@@ -514,7 +543,8 @@ export async function createProxyServer(
     }
   });
 
-  const server = serve({ fetch: app.fetch, port, hostname: "127.0.0.1" });
+  const bindHost = options.hostname ?? "127.0.0.1";
+  const server = serve({ fetch: app.fetch, port, hostname: bindHost });
 
   // Port resolution
   const addr = server.address();
@@ -538,7 +568,7 @@ export async function createProxyServer(
 
   return {
     port,
-    url: `http://127.0.0.1:${port}`,
+    url: `http://${bindHost}:${port}`,
     shutdown: async () => {
       return new Promise<void>((resolve) => server.close(() => resolve()));
     },

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -36,7 +36,7 @@ import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
 import { getRuntimeProviders } from "./providers/runtime-providers.js";
 import { loadConfig } from "./profile-config.js";
 import { registerForkExtensions, stripBillingHeaderFromBody, logRequest, createHostnameConfig } from "./fork/index.js";
-import { executeWebSearch, executeWebFetch } from "./handlers/shared/web-search-executor.js";
+import { executeWebSearch, executeWebFetch, isLowQualityWebContent, extractUrlFromWebContent, cleanRawWebContent } from "./handlers/shared/web-search-executor.js";
 
 /**
  * Intercept WebSearch/WebFetch tool calls and execute them via SearXNG instead
@@ -75,6 +75,30 @@ async function interceptWebTools(c: any, body: any): Promise<Response | null> {
       // MCP web_url_read → MCP via r.jina.ai → direct HTTP → error text.
       const resultText = await executeWebFetch(url, 10_000);
       return buildTextResponse(body.model || "unknown", resultText, isStreaming);
+    }
+
+    // Case 3: Claude Code already fetched the page and sends raw HTML/markdown
+    // to a sub-agent for analysis. Format: "Web page content:\n---\n<content>"
+    // This happens when Claude Code's native WebFetch tool fetches the page
+    // itself, converts to markdown poorly, and delegates to a sub-agent.
+    const webContentMatch = text.match(/^Web page content:\s*\n---\n([\s\S]+)$/);
+    if (webContentMatch) {
+      const rawContent = webContentMatch[1];
+      if (isLowQualityWebContent(rawContent)) {
+        log(`[WebTools] Detected low-quality web content in sub-agent, attempting re-fetch`);
+        const url = extractUrlFromWebContent(rawContent);
+        if (url) {
+          log(`[WebTools] Re-fetching "${url}" via clean pipeline`);
+          const cleanContent = await executeWebFetch(url, 10_000);
+          return buildTextResponse(body.model || "unknown", cleanContent, isStreaming);
+        }
+        // No URL extractable — clean the raw content as best we can
+        log(`[WebTools] No URL found, cleaning raw web content`);
+        const cleaned = cleanRawWebContent(rawContent);
+        return buildTextResponse(body.model || "unknown", cleaned, isStreaming);
+      }
+      // Content looks reasonable — let it through to the normal handler
+      return null;
     }
   }
 

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -608,6 +608,26 @@ export async function createProxyServer(
       const body = await c.req.json();
       const handler = await getHandlerForRequest(body.model);
 
+      // Strip Claude Code billing header from system prompt for non-Anthropic
+      // providers. Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
+      // into the prompt body — the `cch=` token changes every request, which breaks
+      // vLLM prefix caching (strict hash). Only Anthropic needs this; strip for others.
+      if (!(handler instanceof NativeHandler) && typeof body.system === "string") {
+        body.system = body.system.replace(
+          /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+          ""
+        );
+      } else if (!(handler instanceof NativeHandler) && Array.isArray(body.system)) {
+        for (const block of body.system) {
+          if (block.type === "text" && typeof block.text === "string") {
+            block.text = block.text.replace(
+              /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
+              ""
+            );
+          }
+        }
+      }
+
       // Route
       return handler.handle(c, body);
     } catch (e) {

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -36,6 +36,152 @@ import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
 import { getRuntimeProviders } from "./providers/runtime-providers.js";
 import { loadConfig } from "./profile-config.js";
 import { registerForkExtensions, stripBillingHeaderFromBody, logRequest, createHostnameConfig } from "./fork/index.js";
+import { executeWebSearch } from "./handlers/shared/web-search-executor.js";
+
+/**
+ * Intercept WebSearch/WebFetch tool calls and execute them via SearXNG instead
+ * of forwarding to the provider. Returns a streaming response with SearXNG results.
+ *
+ * Claude Code's WebSearch tool sends a sub-agent request with a single user message:
+ *   "Perform a web search for the query: <query>"
+ * We intercept this, execute SearXNG, and return the results as text.
+ */
+async function interceptWebTools(c: any, body: any): Promise<Response | null> {
+  const messages = body.messages || [];
+  const isStreaming = body.stream === true;
+
+  // Case 1: Sub-agent web search request (1 message, user role, starts with "Perform a web search")
+  if (messages.length === 1 && messages[0].role === "user") {
+    const text = typeof messages[0].content === "string"
+      ? messages[0].content
+      : Array.isArray(messages[0].content)
+        ? messages[0].content.map((b: any) => b.text || "").join("")
+        : "";
+
+    const searchMatch = text.match(/^Perform a web search for the query:\s*(.+)$/s);
+    if (searchMatch) {
+      const query = searchMatch[1].trim();
+      log(`[WebTools] Intercepted sub-agent web search: "${query}"`);
+      const results = await executeWebSearch(query, 5000);
+      log(`[WebTools] SearXNG results: ${results.slice(0, 100)}...`);
+      return buildTextResponse(body.model || "unknown", results, isStreaming);
+    }
+
+    const fetchMatch = text.match(/^Perform a web fetch for the URL:\s*(.+)$/s);
+    if (fetchMatch) {
+      const url = fetchMatch[1].trim();
+      log(`[WebTools] Intercepted sub-agent web fetch: "${url}"`);
+      let resultText: string;
+      try {
+        const fetchUrl = `${process.env.SEARXNG_URL || "http://search.myia.io"}/search?q=${encodeURIComponent(url)}&format=json&categories=general`;
+        const resp = await fetch(fetchUrl, { signal: AbortSignal.timeout(5000) });
+        const data = await resp.json() as any;
+        const results = (data.results || []).slice(0, 3);
+        resultText = results.length > 0
+          ? results.map((r: any) => `**${r.title}**\n${r.url}\n${r.content || ""}`).join("\n\n")
+          : `[No results found for URL: ${url}]`;
+      } catch (err: any) {
+        resultText = `[Web fetch for "${url}" failed: ${err.message}]`;
+      }
+      return buildTextResponse(body.model || "unknown", resultText, isStreaming);
+    }
+  }
+
+  // Case 2: tool_use in last assistant message for WebSearch/WebFetch
+  const lastAssistant = [...messages].reverse().find((m: any) => m.role === "assistant");
+  if (lastAssistant?.content) {
+    const content = Array.isArray(lastAssistant.content) ? lastAssistant.content : [];
+    const webToolCalls = content.filter(
+      (b: any) => b.type === "tool_use" && (b.name === "WebSearch" || b.name === "WebFetch")
+    );
+    if (webToolCalls.length > 0) {
+      log(`[WebTools] Intercepting ${webToolCalls.length} tool_use WebSearch/WebFetch`);
+      // For now, let these fall through to the normal handler
+      // (they'll be handled by the stream parser's searchWeb detection)
+    }
+  }
+
+  return null;
+}
+
+function buildTextResponse(model: string, text: string, streaming: boolean): Response {
+  const encoder = new TextEncoder();
+  const send = (event: string, data: any) =>
+    encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+
+  if (!streaming) {
+    // Non-streaming JSON response
+    return new Response(JSON.stringify({
+      id: `msg_webtools_${Date.now()}`,
+      type: "message",
+      role: "assistant",
+      model,
+      content: [{ type: "text", text }],
+      stop_reason: "end_turn",
+      stop_sequence: null,
+      usage: { input_tokens: 0, output_tokens: 0 },
+    }), {
+      headers: {
+        "Content-Type": "application/json",
+        "anthropic-version": "2023-06-01",
+      },
+    });
+  }
+
+  // Streaming SSE response
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(send("message_start", {
+        type: "message_start",
+        message: {
+          id: `msg_webtools_${Date.now()}`,
+          type: "message",
+          role: "assistant",
+          model,
+          content: [],
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      }));
+
+      controller.enqueue(send("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }));
+
+      controller.enqueue(send("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text },
+      }));
+
+      controller.enqueue(send("content_block_stop", {
+        type: "content_block_stop",
+        index: 0,
+      }));
+
+      controller.enqueue(send("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { input_tokens: 0, output_tokens: 0 },
+      }));
+
+      controller.enqueue(send("message_stop", { type: "message_stop" }));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+      "anthropic-version": "2023-06-01",
+    },
+  });
+}
 
 export interface ProxyServerOptions {
   summarizeTools?: boolean; // Summarize tool descriptions for local models
@@ -542,6 +688,26 @@ export async function createProxyServer(
   app.post("/v1/messages", async (c) => {
     try {
       const body = await c.req.json();
+
+      // Log tool names in request for debugging WebSearch/WebFetch
+      const toolNames = (body.tools || []).map((t: any) => t.name);
+      if (toolNames.length > 0) log(`[Proxy] Tools in request: ${toolNames.join(", ")}`);
+      // Also check messages for tool_use blocks
+      const lastMsg = body.messages?.[body.messages.length - 1];
+      if (lastMsg?.content) {
+        const blocks = Array.isArray(lastMsg.content) ? lastMsg.content : [];
+        const toolUses = blocks.filter((b: any) => b.type === "tool_use");
+        if (toolUses.length > 0) log(`[Proxy] Last msg tool_use: ${toolUses.map((t: any) => t.name).join(", ")}`);
+      }
+
+      // Intercept WebSearch/WebFetch tool calls and execute via SearXNG
+      try {
+        const webToolResponse = await interceptWebTools(c, body);
+        if (webToolResponse) return webToolResponse;
+      } catch (e: any) {
+        log(`[WebTools] Intercept error (falling through to normal handler): ${e.message}`);
+      }
+
       const handler = await getHandlerForRequest(body.model);
       logRequest(body, handler.constructor.name, c.req.raw, hostnameConfig.remoteAddrMap);
       stripBillingHeaderFromBody(body, handler instanceof NativeHandler);

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -466,13 +466,37 @@ export async function createProxyServer(
   const app = new Hono();
   app.use("*", cors());
 
-  // Proxy auth: validate standard Anthropic auth headers against the proxy key.
-  // Claude Code sends ANTHROPIC_AUTH_TOKEN as "authorization: Bearer <token>" or
-  // "x-api-key: <token>". We check all three headers so the proxy key doubles as
-  // the auth token — no custom headers needed.
-  // Health/status endpoints are exempt for Docker healthcheck compatibility.
+  // Model-aware proxy auth: Anthropic pass-through is exempt (OAuth or proxy-key
+  // swap handled by NativeHandler). Non-Anthropic providers require the proxy key
+  // in x-api-key / authorization / x-proxy-key. GET requests and health endpoints
+  // are exempt for Docker healthcheck and model discovery compatibility.
   if (proxyKey) {
     app.use("/v1/*", async (c, next) => {
+      if (c.req.method === "GET") {
+        return await next();
+      }
+
+      // Peek at body.model to determine target provider.
+      // Hono caches parsed JSON — safe to call again from the route handler.
+      let model: string | undefined;
+      try {
+        const body = await c.req.json();
+        model = body?.model;
+      } catch {
+        return await next(); // Malformed body — let handler return 400
+      }
+
+      // Anthropic pass-through: skip proxy key validation entirely.
+      // NativeHandler will either swap proxyKey → stored Anthropic key,
+      // or pass the client's OAuth token through unchanged.
+      if (model) {
+        const spec = parseModelSpec(model);
+        if (spec.provider === "native-anthropic") {
+          return await next();
+        }
+      }
+
+      // Non-Anthropic: enforce proxy key
       const authHeader = c.req.header("authorization");
       const apiKeyHeader = c.req.header("x-api-key");
       const proxyKeyHeader = c.req.header("x-proxy-key");
@@ -487,7 +511,7 @@ export async function createProxyServer(
       }
       await next();
     });
-    log("[Proxy] Authentication enabled (proxy key required via authorization/x-api-key/x-proxy-key)");
+    log("[Proxy] Authentication enabled (Anthropic pass-through; proxy key required for other providers)");
   }
 
   app.get("/", (c) =>
@@ -607,6 +631,12 @@ export async function createProxyServer(
     try {
       const body = await c.req.json();
       const handler = await getHandlerForRequest(body.model);
+      const xff = c.req.header("x-forwarded-for") || "";
+      const xrip = c.req.header("x-real-ip") || "";
+      const ua = c.req.header("user-agent") || "";
+      const directIp = remoteAddrMap.get(c.req.raw) || "";
+      const src = xff || xrip || directIp || "direct";
+      console.log(`[claudish] [Request] model=${body.model ?? "(none)"} handler=${handler.constructor.name} src=${src} ua=${ua.slice(0, 60)}`);
 
       // Strip Claude Code billing header from system prompt for non-Anthropic
       // providers. Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
@@ -637,7 +667,22 @@ export async function createProxyServer(
   });
 
   const bindHost = options.hostname ?? "127.0.0.1";
-  const server = serve({ fetch: app.fetch, port, hostname: bindHost });
+  // Store remote addresses for direct connections (no IIS/proxy).
+  // Hono middleware can't access the socket, so we intercept at the
+  // serve() level and pass the IP through the Request headers.
+  const remoteAddrMap = new WeakMap<Request, string>();
+  const server = serve({
+    fetch(req, env, ctx) {
+      if (!req.headers.get("x-forwarded-for") && !req.headers.get("x-real-ip")) {
+        // @ts-expect-error — Bun injects remoteAddress on the server info object
+        const addr = ctx?.remoteAddress?.address as string | undefined;
+        if (addr) remoteAddrMap.set(req, addr);
+      }
+      return app.fetch(req, env, ctx);
+    },
+    port,
+    hostname: bindHost,
+  });
 
   // Port resolution
   const addr = server.address();

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -511,20 +511,38 @@ export async function createProxyServer(
       }
       const handler = await getHandlerForRequest(body.model);
 
-      // If native, we just forward. OpenRouter needs estimation.
+      // If native, forward transparently (all client headers passthrough).
       if (handler instanceof NativeHandler) {
-        const headers: any = { "Content-Type": "application/json" };
-        if (anthropicApiKey) {
-          if (anthropicApiKey.startsWith("sk-ant-oat")) {
-            headers["authorization"] = `Bearer ${anthropicApiKey}`;
-          } else {
-            headers["x-api-key"] = anthropicApiKey;
+        const HOP_BY_HOP = new Set([
+          "host", "connection", "keep-alive", "transfer-encoding", "te",
+          "trailer", "upgrade", "content-length",
+        ]);
+        const reqHeaders: Record<string, string> = { "Content-Type": "application/json" };
+        for (const [key, value] of Object.entries(c.req.header())) {
+          if (HOP_BY_HOP.has(key.toLowerCase()) || typeof value !== "string") continue;
+          reqHeaders[key] = value;
+        }
+        // Proxy key override (same logic as NativeHandler)
+        if (proxyKey) {
+          const authHeader = c.req.header("authorization");
+          const bearerToken = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : authHeader;
+          const clientAuthToken = c.req.header("x-api-key") || bearerToken;
+          if (clientAuthToken === proxyKey) {
+            delete reqHeaders["x-api-key"];
+            delete reqHeaders["authorization"];
+            if (anthropicApiKey) {
+              if (anthropicApiKey.startsWith("sk-ant-oat")) {
+                reqHeaders["authorization"] = `Bearer ${anthropicApiKey}`;
+              } else {
+                reqHeaders["x-api-key"] = anthropicApiKey;
+              }
+            }
           }
         }
 
         const res = await fetch("https://api.anthropic.com/v1/messages/count_tokens", {
           method: "POST",
-          headers,
+          headers: reqHeaders,
           body: JSON.stringify(body),
         });
         return c.json(await res.json());

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -36,7 +36,7 @@ import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
 import { getRuntimeProviders } from "./providers/runtime-providers.js";
 import { loadConfig } from "./profile-config.js";
 import { registerForkExtensions, stripBillingHeaderFromBody, logRequest, createHostnameConfig } from "./fork/index.js";
-import { executeWebSearch } from "./handlers/shared/web-search-executor.js";
+import { executeWebSearch, executeWebFetch } from "./handlers/shared/web-search-executor.js";
 
 /**
  * Intercept WebSearch/WebFetch tool calls and execute them via SearXNG instead
@@ -71,18 +71,9 @@ async function interceptWebTools(c: any, body: any): Promise<Response | null> {
     if (fetchMatch) {
       const url = fetchMatch[1].trim();
       log(`[WebTools] Intercepted sub-agent web fetch: "${url}"`);
-      let resultText: string;
-      try {
-        const fetchUrl = `${process.env.SEARXNG_URL || "http://search.myia.io"}/search?q=${encodeURIComponent(url)}&format=json&categories=general`;
-        const resp = await fetch(fetchUrl, { signal: AbortSignal.timeout(5000) });
-        const data = await resp.json() as any;
-        const results = (data.results || []).slice(0, 3);
-        resultText = results.length > 0
-          ? results.map((r: any) => `**${r.title}**\n${r.url}\n${r.content || ""}`).join("\n\n")
-          : `[No results found for URL: ${url}]`;
-      } catch (err: any) {
-        resultText = `[Web fetch for "${url}" failed: ${err.message}]`;
-      }
+      // Real fetch with graceful degradation:
+      // MCP web_url_read → MCP via r.jina.ai → direct HTTP → error text.
+      const resultText = await executeWebFetch(url, 10_000);
       return buildTextResponse(body.model || "unknown", resultText, isStreaming);
     }
   }

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -54,6 +54,9 @@ export async function createProxyServer(
   modelMap?: { opus?: string; sonnet?: string; haiku?: string; subagent?: string },
   options: ProxyServerOptions = {}
 ): Promise<ProxyServer> {
+  // Resolve proxy key early — needed for both auth middleware and NativeHandler
+  const proxyKey = process.env.CLAUDISH_PROXY_KEY || loadConfig().proxyKey;
+
   // Load user-declared custom endpoints from ~/.claudish/config.json and
   // register them in the runtime provider registry so they appear in lookups
   // and handler creation. Runs once per proxy lifetime; idempotent.
@@ -76,7 +79,7 @@ export async function createProxyServer(
   }
 
   // Define handlers for different roles
-  const nativeHandler = new NativeHandler(anthropicApiKey, options.advisorModels, options.advisorCollector);
+  const nativeHandler = new NativeHandler(anthropicApiKey, options.advisorModels, options.advisorCollector, proxyKey);
   const openRouterHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> OpenRouter Handler
   const localProviderHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> Local Provider Handler
   const remoteProviderHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> Gemini/OpenAI Handler
@@ -468,7 +471,6 @@ export async function createProxyServer(
   // "x-api-key: <token>". We check all three headers so the proxy key doubles as
   // the auth token — no custom headers needed.
   // Health/status endpoints are exempt for Docker healthcheck compatibility.
-  const proxyKey = process.env.CLAUDISH_PROXY_KEY || loadConfig().proxyKey;
   if (proxyKey) {
     app.use("/v1/*", async (c, next) => {
       const authHeader = c.req.header("authorization");
@@ -512,7 +514,13 @@ export async function createProxyServer(
       // If native, we just forward. OpenRouter needs estimation.
       if (handler instanceof NativeHandler) {
         const headers: any = { "Content-Type": "application/json" };
-        if (anthropicApiKey) headers["x-api-key"] = anthropicApiKey;
+        if (anthropicApiKey) {
+          if (anthropicApiKey.startsWith("sk-ant-oat")) {
+            headers["authorization"] = `Bearer ${anthropicApiKey}`;
+          } else {
+            headers["x-api-key"] = anthropicApiKey;
+          }
+        }
 
         const res = await fetch("https://api.anthropic.com/v1/messages/count_tokens", {
           method: "POST",

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -35,6 +35,7 @@ import { createHandlerForProvider } from "./providers/provider-profiles.js";
 import { loadCustomEndpoints } from "./providers/custom-endpoints-loader.js";
 import { getRuntimeProviders } from "./providers/runtime-providers.js";
 import { loadConfig } from "./profile-config.js";
+import { registerForkExtensions, stripBillingHeaderFromBody, logRequest, createHostnameConfig } from "./fork/index.js";
 
 export interface ProxyServerOptions {
   summarizeTools?: boolean; // Summarize tool descriptions for local models
@@ -42,7 +43,7 @@ export interface ProxyServerOptions {
   isInteractive?: boolean; // Whether the current session is interactive (gates consent prompt)
   advisorModels?: string[]; // Advisor models from --advisor flag
   advisorCollector?: string | null; // Collector model (null = no synthesis)
-  hostname?: string; // Bind address (default: "127.0.0.1", use "0.0.0.0" for Docker)
+  hostname?: string; // Bind address (default: "127.0.0.1", use "0.0.0.0" for Docker) — fork extension
 }
 
 export async function createProxyServer(
@@ -463,56 +464,14 @@ export async function createProxyServer(
     return getOpenRouterHandler(target, invocationMode);
   };
 
+  // Fork extension: hostname binding + remote address tracking
+  const hostnameConfig = createHostnameConfig(options.hostname);
+
   const app = new Hono();
   app.use("*", cors());
 
-  // Model-aware proxy auth: Anthropic pass-through is exempt (OAuth or proxy-key
-  // swap handled by NativeHandler). Non-Anthropic providers require the proxy key
-  // in x-api-key / authorization / x-proxy-key. GET requests and health endpoints
-  // are exempt for Docker healthcheck and model discovery compatibility.
-  if (proxyKey) {
-    app.use("/v1/*", async (c, next) => {
-      if (c.req.method === "GET") {
-        return await next();
-      }
-
-      // Peek at body.model to determine target provider.
-      // Hono caches parsed JSON — safe to call again from the route handler.
-      let model: string | undefined;
-      try {
-        const body = await c.req.json();
-        model = body?.model;
-      } catch {
-        return await next(); // Malformed body — let handler return 400
-      }
-
-      // Anthropic pass-through: skip proxy key validation entirely.
-      // NativeHandler will either swap proxyKey → stored Anthropic key,
-      // or pass the client's OAuth token through unchanged.
-      if (model) {
-        const spec = parseModelSpec(model);
-        if (spec.provider === "native-anthropic") {
-          return await next();
-        }
-      }
-
-      // Non-Anthropic: enforce proxy key
-      const authHeader = c.req.header("authorization");
-      const apiKeyHeader = c.req.header("x-api-key");
-      const proxyKeyHeader = c.req.header("x-proxy-key");
-
-      const bearerToken = authHeader?.startsWith("Bearer ")
-        ? authHeader.slice(7)
-        : authHeader;
-
-      const provided = proxyKeyHeader || apiKeyHeader || bearerToken;
-      if (!provided || provided !== proxyKey) {
-        return c.json(wrapAnthropicError(401, "invalid proxy authentication"), 401);
-      }
-      await next();
-    });
-    log("[Proxy] Authentication enabled (Anthropic pass-through; proxy key required for other providers)");
-  }
+  // Fork extensions: proxy auth + model discovery
+  registerForkExtensions(app, { proxyKey });
 
   app.get("/", (c) =>
     c.json({
@@ -522,53 +481,6 @@ export async function createProxyServer(
     })
   );
   app.get("/health", (c) => c.json({ status: "ok" }));
-
-  // Model discovery endpoint — Claude Code queries /v1/models when
-  // CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1 is set. Returns all
-  // routable models from config.json routing rules + custom endpoints.
-  app.get("/v1/models", (c) => {
-    const cfg = loadConfig();
-    const seen = new Set<string>();
-    const models: { id: string; display_name: string; created_at: string }[] = [];
-
-    // From routing rules — each key is a model name
-    if (cfg.routing) {
-      for (const modelName of Object.keys(cfg.routing)) {
-        if (!seen.has(modelName)) {
-          seen.add(modelName);
-          models.push({
-            id: modelName,
-            display_name: modelName,
-            created_at: "2026-01-01T00:00:00Z",
-          });
-        }
-      }
-    }
-
-    // From custom endpoints — each declared model
-    if (cfg.customEndpoints) {
-      for (const [, ep] of Object.entries(cfg.customEndpoints)) {
-        const endpoint = ep as { models?: string[] };
-        if (endpoint.models) {
-          for (const m of endpoint.models) {
-            if (!seen.has(m)) {
-              seen.add(m);
-              models.push({
-                id: m,
-                display_name: m,
-                created_at: "2026-01-01T00:00:00Z",
-              });
-            }
-          }
-        }
-      }
-    }
-
-    return c.json({
-      object: "list",
-      data: models,
-    });
-  });
 
   // Token counting
   app.post("/v1/messages/count_tokens", async (c) => {
@@ -631,32 +543,8 @@ export async function createProxyServer(
     try {
       const body = await c.req.json();
       const handler = await getHandlerForRequest(body.model);
-      const xff = c.req.header("x-forwarded-for") || "";
-      const xrip = c.req.header("x-real-ip") || "";
-      const ua = c.req.header("user-agent") || "";
-      const directIp = remoteAddrMap.get(c.req.raw) || "";
-      const src = xff || xrip || directIp || "direct";
-      console.log(`[claudish] [Request] model=${body.model ?? "(none)"} handler=${handler.constructor.name} src=${src} ua=${ua.slice(0, 60)}`);
-
-      // Strip Claude Code billing header from system prompt for non-Anthropic
-      // providers. Claude Code injects `x-anthropic-billing-header: cc_version=...; cch=XXXXX;`
-      // into the prompt body — the `cch=` token changes every request, which breaks
-      // vLLM prefix caching (strict hash). Only Anthropic needs this; strip for others.
-      if (!(handler instanceof NativeHandler) && typeof body.system === "string") {
-        body.system = body.system.replace(
-          /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
-          ""
-        );
-      } else if (!(handler instanceof NativeHandler) && Array.isArray(body.system)) {
-        for (const block of body.system) {
-          if (block.type === "text" && typeof block.text === "string") {
-            block.text = block.text.replace(
-              /x-anthropic-billing-header: cc_version=[^\n]*\n?/g,
-              ""
-            );
-          }
-        }
-      }
+      logRequest(body, handler.constructor.name, c.req.raw, hostnameConfig.remoteAddrMap);
+      stripBillingHeaderFromBody(body, handler instanceof NativeHandler);
 
       // Route
       return handler.handle(c, body);
@@ -666,22 +554,17 @@ export async function createProxyServer(
     }
   });
 
-  const bindHost = options.hostname ?? "127.0.0.1";
-  // Store remote addresses for direct connections (no IIS/proxy).
-  // Hono middleware can't access the socket, so we intercept at the
-  // serve() level and pass the IP through the Request headers.
-  const remoteAddrMap = new WeakMap<Request, string>();
   const server = serve({
     fetch(req, env, ctx) {
       if (!req.headers.get("x-forwarded-for") && !req.headers.get("x-real-ip")) {
         // @ts-expect-error — Bun injects remoteAddress on the server info object
         const addr = ctx?.remoteAddress?.address as string | undefined;
-        if (addr) remoteAddrMap.set(req, addr);
+        if (addr) hostnameConfig.remoteAddrMap.set(req, addr);
       }
       return app.fetch(req, env, ctx);
     },
     port,
-    hostname: bindHost,
+    hostname: hostnameConfig.hostname,
   });
 
   // Port resolution
@@ -706,7 +589,7 @@ export async function createProxyServer(
 
   return {
     port,
-    url: `http://${bindHost}:${port}`,
+    url: `http://${hostnameConfig.hostname}:${port}`,
     shutdown: async () => {
       return new Promise<void>((resolve) => server.close(() => resolve()));
     },

--- a/packages/cli/src/standalone-proxy.ts
+++ b/packages/cli/src/standalone-proxy.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env bun
+/**
+ * Claudish Standalone Proxy Server
+ *
+ * Starts the proxy server without wrapping Claude Code.
+ * Used for cluster deployments where other machines route LLM requests
+ * through this proxy.
+ *
+ * Usage: bun packages/cli/src/standalone-proxy.ts [--port 3000]
+ */
+
+import { config } from "dotenv";
+config({ quiet: true });
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// Load stored API keys from ~/.claudish/config.json
+function loadStoredApiKeys(): void {
+  try {
+    const configPath = join(homedir(), ".claudish", "config.json");
+    if (!existsSync(configPath)) return;
+    const raw = readFileSync(configPath, "utf-8");
+    const cfg = JSON.parse(raw) as {
+      apiKeys?: Record<string, string>;
+      endpoints?: Record<string, string>;
+    };
+    if (cfg.apiKeys) {
+      for (const [envVar, value] of Object.entries(cfg.apiKeys)) {
+        if (!process.env[envVar] && typeof value === "string") {
+          process.env[envVar] = value;
+        }
+      }
+    }
+    if (cfg.endpoints) {
+      for (const [envVar, value] of Object.entries(cfg.endpoints)) {
+        if (!process.env[envVar] && typeof value === "string") {
+          process.env[envVar] = value;
+        }
+      }
+    }
+  } catch {
+    // Silently ignore
+  }
+}
+
+loadStoredApiKeys();
+
+// Parse --port and --host from args
+const args = process.argv.slice(2);
+let port = 3000;
+let hostname = process.env.CLAUDISH_HOST || "127.0.0.1";
+const portIdx = args.indexOf("--port");
+if (portIdx !== -1 && args[portIdx + 1]) {
+  port = Number.parseInt(args[portIdx + 1], 10);
+}
+const hostIdx = args.indexOf("--host");
+if (hostIdx !== -1 && args[hostIdx + 1]) {
+  hostname = args[hostIdx + 1];
+}
+
+import { createProxyServer } from "./proxy-server.js";
+import { loadConfig, getModelMapping } from "./profile-config.js";
+
+// Read active profile's model mapping for role-based routing
+// (opus/sonnet/haiku role remapping from config)
+const cfg = loadConfig();
+const modelMap = getModelMapping(cfg.defaultProfile);
+const activeProfile = cfg.profiles[cfg.defaultProfile];
+
+const server = await createProxyServer(
+  port,
+  process.env.OPENROUTER_API_KEY,
+  undefined,
+  false,
+  process.env.ANTHROPIC_API_KEY,
+  modelMap.opus || modelMap.sonnet || modelMap.haiku ? modelMap : undefined,
+  { quiet: false, hostname }
+);
+
+const mappingInfo = modelMap.opus
+  ? ` (opus→${modelMap.opus}, sonnet→${modelMap.sonnet || "passthrough"}, haiku→${modelMap.haiku || "passthrough"})`
+  : " (passthrough — no profile mapping)";
+console.log(`[claudish-proxy] Standalone proxy running on http://${hostname}:${port}`);
+console.log(`[claudish-proxy] Profile: ${cfg.defaultProfile}${activeProfile ? ` — ${activeProfile.description ?? ""}` : ""}`);
+console.log(`[claudish-proxy] Role mapping: ${modelMap.opus ? `opus=${modelMap.opus}, sonnet=${modelMap.sonnet ?? "passthrough"}, haiku=${modelMap.haiku ?? "passthrough"}` : "none (all models passthrough)"}`);
+console.log(`[claudish-proxy] Config: ~/.claudish/config.json`);
+console.log(`[claudish-proxy] Press Ctrl+C to stop`);
+
+// Keep process alive
+process.on("SIGINT", async () => {
+  console.log("\n[claudish-proxy] Shutting down...");
+  await server.shutdown();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  await server.shutdown();
+  process.exit(0);
+});

--- a/packages/cli/src/standalone-proxy.ts
+++ b/packages/cli/src/standalone-proxy.ts
@@ -61,13 +61,12 @@ if (hostIdx !== -1 && args[hostIdx + 1]) {
 }
 
 import { createProxyServer } from "./proxy-server.js";
-import { loadConfig, getModelMapping } from "./profile-config.js";
+import { loadConfig } from "./profile-config.js";
 
-// Read active profile's model mapping for role-based routing
-// (opus/sonnet/haiku role remapping from config)
-const cfg = loadConfig();
-const modelMap = getModelMapping(cfg.defaultProfile);
-const activeProfile = cfg.profiles[cfg.defaultProfile];
+// No modelMap — the proxy is a transparent router. Every model name routes
+// to its provider via config.json routing rules:
+//   claude-opus-4-7 → anthropic, glm-5.1 → z.ai, qwen3.6-35b-a3b → vllm-myia
+// Any model can be used directly; no role remapping.
 
 const server = await createProxyServer(
   port,
@@ -75,16 +74,11 @@ const server = await createProxyServer(
   undefined,
   false,
   process.env.ANTHROPIC_API_KEY,
-  modelMap.opus || modelMap.sonnet || modelMap.haiku ? modelMap : undefined,
+  undefined,
   { quiet: false, hostname }
 );
 
-const mappingInfo = modelMap.opus
-  ? ` (opus→${modelMap.opus}, sonnet→${modelMap.sonnet || "passthrough"}, haiku→${modelMap.haiku || "passthrough"})`
-  : " (passthrough — no profile mapping)";
 console.log(`[claudish-proxy] Standalone proxy running on http://${hostname}:${port}`);
-console.log(`[claudish-proxy] Profile: ${cfg.defaultProfile}${activeProfile ? ` — ${activeProfile.description ?? ""}` : ""}`);
-console.log(`[claudish-proxy] Role mapping: ${modelMap.opus ? `opus=${modelMap.opus}, sonnet=${modelMap.sonnet ?? "passthrough"}, haiku=${modelMap.haiku ?? "passthrough"}` : "none (all models passthrough)"}`);
 console.log(`[claudish-proxy] Config: ~/.claudish/config.json`);
 console.log(`[claudish-proxy] Press Ctrl+C to stop`);
 

--- a/packages/cli/src/test-fixtures/sse-responses/regression-zai-glm5-startofstream-ratelimit.sse
+++ b/packages/cli/src/test-fixtures/sse-responses/regression-zai-glm5-startofstream-ratelimit.sse
@@ -1,0 +1,6 @@
+event: ping
+data: {"type":"ping"}
+
+event: error
+data: {"error":{"code":"1302","message":"Your account has reached its rate limit (concurrency/RPM). Please try again later."},"request_id":"20260602xstartofstreamratelimit"}
+

--- a/packages/cli/src/test-fixtures/sse-responses/regression-zai-server-tool-use.sse
+++ b/packages/cli/src/test-fixtures/sse-responses/regression-zai-server-tool-use.sse
@@ -1,0 +1,26 @@
+event: message_start
+data: {"type":"message_start","message":{"id":"msg_stu_test","type":"message","role":"assistant","content":[],"model":"glm-5.2","stop_reason":null,"usage":{"input_tokens":100,"output_tokens":1}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me look that up."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"server_tool_use","id":"srvu_test","name":"webReader","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"url\":\"https://example.com\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"input_tokens":100,"output_tokens":10}}
+
+event: message_stop
+data: {"type":"message_stop"}

--- a/scripts/.gitkeep-info
+++ b/scripts/.gitkeep-info
@@ -1,0 +1,1 @@
+# scripts/ - utility scripts (not part of the build)

--- a/scripts/CaptureUtils.psm1
+++ b/scripts/CaptureUtils.psm1
@@ -1,0 +1,266 @@
+# CaptureUtils.psm1 — Shared functions for claudish traffic analysis scripts
+
+$ErrorActionPreference = 'Stop'
+
+# Default capture directory (override with -Dir parameter)
+$script:DefaultCaptureDir = 'D:\claudish-captures'
+
+# 7-Zip path (same as compress-captures.ps1)
+$script:SevenZip = 'D:\Apps\PortableApps\7-ZipPortable\App\7-Zip64\7z.exe'
+
+function Get-CaptureRequests {
+    <#
+    .SYNOPSIS
+    Enumerate and parse req-*.json capture files.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$Dir = $script:DefaultCaptureDir,
+        [int]$Hours = 2,
+        [switch]$All
+    )
+
+    $cutoff = if ($All) { [datetime]::MinValue } else { (Get-Date).AddHours(-$Hours) }
+
+    Get-ChildItem (Join-Path $Dir 'req-*.json') -File |
+        Where-Object { $All -or $_.LastWriteTime -gt $cutoff } |
+        ForEach-Object {
+            try {
+                $raw = Get-Content $_.FullName -Raw -Encoding UTF8
+                $j = $raw | ConvertFrom-Json -ErrorAction Stop
+
+                # Extract metadata from body
+                $workspace = Get-WorkspaceFromSystem $j.body.system
+                $sessionInfo = Get-SessionIdFromMetadata $j.body.metadata
+                $ccInfo = Get-CCVersionFromSystem $j.body.system
+                $msgCount = if ($j.body.messages) { @($j.body.messages).Count } else { 0 }
+                $toolCount = if ($j.body.tools) { @($j.body.tools).Count } else { 0 }
+
+                # Extract filename counter for resp correlation
+                $counter = if ($_.Name -match 'req-\d+-(\d+)-') { [int]$Matches[1] } else { 0 }
+
+                [PSCustomObject]@{
+                    File       = $_.Name
+                    Timestamp  = $j.ts
+                    Model      = if ($j.model) { $j.model } else { '(none)' }
+                    Machine    = if ($j.machine) { $j.machine } else { '(unknown)' }
+                    Workspace  = $workspace
+                    SessionId  = $sessionInfo.SessionId
+                    DeviceId   = $sessionInfo.DeviceId
+                    AccountId  = $sessionInfo.AccountId
+                    CCVersion  = $ccInfo.Version
+                    Entrypoint = $ccInfo.Entrypoint
+                    MsgCount   = $msgCount
+                    ToolCount  = $toolCount
+                    MaxTokens  = $j.body.max_tokens
+                    Counter    = $counter
+                    Size       = $_.Length
+                    FileTime   = $_.LastWriteTime
+                }
+            } catch {
+                # Skip unparseable files silently
+            }
+        }
+}
+
+function Get-WorkspaceFromSystem {
+    <#
+    .SYNOPSIS
+    Extract the workspace path from the system prompt blocks.
+    Looks for "Primary working directory:" in system[2].text.
+    #>
+    [CmdletBinding()]
+    param($System)
+
+    if (-not $System) { return '(no system)' }
+
+    foreach ($block in $System) {
+        if ($block.text -match 'Primary working directory:\s*(.+?)[\r\n]') {
+            return $Matches[1].Trim()
+        }
+    }
+    return '(no workspace)'
+}
+
+function Get-SessionIdFromMetadata {
+    <#
+    .SYNOPSIS
+    Extract session_id, device_id, and account_uuid from metadata.user_id.
+    Handles both formats:
+      - JSON: {"device_id":"...","account_uuid":"...","session_id":"..."}
+      - Flat: user_<hash>_account_<uuid>_session_<uuid>
+    #>
+    [CmdletBinding()]
+    param($Metadata)
+
+    $result = @{ SessionId = ''; DeviceId = ''; AccountId = '' }
+    if (-not $Metadata -or -not $Metadata.user_id) { return $result }
+
+    $uid = $Metadata.user_id
+
+    # Try JSON format first
+    try {
+        $parsed = $uid | ConvertFrom-Json -ErrorAction Stop
+        $result.SessionId = $parsed.session_id ?? ''
+        $result.DeviceId = $parsed.device_id ?? ''
+        $result.AccountId = $parsed.account_uuid ?? ''
+        return $result
+    } catch {
+        # Not JSON, try flat format
+    }
+
+    # Flat format: user_<hash>_account_<uuid>_session_<uuid>
+    if ($uid -match '_session_([0-9a-f-]+)') {
+        $result.SessionId = $Matches[1]
+    }
+    if ($uid -match '_account_([0-9a-f-]+)') {
+        $result.AccountId = $Matches[1]
+    }
+
+    return $result
+}
+
+function Get-CCVersionFromSystem {
+    <#
+    .SYNOPSIS
+    Extract Claude Code version and entrypoint from system[0] billing header.
+    #>
+    [CmdletBinding()]
+    param($System)
+
+    $result = @{ Version = ''; Entrypoint = '' }
+    if (-not $System -or $System.Count -eq 0) { return $result }
+
+    $text = $System[0].text ?? $System[0] ?? ''
+
+    if ($text -match 'cc_version=([^;\s]+)') {
+        $result.Version = $Matches[1]
+    }
+    if ($text -match 'cc_entrypoint=([^;\s]+)') {
+        $result.Entrypoint = $Matches[1]
+    }
+
+    return $result
+}
+
+function Get-ResponseForRequest {
+    <#
+    .SYNOPSIS
+    Find the resp-*.sse file matching a request counter and extract token usage.
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$Counter,
+        [string]$Dir = $script:DefaultCaptureDir
+    )
+
+    $pattern = "resp-*-r$($Counter.ToString('0000'))-*.sse"
+    $respFile = Get-ChildItem (Join-Path $Dir $pattern) -File | Select-Object -First 1
+
+    if (-not $respFile) { return $null }
+
+    # Parse header lines for stop_reason and elapsed_ms
+    $header = Get-Content $respFile.FullName -TotalCount 10 -ErrorAction SilentlyContinue
+    $result = @{ StopReason = ''; ElapsedMs = 0; InputTokens = 0; OutputTokens = 0 }
+
+    foreach ($line in $header) {
+        if ($line -match 'stop_reason["\s:]+(\w+)') { $result.StopReason = $Matches[1] }
+        if ($line -match 'elapsed_ms=(\d+)') { $result.ElapsedMs = [int]$Matches[1] }
+    }
+
+    # Parse SSE data for token usage (last message_delta with usage)
+    $content = Get-Content $respFile.FullName -Raw -ErrorAction SilentlyContinue
+    $lastUsage = [regex]::Matches($content, '"usage":\{[^}]*"input_tokens":(\d+)[^}]*"output_tokens":(\d+)')
+    if ($lastUsage.Count -gt 0) {
+        $m = $lastUsage[$lastUsage.Count - 1]
+        $result.InputTokens = [int]$m.Groups[1].Value
+        $result.OutputTokens = [int]$m.Groups[2].Value
+    }
+
+    return $result
+}
+
+function Get-ArchivedDays {
+    <#
+    .SYNOPSIS
+    List available archive dates in the archive directory.
+    #>
+    [CmdletBinding()]
+    param([string]$Dir = $script:DefaultCaptureDir)
+
+    $archiveDir = Join-Path $Dir 'archive'
+    if (-not (Test-Path $archiveDir)) { return @() }
+
+    Get-ChildItem (Join-Path $archiveDir 'captures-*.7z') -File |
+        ForEach-Object {
+            if ($_.Name -match 'captures-(\d{4}-\d{2}-\d{2})') {
+                [PSCustomObject]@{
+                    Date = [datetime]::ParseExact($Matches[1], 'yyyy-MM-dd', $null)
+                    File = $_.FullName
+                    Size = $_.Length
+                }
+            }
+        } | Sort-Object Date
+}
+
+function Expand-ArchiveDay {
+    <#
+    .SYNOPSIS
+    Extract a 7z archive to a temp directory and return the path.
+    Caller is responsible for cleanup.
+    #>
+    [CmdletBinding()]
+    param([string]$ArchivePath)
+
+    if (-not (Test-Path $script:SevenZip)) {
+        Write-Error "7-Zip not found at: $script:SevenZip"
+        return $null
+    }
+
+    $tempDir = Join-Path $env:TEMP "claudish-archive-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    & $script:SevenZip x $ArchivePath "-o$tempDir" -y -bso0 -bsp0 2>$null | Out-Null
+
+    if (Test-Path (Join-Path $tempDir 'req-*.json')) {
+        return $tempDir
+    }
+
+    # Check for subdirectory (7z might extract into a folder)
+    $subDir = Get-ChildItem $tempDir -Directory | Select-Object -First 1
+    if ($subDir -and (Test-Path (Join-Path $subDir.FullName 'req-*.json'))) {
+        return $subDir.FullName
+    }
+
+    Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    return $null
+}
+
+# Device ID → machine name mapping (fallback for header-less requests).
+# Primary attribution is the X-Claudish-Machine header; this map only fires
+# when a request arrives WITHOUT that header. As of 2026-06, all interactive
+# machines (po-2023, po-2025, po-2026, ai-01) send the header, so the only
+# header-less source is ai-01's scheduled cron agents (mapped below). Add
+# entries here only when a NEW machine is seen without the header — extract
+# its device_id from metadata.user_id in a capture.
+$script:DeviceMap = @{
+    'a13baee2e6c8cc200e25ace229c9937ccbe20e7b66f4cda3f9dc0fc22e3650ae' = 'myia-po-2023'
+    'b5909fd92642d80ee243e7c7377df756e4d09b683bfc45d625de53307df093c7' = 'myia-ai-01'
+}
+
+function Resolve-MachineFromDevice {
+    <#
+    .SYNOPSIS
+    Resolve a machine name from device_id when the machine header is empty.
+    #>
+    [CmdletBinding()]
+    param([string]$DeviceId)
+
+    if ($script:DeviceMap.ContainsKey($DeviceId)) {
+        return $script:DeviceMap[$DeviceId]
+    }
+    return "device:$($DeviceId.Substring(0,8))"
+}
+
+Export-ModuleMember -Function Get-CaptureRequests, Get-WorkspaceFromSystem, Get-SessionIdFromMetadata,
+    Get-CCVersionFromSystem, Get-ResponseForRequest, Get-ArchivedDays, Expand-ArchiveDay, Resolve-MachineFromDevice

--- a/scripts/claudish-watchdog.ps1
+++ b/scripts/claudish-watchdog.ps1
@@ -32,7 +32,7 @@ function Test-ProxyWithTools {
     # GLM will respond with tool_use or text — either way the stream must complete.
     # This exercises the exact code path (openai-sse tool_call handling) that hangs.
     $body = @{
-        model = "glm-5.1"
+        model = "glm-5.2"
         max_tokens = 100
         stream = $true
         tools = @(

--- a/scripts/claudish-watchdog.ps1
+++ b/scripts/claudish-watchdog.ps1
@@ -1,0 +1,161 @@
+# Claudish Watchdog — detects tool-call stream hangs and auto-restarts
+#
+# The proxy hangs on tool_call paths (WebSearch, GLM tool_use), not simple text.
+# This watchdog tests the EXACT code path that degrades:
+#   1. A streaming request WITH tools defined (triggers tool_use in the model)
+#   2. Checks that the stream completes within timeout
+#   3. Also checks container uptime — proactive restart at 11h before degradation
+#
+# Install (run as admin):
+#   schtasks /create /tn "ClaudishWatchdog" /tr "powershell -ExecutionPolicy Bypass -WindowStyle Hidden -File D:\Dev\claudish\scripts\claudish-watchdog.ps1" /sc minute /mo 15 /ru SYSTEM /rl HIGHEST /f
+#
+# Logs to: C:\Users\jsboi\.claudish\watchdog.log
+
+$ErrorActionPreference = "Stop"
+$LogPath = "$env:USERPROFILE\.claudish\watchdog.log"
+$ProxyUrl = "http://localhost:3000"
+$ContainerName = "claudish-proxy"
+$StreamTimeoutSec = 90
+$ProactiveRestartHours = 11
+
+function Write-Log($msg) {
+    $ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    $line = "[$ts] $msg"
+    Add-Content -Path $LogPath -Value $line -Encoding UTF8
+    Write-Host $line
+}
+
+function Test-ProxyWithTools {
+    param([string]$Url, [int]$TimeoutSec)
+
+    # This payload mimics a real Claude Code request WITH tools.
+    # GLM will respond with tool_use or text — either way the stream must complete.
+    # This exercises the exact code path (openai-sse tool_call handling) that hangs.
+    $body = @{
+        model = "glm-5.1"
+        max_tokens = 100
+        stream = $true
+        tools = @(
+            @{
+                name = "Bash"
+                description = "Run a bash command"
+                input_schema = @{
+                    type = "object"
+                    properties = @{
+                        command = @{ type = "string"; description = "The command" }
+                    }
+                    required = @("command")
+                }
+            },
+            @{
+                name = "Read"
+                description = "Read a file"
+                input_schema = @{
+                    type = "object"
+                    properties = @{
+                        file_path = @{ type = "string"; description = "Path" }
+                    }
+                    required = @("file_path")
+                }
+            }
+        )
+        messages = @(
+            @{
+                role = "user"
+                content = "List the current directory using Bash. Do it now."
+            }
+        )
+    } | ConvertTo-Json -Depth 10
+
+    try {
+        $response = Invoke-WebRequest -Uri "$Url/v1/messages" `
+            -Method POST `
+            -ContentType "application/json" `
+            -Body $body `
+            -TimeoutSec $TimeoutSec `
+            -UseBasicParsing
+
+        $content = $response.Content
+
+        # Stream must contain a terminal event
+        if ($content -match "message_stop") {
+            $hasToolUse = $content -match "tool_use"
+            $type = if ($hasToolUse) { "tool_use+end" } else { "text+end" }
+            return @{ Ok = $true; Detail = "stream OK ($type, $($content.Length) bytes)" }
+        } elseif ($content.Length -gt 100) {
+            # Got data but no message_stop — suspicious but not fatal
+            return @{ Ok = $false; Detail = "stream incomplete ($($content.Length) bytes, no message_stop)" }
+        } elseif ($content.Length -gt 0) {
+            return @{ Ok = $false; Detail = "short response ($($content.Length) bytes): $($content.Substring(0, [Math]::Min(200, $content.Length)))" }
+        } else {
+            return @{ Ok = $false; Detail = "EMPTY response — stream hung" }
+        }
+    }
+    catch [System.Net.WebException] {
+        return @{ Ok = $false; Detail = "HTTP error: $($_.Exception.Message)" }
+    }
+    catch {
+        $msg = $_.Exception.Message
+        if ($msg -match "timed? ?out" -or $msg -match "timeout") {
+            return @{ Ok = $false; Detail = "TIMEOUT after ${TimeoutSec}s — stream hung" }
+        }
+        return @{ Ok = $false; Detail = "error: $msg" }
+    }
+}
+
+# --- Main ---
+
+Write-Log "=== Watchdog check ==="
+
+# Step 1: Container running?
+$containerStatus = docker inspect $ContainerName --format "{{.State.Status}}" 2>$null
+if ($LASTEXITCODE -ne 0 -or $containerStatus -ne "running") {
+    Write-Log "CRITICAL: Container not running (status=$containerStatus). Starting..."
+    docker start $ContainerName 2>$null
+    Start-Sleep -Seconds 15
+    $recheck = docker inspect $ContainerName --format "{{.State.Status}}" 2>$null
+    if ($recheck -eq "running") {
+        Write-Log "RECOVERED: Container started"
+    } else {
+        Write-Log "FATAL: Container won't start (status=$recheck)"
+        exit 1
+    }
+    exit 0
+}
+
+# Step 2: Uptime check
+$startedAt = docker inspect $ContainerName --format "{{.State.StartedAt}}" 2>$null
+$startTime = [DateTimeOffset]::Parse($startedAt)
+$uptime = [DateTimeOffset]::UtcNow - $startTime
+$uptimeHours = [Math]::Round($uptime.TotalHours, 1)
+
+# Step 3: Proactive restart if uptime > threshold (prevent degradation BEFORE it happens)
+if ($uptimeHours -ge $ProactiveRestartHours) {
+    Write-Log "PROACTIVE: Uptime ${uptimeHours}h >= ${ProactiveRestartHours}h. Restarting to prevent degradation..."
+    docker restart $ContainerName 2>$null
+    Start-Sleep -Seconds 20
+    $result = Test-ProxyWithTools -Url $ProxyUrl -TimeoutSec 60
+    Write-Log "After proactive restart: $($result.Detail)"
+    exit $(if ($result.Ok) { 0 } else { 1 })
+}
+
+# Step 4: Real tool-call streaming test
+$result = Test-ProxyWithTools -Url $ProxyUrl -TimeoutSec $StreamTimeoutSec
+
+if ($result.Ok) {
+    Write-Log "OK (uptime=${uptimeHours}h). $($result.Detail)"
+} else {
+    Write-Log "FAIL (uptime=${uptimeHours}h): $($result.Detail)"
+    Write-Log "ACTION: Restarting container..."
+    docker restart $ContainerName 2>$null
+    Start-Sleep -Seconds 20
+
+    # Verify recovery
+    $result2 = Test-ProxyWithTools -Url $ProxyUrl -TimeoutSec 60
+    if ($result2.Ok) {
+        Write-Log "RECOVERED: $($result2.Detail)"
+    } else {
+        Write-Log "CRITICAL: Still broken after restart: $($result2.Detail)"
+        exit 1
+    }
+}

--- a/scripts/compress-captures.ps1
+++ b/scripts/compress-captures.ps1
@@ -60,7 +60,15 @@ param(
   [string]$CaptureDir = "D:\claudish-captures",
   [string]$ArchiveDir = "",
   [string]$SevenZip   = "D:\Apps\PortableApps\7-ZipPortable\App\7-Zip64\7z.exe",
-  [int]   $KeepDays   = 1
+  [int]   $KeepDays   = 1,
+  # Off-site backup via Google Drive Desktop (mounted drive, no API/auth).
+  # Empty = skip GDrive entirely (local compaction only). The path is the local
+  # mount point of the Drive, so this is just a Windows file copy.
+  [string]$GDriveDir  = "G:\Mon Drive\MyIA\backups\claudish-captures",
+  # Local retention: archives older than this (in days) are purged from the
+  # local ArchiveDir, BUT only after confirming the copy exists on GDrive.
+  # GDrive keeps everything; this only bounds local disk usage.
+  [int]   $KeepLocalDays = 30
 )
 
 $ErrorActionPreference = "Stop"
@@ -135,10 +143,64 @@ foreach ($day in $daysToArchive) {
       Log ("OK  {0}: {1} files, {2:N1} MB -> {3:N1} MB ({4}:1), loose deleted" -f `
            $day, $files.Count, ($rawBytes/1MB), ($archBytes/1MB), $ratio)
       $totalRaw += $rawBytes; $totalArch += $archBytes; $totalFiles += $files.Count
+
+      # --- off-site backup (Google Drive Desktop mount, plain file copy) ------
+      # Non-fatal: if the Drive isn't mounted (laptop offline, G: missing) or
+      # the copy fails, we log a WARN and continue. The local archive already
+      # exists (verified), so we never lose data — only the off-site copy is
+      # deferred. The purge-30d block below will NOT delete local archives that
+      # aren't confirmed on GDrive, so a missed upload retries the next night.
+      if ($GDriveDir) {
+        if (Test-Path -LiteralPath $GDriveDir) {
+          try {
+            Copy-Item -LiteralPath $archivePath -Destination $GDriveDir -Force -ErrorAction Stop
+            # Confirm the copy landed with matching size before trusting it.
+            $dest = Join-Path $GDriveDir (Split-Path $archivePath -Leaf)
+            if ((Test-Path -LiteralPath $dest) -and (Get-Item -LiteralPath $dest).Length -eq $archBytes) {
+              Log ("GDRIVE {0}: uploaded ({1:N1} MB)" -f $day, ($archBytes/1MB))
+            } else {
+              $errors++
+              Log ("WARN  {0}: GDrive copy size mismatch -> local kept, retry next run" -f $day)
+            }
+          } catch {
+            $errors++
+            Log ("WARN  {0}: GDrive copy failed: {1} -> local kept, retry next run" -f $day, $_.Exception.Message)
+          }
+        } else {
+          Log ("WARN  GDriveDir not mounted ({0}) -> off-site deferred, local kept" -f $GDriveDir)
+        }
+      }
     } else {
       $errors++
       Log ("ERROR {0}: 7z add rc={1} test rc={2} -> KEEPING loose files (not deleted)" -f $day, $addRc, $testRc)
     }
+  }
+}
+
+# --- local retention purge: delete archives older than KeepLocalDays, ONLY if
+# confirmed present (and same size) on GDrive. This bounds local disk; GDrive
+# keeps the full history. If GDriveDir is unset or not mounted, purge is
+# skipped entirely (safe default — never delete without an off-site copy).
+if ($KeepLocalDays -gt 0 -and $GDriveDir -and (Test-Path -LiteralPath $ArchiveDir) -and (Test-Path -LiteralPath $GDriveDir)) {
+  $purgeCutoff = (Get-Date).ToUniversalTime().Date.AddDays(-$KeepLocalDays)
+  $purged = 0; $purgeSkipped = 0
+  foreach ($arch in (Get-ChildItem -LiteralPath $ArchiveDir -Filter 'captures-*.7z' -File)) {
+    if ($arch.Name -notmatch 'captures-(\d{4}-\d{2}-\d{2})\.7z') { continue }
+    $dayDate = [datetime]::ParseExact($matches[1], 'yyyy-MM-dd', $null)
+    if ($dayDate -ge $purgeCutoff) { continue }   # within retention window
+    $dest = Join-Path $GDriveDir $arch.Name
+    # Require off-site copy to exist AND match local size before deleting.
+    if ((Test-Path -LiteralPath $dest) -and (Get-Item -LiteralPath $dest).Length -eq $arch.Length) {
+      if ($PSCmdlet.ShouldProcess($arch.FullName, "purge local (>{0}d, confirmed on GDrive)" -f $KeepLocalDays)) {
+        Remove-Item -LiteralPath $arch.FullName -Force
+        $purged++
+      }
+    } else {
+      $purgeSkipped++
+    }
+  }
+  if ($purged -gt 0 -or $purgeSkipped -gt 0) {
+    Log ("PURGE >{0}d: {1} local archive(s) deleted, {2} kept (not yet on GDrive)" -f $KeepLocalDays, $purged, $purgeSkipped)
   }
 }
 

--- a/scripts/compress-captures.ps1
+++ b/scripts/compress-captures.ps1
@@ -1,0 +1,151 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+  Nightly compaction of claudish diagnostic captures with 7-Zip.
+
+.DESCRIPTION
+  The claudish proxy writes raw request/response captures (req-*.json /
+  resp-*.sse) into a flat directory bind-mounted from the container
+  (CLAUDISH_CAPTURE_DIR=/captures -> D:\claudish-captures). These are text
+  with massive cross-request redundancy (the same large system prompts and
+  conversation histories repeat across thousands of files), so 7-Zip LZMA2
+  compresses them ~30:1 or better.
+
+  Left uncompressed, ~3-8 GB/day of loose files would fill the disk within
+  months. This script packs every COMPLETED past day (UTC) into a single
+  per-day .7z under <CaptureDir>\archive\, verifies the archive integrity,
+  and ONLY THEN deletes the loose originals. The current day (and any extra
+  days requested via -KeepDays) is left untouched so live analysis still has
+  fresh loose files to work with.
+
+  Designed to run unattended (Windows Task Scheduler). Idempotent: re-running
+  appends stragglers to an existing day archive, re-verifies, and removes the
+  loose copies. Never deletes anything without a verified archive (7z t == 0).
+
+.PARAMETER CaptureDir
+  Directory holding the loose req-*/resp-* capture files.
+
+.PARAMETER ArchiveDir
+  Where per-day .7z archives are written. Default: <CaptureDir>\archive.
+
+.PARAMETER SevenZip
+  Path to 7z.exe.
+
+.PARAMETER KeepDays
+  Number of most-recent UTC days to leave loose (including today).
+  1 = archive everything strictly before today (default).
+
+.PARAMETER WhatIf
+  Show what would be archived/deleted without changing anything.
+
+.NOTES
+  Installed on this machine as the nightly Task Scheduler job
+  "ClaudishCaptureCompaction" (daily 04:17 local, runs as the interactive
+  user, StartWhenAvailable to catch up missed runs). Re-create it with:
+
+    $action  = New-ScheduledTaskAction -Execute 'C:\Program Files\PowerShell\7\pwsh.exe' `
+                 -Argument '-NoProfile -ExecutionPolicy Bypass -File "d:\Dev\claudish\scripts\compress-captures.ps1"'
+    $trigger = New-ScheduledTaskTrigger -Daily -At ([datetime]'04:17')
+    $set     = New-ScheduledTaskSettingsSet -StartWhenAvailable -DontStopOnIdleEnd `
+                 -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
+                 -ExecutionTimeLimit (New-TimeSpan -Hours 3) -MultipleInstances IgnoreNew
+    $princ   = New-ScheduledTaskPrincipal -UserId "$env:USERDOMAIN\$env:USERNAME" -LogonType Interactive -RunLevel Limited
+    Register-ScheduledTask -TaskName 'ClaudishCaptureCompaction' -Action $action `
+                 -Trigger $trigger -Settings $set -Principal $princ -Force
+
+  Remove it with:  Unregister-ScheduledTask -TaskName 'ClaudishCaptureCompaction' -Confirm:$false
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [string]$CaptureDir = "D:\claudish-captures",
+  [string]$ArchiveDir = "",
+  [string]$SevenZip   = "D:\Apps\PortableApps\7-ZipPortable\App\7-Zip64\7z.exe",
+  [int]   $KeepDays   = 1
+)
+
+$ErrorActionPreference = "Stop"
+if (-not $ArchiveDir) { $ArchiveDir = Join-Path $CaptureDir "archive" }
+$logFile = Join-Path $CaptureDir "compaction.log"
+
+function Log([string]$msg) {
+  $line = "{0:yyyy-MM-ddTHH:mm:ssZ} {1}" -f (Get-Date).ToUniversalTime(), $msg
+  Write-Host $line
+  try { Add-Content -LiteralPath $logFile -Value $line -Encoding utf8 } catch {}
+}
+
+# --- preconditions -----------------------------------------------------------
+if (-not (Test-Path -LiteralPath $SevenZip))   { Log "FATAL: 7z not found at $SevenZip"; exit 2 }
+if (-not (Test-Path -LiteralPath $CaptureDir)) { Log "FATAL: capture dir not found: $CaptureDir"; exit 2 }
+if (-not (Test-Path -LiteralPath $ArchiveDir)) { New-Item -ItemType Directory -Path $ArchiveDir -Force | Out-Null }
+
+# Cutoff: archive any day strictly older than (todayUTC - (KeepDays-1)).
+$cutoff = (Get-Date).ToUniversalTime().Date.AddDays(-([Math]::Max(0, $KeepDays - 1)))
+Log "START compaction CaptureDir=$CaptureDir KeepDays=$KeepDays cutoff(UTC)=$($cutoff.ToString('yyyy-MM-dd'))"
+
+# --- enumerate loose captures, group by their filename date (UTC) ------------
+$rx = '^(req|resp)-.*?(?<d>\d{4}-\d{2}-\d{2})T\d{2}-\d{2}-\d{2}'
+$loose = Get-ChildItem -LiteralPath $CaptureDir -File | Where-Object { $_.Name -match $rx }
+if (-not $loose) { Log "nothing to do (0 loose capture files)"; Log "END"; exit 0 }
+
+$byDay = @{}
+foreach ($f in $loose) {
+  if ($f.Name -match $rx) {
+    $d = $matches['d']
+    if (-not $byDay.ContainsKey($d)) { $byDay[$d] = New-Object System.Collections.ArrayList }
+    [void]$byDay[$d].Add($f)
+  }
+}
+
+$daysToArchive = $byDay.Keys | Where-Object { [datetime]::ParseExact($_, 'yyyy-MM-dd', $null) -lt $cutoff } | Sort-Object
+if (-not $daysToArchive) { Log "nothing to do (no completed past days; newest is kept loose)"; Log "END"; exit 0 }
+
+$totalRaw = 0L; $totalArch = 0L; $totalFiles = 0; $errors = 0
+
+foreach ($day in $daysToArchive) {
+  $files = $byDay[$day]
+  $rawBytes = ($files | Measure-Object -Property Length -Sum).Sum
+  $archivePath = Join-Path $ArchiveDir "captures-$day.7z"
+
+  if ($PSCmdlet.ShouldProcess("$($files.Count) files for $day", "7z archive -> $archivePath then delete loose")) {
+    # Write an exact file list (bare names, no BOM) for 7z's @listfile.
+    $listFile = Join-Path $env:TEMP ("claudish-compact-$day-{0}.lst" -f $PID)
+    [System.IO.File]::WriteAllLines($listFile, ($files | ForEach-Object { $_.Name }), (New-Object System.Text.UTF8Encoding($false)))
+
+    Push-Location $CaptureDir
+    try {
+      # LZMA2, max compression. -md=128m dictionary spans the cross-request
+      # redundancy while keeping the unattended job memory-safe (~1.5 GB).
+      # NB: no `--` here — 7-Zip's `--` stops @listfile parsing too, which would
+      # make it treat the list as a literal filename. The archive path and the
+      # @list arg are both safe (no leading `-`), so `--` is unnecessary.
+      & $SevenZip a -t7z -m0=lzma2 -mx=9 -md=128m -mfb=273 -mmt=on -bso0 -bsp0 "$archivePath" "@$listFile" | Out-Null
+      $addRc = $LASTEXITCODE
+      & $SevenZip t -bso0 -bsp0 "$archivePath" | Out-Null
+      $testRc = $LASTEXITCODE
+    } finally {
+      Pop-Location
+      Remove-Item -LiteralPath $listFile -Force -ErrorAction SilentlyContinue
+    }
+
+    if ($addRc -eq 0 -and $testRc -eq 0 -and (Test-Path -LiteralPath $archivePath)) {
+      $archBytes = (Get-Item -LiteralPath $archivePath).Length
+      # Verified archive exists -> safe to delete the loose originals.
+      $files | Remove-Item -Force
+      $ratio = if ($archBytes -gt 0) { [Math]::Round($rawBytes / $archBytes, 1) } else { 0 }
+      Log ("OK  {0}: {1} files, {2:N1} MB -> {3:N1} MB ({4}:1), loose deleted" -f `
+           $day, $files.Count, ($rawBytes/1MB), ($archBytes/1MB), $ratio)
+      $totalRaw += $rawBytes; $totalArch += $archBytes; $totalFiles += $files.Count
+    } else {
+      $errors++
+      Log ("ERROR {0}: 7z add rc={1} test rc={2} -> KEEPING loose files (not deleted)" -f $day, $addRc, $testRc)
+    }
+  }
+}
+
+if ($totalArch -gt 0) {
+  $tr = [Math]::Round($totalRaw / $totalArch, 1)
+  Log ("SUMMARY: {0} day(s), {1} files, {2:N1} MB -> {3:N1} MB ({4}:1)" -f `
+       $daysToArchive.Count, $totalFiles, ($totalRaw/1MB), ($totalArch/1MB), $tr)
+}
+Log "END (errors=$errors)"
+exit $errors

--- a/scripts/traffic-history.ps1
+++ b/scripts/traffic-history.ps1
@@ -1,0 +1,135 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+Analyze historical claudish traffic from 7z archives.
+
+.DESCRIPTION
+Extracts and analyzes capture data from compressed archives in the
+archive directory. Supports single-day or multi-day lookback.
+
+.PARAMETER Date
+Specific date to analyze (format: yyyy-MM-dd).
+
+.PARAMETER Days
+Number of days to look back (default: 1).
+
+.PARAMETER Dir
+Capture directory (default: D:\claudish-captures).
+
+.EXAMPLE
+.\traffic-history.ps1 -Date 2026-06-06
+.\traffic-history.ps1 -Days 7
+#>
+[CmdletBinding()]
+param(
+    [string]$Date,
+    [int]$Days = 1,
+    [string]$Dir = 'D:\claudish-captures'
+)
+
+Import-Module (Join-Path $PSScriptRoot 'CaptureUtils.psm1') -Force
+
+# Determine which archive days to process
+$archives = @(Get-ArchivedDays -Dir $Dir)
+
+if ($Date) {
+    $targetDate = [datetime]::ParseExact($Date, 'yyyy-MM-dd', $null)
+    $archives = $archives | Where-Object { $_.Date.Date -eq $targetDate.Date }
+} elseif ($Days -gt 0) {
+    $cutoff = (Get-Date).Date.AddDays(-$Days)
+    $archives = $archives | Where-Object { $_.Date.Date -ge $cutoff }
+}
+
+if ($archives.Count -eq 0) {
+    Write-Host "No archives found for the requested period."
+    Write-Host "Available archives:"
+    $allArchives = @(Get-ArchivedDays -Dir $Dir)
+    if ($allArchives.Count -eq 0) {
+        Write-Host "  (none)" -ForegroundColor DarkGray
+    } else {
+        $allArchives | ForEach-Object {
+            Write-Host ("  {0}  {1:N1} MB" -f $_.Date.ToString('yyyy-MM-dd'), ($_.Size / 1MB))
+        }
+    }
+    exit 0
+}
+
+Write-Host ""
+Write-Host "=== Claudish Historical Traffic ===" -ForegroundColor Cyan
+Write-Host "Archives to process: $($archives.Count)" -ForegroundColor Gray
+Write-Host ""
+
+$tempDirs = @()
+
+try {
+    foreach ($arch in $archives) {
+        Write-Host ("Processing {0} ({1:N1} MB)..." -f $arch.Date.ToString('yyyy-MM-dd'), ($arch.Size / 1MB)) -ForegroundColor Yellow
+
+        $extractDir = Expand-ArchiveDay $arch.File
+        if (-not $extractDir) {
+            Write-Host "  Failed to extract archive." -ForegroundColor Red
+            continue
+        }
+        $tempDirs += $extractDir
+
+        $requests = @(Get-CaptureRequests -Dir $extractDir -All)
+
+        if ($requests.Count -eq 0) {
+            Write-Host "  No requests found in archive." -ForegroundColor DarkGray
+            continue
+        }
+
+        Write-Host ("  {0} requests" -f $requests.Count)
+
+        # Summary by machine
+        $byMachine = $requests | Group-Object Machine | Sort-Object Count -Descending
+        foreach ($g in $byMachine) {
+            $models = ($g.Group | Group-Object Model | Sort-Object Count -Descending |
+                ForEach-Object { "$($_.Name) ($($_.Count))" }) -join ', '
+            $workspaces = ($g.Group | Where-Object { $_.Workspace -ne '(no workspace)' } |
+                Select-Object -ExpandProperty Workspace -Unique) -join ', '
+            $sessions = ($g.Group | Where-Object { $_.SessionId } |
+                Select-Object -ExpandProperty SessionId -Unique).Count
+
+            Write-Host ("    {0,-16} {1,4} reqs  {2} sessions  models: {3}" -f $g.Name, $g.Count, $sessions, $models)
+            if ($workspaces) {
+                Write-Host ("    {0,16}         workspaces: {1}" -f '', $workspaces) -ForegroundColor DarkGray
+            }
+        }
+        Write-Host ""
+    }
+
+    # Cross-day session summary
+    Write-Host "--- Cross-Day Sessions ---" -ForegroundColor Yellow
+    $allRequests = @()
+    foreach ($td in $tempDirs) {
+        $allRequests += @(Get-CaptureRequests -Dir $td -All)
+    }
+
+    $crossSessions = $allRequests | Where-Object { $_.SessionId } |
+        Group-Object SessionId |
+        Where-Object { $_.Count -gt 5 } |
+        Sort-Object Count -Descending |
+        Select-Object -First 20
+
+    if ($crossSessions) {
+        foreach ($s in $crossSessions) {
+            $latest = $s.Group | Sort-Object FileTime -Descending | Select-Object -First 1
+            $oldest = $s.Group | Sort-Object FileTime | Select-Object -First 1
+            $shortSid = if ($s.Name.Length -gt 8) { $s.Name.Substring(0, 8) + '…' } else { $s.Name }
+            $duration = $latest.FileTime - $oldest.FileTime
+            $durationStr = if ($duration.TotalHours -ge 1) { "{0:N1}h" -f $duration.TotalHours } else { "{0:N0}m" -f $duration.TotalMinutes }
+            $models = ($s.Group | Select-Object -ExpandProperty Model -Unique) -join ', '
+
+            Write-Host ("  {0}  {1,4} reqs  {2,6}  {3}  {4}" -f $shortSid, $s.Count, $durationStr, $models, $latest.Workspace)
+        }
+    } else {
+        Write-Host "  (no sessions with > 5 requests)" -ForegroundColor DarkGray
+    }
+
+} finally {
+    # Cleanup temp directories
+    foreach ($td in $tempDirs) {
+        Remove-Item $td -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/scripts/traffic-live.ps1
+++ b/scripts/traffic-live.ps1
@@ -1,0 +1,188 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+  Live traffic analysis from claudish-proxy docker logs.
+
+.DESCRIPTION
+  Standardized analysis of `docker logs claudish-proxy --since Nh`. This is the
+  FAST path for surveillance (the 6h cron): it reads stdout logs directly,
+  avoiding the cost of parsing thousands of req-*.json captures.
+
+  Use this script instead of hand-rolled grep commands — it encodes the
+  precise filters that avoid the false-positive traps documented in
+  proxy-log-monitoring (bytes=NNNN matching error codes, timestamp digits
+  matching 429, [msg:N] previews matching keywords).
+
+  For richer detail (workspace, session_id, CC version, token usage) use
+  traffic-summary.ps1 / traffic-sessions.ps1 against the capture files.
+  For historical analysis use traffic-history.ps1 against the 7z archives.
+
+.PARAMETER Hours
+  Look-back window in hours (default: 6, matches the surveillance cron).
+
+.PARAMETER Container
+  Docker container name (default: claudish-proxy).
+
+.PARAMETER AnthropicMachines
+  Comma-separated machine names authorized for Anthropic models
+  (Opus/Fable/Sonnet). Requests from other machines are flagged for review.
+  Default: 'myia-ai-01'. (po-2025 may run an authorized Safari workflow —
+  review, do not auto-flag.)
+
+.EXAMPLE
+  .\scripts\traffic-live.ps1
+  .\scripts\traffic-live.ps1 -Hours 1
+  .\scripts\traffic-live.ps1 -Hours 24 -AnthropicMachines 'myia-ai-01,myia-po-2025'
+#>
+[CmdletBinding()]
+param(
+    [int]$Hours = 6,
+    [string]$Container = 'claudish-proxy',
+    [string]$AnthropicMachines = 'myia-ai-01'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# --- gather logs -------------------------------------------------------------
+# --timestamps prepends ISO8601 to each line → enables temporal analysis
+# (e.g. detecting whether an anomaly is recent vs residual).
+$raw = docker logs --timestamps --since "${Hours}h" $Container 2>&1
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "ERROR: cannot read docker logs from '$Container' (is the container running?)." -ForegroundColor Red
+    Write-Host $raw
+    exit 1
+}
+
+# Filter to actual log lines (docker injects some non-log output on stderr).
+$lines = $raw | Where-Object { $_ -match '^\d{4}-\d{2}-\d{2}T' }
+if ($lines.Count -eq 0) {
+    Write-Host "No log lines in the last $Hours hours (container may have just started)." -ForegroundColor Yellow
+    exit 0
+}
+
+$requests = $lines | Where-Object { $_ -match '\[Request\]' }
+$responses = $lines | Where-Object { $_ -match '\[resp\]' }
+
+Write-Host ""
+Write-Host "=== Claudish Live Traffic (last ${Hours}h) ===" -ForegroundColor Cyan
+Write-Host "Container: $Container  |  Log lines: $($lines.Count)  |  Requests: $($requests.Count)  |  Responses: $($responses.Count)" -ForegroundColor Gray
+Write-Host ""
+
+# --- by model ----------------------------------------------------------------
+Write-Host "--- By Model (requests) ---" -ForegroundColor Yellow
+$requests | Select-String -Pattern 'model=([^\s]+)' -AllMatches |
+    ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value } |
+    Group-Object | Sort-Object Count -Descending | ForEach-Object {
+        Write-Host ("  {0,-22} {1,5}" -f $_.Name, $_.Count)
+    }
+Write-Host ""
+
+# --- by machine --------------------------------------------------------------
+Write-Host "--- By Machine (requests, via X-Claudish-Machine header) ---" -ForegroundColor Yellow
+$requests | Select-String -Pattern 'machine=([^\s]+)' -AllMatches |
+    ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value } |
+    Group-Object | Sort-Object Count -Descending | ForEach-Object {
+        Write-Host ("  {0,-22} {1,5}" -f $_.Name, $_.Count)
+    }
+
+# Source IPs — for header-less attribution (ai-01 cron agents, legacy CC versions)
+Write-Host "  (header-less source IPs):" -ForegroundColor DarkGray
+$requests | Select-String -Pattern 'src=([\d.]+)' -AllMatches |
+    ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value } |
+    Group-Object | Sort-Object Count -Descending | Select-Object -First 5 | ForEach-Object {
+        Write-Host ("    {0,-18} {1,5}" -f $_.Name, $_.Count) -ForegroundColor DarkGray
+    }
+Write-Host ""
+
+# --- handlers ----------------------------------------------------------------
+Write-Host "--- By Handler ---" -ForegroundColor Yellow
+$requests | Select-String -Pattern 'handler=([A-Za-z]+)' -AllMatches |
+    ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value } |
+    Group-Object | Sort-Object Count -Descending | ForEach-Object {
+        Write-Host ("  {0,-22} {1,5}" -f $_.Name, $_.Count)
+    }
+Write-Host ""
+
+# --- errors (PRECISE filters — see proxy-log-monitoring memory) --------------
+Write-Host "--- Errors (precise) ---" -ForegroundColor Yellow
+
+$realRateLimit = ($lines | Select-String -Pattern '\[RateLimit\]|\[130[0-9]\]|HTTP 429').Count
+$emptyBytes0   = ($responses | Select-String -Pattern 'bytes=0 ').Count
+$finalizeErr   = ($lines | Select-String -Pattern 'finalizeWithError').Count
+$http5xx       = ($lines | Select-String -Pattern 'status=5\d\d|HTTP 5\d\d').Count
+$fallback      = ($lines | Select-String -Pattern '\[Fallback\]').Count
+$exhausted     = ($lines | Select-String -Pattern 'giving up|chain exhausted|all providers').Count
+
+Write-Host ("  rate-limit (REAL):   {0}" -f $realRateLimit)
+Write-Host ("  empty (bytes=0):     {0}" -f $emptyBytes0)
+Write-Host ("  finalizeWithError:   {0}" -f $finalizeErr)
+Write-Host ("  HTTP 5xx:            {0}" -f $http5xx)
+Write-Host ("  [Fallback] events:   {0}  (absorbed, check exhausted=0)" -f $fallback)
+Write-Host ("  chain exhausted:     {0}  (>0 = requests lost)" -f $exhausted)
+Write-Host ""
+
+# --- never-hang (priority #1) ------------------------------------------------
+Write-Host "--- Never-Hang (priority #1) ---" -ForegroundColor Yellow
+$closedTrue = ($responses | Select-String -Pattern 'closed=true').Count
+$notClosed  = $responses | Where-Object { $_ -notmatch 'closed=true' }
+Write-Host ("  [resp] total: {0}  |  closed=true: {1}  |  NOT closed: {2}" -f $responses.Count, $closedTrue, $notClosed.Count)
+if ($notClosed.Count -gt 0) {
+    Write-Host "  !!! HANG SUSPECTS — investigate these responses:" -ForegroundColor Red
+    $notClosed | Select-Object -First 5 | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+} else {
+    Write-Host "  All responses closed cleanly." -ForegroundColor Green
+}
+Write-Host ""
+
+# --- Anthropic leak check ----------------------------------------------------
+# Opus + Fable + Sonnet are the Anthropic-billed models. By cluster policy
+# these must come from the authorized machine(s). po-2025 may have an
+# authorized Safari workflow — flagged REVIEW, not LEAK (lesson 2026-06-21).
+Write-Host "--- Anthropic Distribution (Opus/Fable/Sonnet) ---" -ForegroundColor Yellow
+$authorized = $AnthropicMachines.Split(',') | ForEach-Object { $_.Trim() }
+
+$anthropicReqs = $requests | Where-Object { $_ -match 'claude-opus|claude-fable|claude-sonnet' }
+if ($anthropicReqs.Count -eq 0) {
+    Write-Host "  No Anthropic-model traffic this window." -ForegroundColor Green
+} else {
+    $byMachine = $anthropicReqs | Select-String -Pattern 'machine=([^\s]+)' -AllMatches |
+        ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value } |
+        Group-Object | Sort-Object Count -Descending
+    foreach ($g in $byMachine) {
+        $tag = if ($authorized -contains $g.Name) { 'OK (authorized)' }
+               elseif ($g.Name -eq 'myia-po-2025') { 'REVIEW (Safari workflow may be authorized)' }
+               else { 'LEAK (not authorized for Anthropic)' }
+        $color = if ($tag -like 'OK*') { 'Green' } elseif ($tag -like 'REVIEW*') { 'Yellow' } else { 'Red' }
+        Write-Host ("  {0,-22} {1,5}  [{2}]" -f $g.Name, $g.Count, $tag) -ForegroundColor $color
+
+        # Sub-breakdown by model for this machine
+        $modelBreakdown = ($anthropicReqs | Where-Object { $_ -match "machine=$($g.Name)" } |
+            Select-String -Pattern 'model=(claude-opus-4-8|claude-fable\S*|claude-sonnet-4-6)' -AllMatches |
+            ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value } |
+            Group-Object | Sort-Object Count -Descending |
+            ForEach-Object { "$($_.Name) x$($_.Count)" }) -join ', '
+        Write-Host ("    models: {0}" -f $modelBreakdown) -ForegroundColor DarkGray
+    }
+}
+Write-Host ""
+
+# --- session loop detection --------------------------------------------------
+# Same reqN repeated many times = possible stuck loop. Normal requests produce
+# 2-3 lines (req + resp + stream marker); counts >= 6 across a wide window
+# warrant a look. Lower counts are just the normal multi-line traces of one req.
+Write-Host "--- Session Loop Check (reqN repeated >= 6 times = review) ---" -ForegroundColor Yellow
+$reqNGroups = $lines | Select-String -Pattern 'reqN=(\d+)' -AllMatches |
+    ForEach-Object { $_.Matches } | ForEach-Object { $_.Groups[1].Value } |
+    Group-Object | Sort-Object Count -Descending
+$suspects = $reqNGroups | Where-Object { $_.Count -ge 6 }
+if ($suspects) {
+    foreach ($g in $suspects | Select-Object -First 5) {
+        Write-Host ("  reqN={0,-8} x{1}  (review for loop)" -f $g.Name, $g.Count) -ForegroundColor Yellow
+    }
+} else {
+    Write-Host "  No reqN repeated >= 6 times — no loop pattern." -ForegroundColor Green
+    $reqNGroups | Select-Object -First 3 | ForEach-Object {
+        Write-Host ("  (normal) reqN={0,-8} x{1}" -f $_.Name, $_.Count) -ForegroundColor DarkGray
+    }
+}
+Write-Host ""

--- a/scripts/traffic-sessions.ps1
+++ b/scripts/traffic-sessions.ps1
@@ -1,0 +1,119 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+List active claudish sessions with full detail from captures.
+
+.DESCRIPTION
+Groups requests by session_id and shows workspace, machine, model,
+CC version, timing, and request statistics for each session.
+
+.PARAMETER Hours
+Session activity window: only show sessions with a request in the last N hours (default: 2).
+
+.PARAMETER All
+Show all sessions found in capture files (no time filter).
+
+.PARAMETER Dir
+Capture directory (default: D:\claudish-captures).
+
+.EXAMPLE
+.\traffic-sessions.ps1
+.\traffic-sessions.ps1 -All
+#>
+[CmdletBinding()]
+param(
+    [int]$Hours = 2,
+    [switch]$All,
+    [string]$Dir = 'D:\claudish-captures'
+)
+
+Import-Module (Join-Path $PSScriptRoot 'CaptureUtils.psm1') -Force
+
+$requests = @(Get-CaptureRequests -Dir $Dir -Hours $Hours -All:$All)
+
+if ($requests.Count -eq 0) {
+    Write-Host "No capture files found."
+    exit 0
+}
+
+# Group by session
+$sessions = $requests | Where-Object { $_.SessionId } |
+    Group-Object SessionId |
+    Sort-Object { ($_.Group | Sort-Object FileTime -Descending | Select-Object -First 1).FileTime } -Descending
+
+if ($sessions.Count -eq 0) {
+    Write-Host "No sessions found (metadata.user_id may be missing)."
+    exit 0
+}
+
+Write-Host ""
+Write-Host "=== Claudish Sessions ===" -ForegroundColor Cyan
+Write-Host "Total: $($sessions.Count) sessions from $($requests.Count) requests" -ForegroundColor Gray
+Write-Host ""
+
+# Also group requests without session for accounting
+$noSession = $requests | Where-Object { -not $_.SessionId }
+if ($noSession) {
+    Write-Host "($($noSession.Count) requests without session_id)" -ForegroundColor DarkGray
+    Write-Host ""
+}
+
+foreach ($s in $sessions) {
+    $latest = $s.Group | Sort-Object FileTime -Descending | Select-Object -First 1
+    $oldest = $s.Group | Sort-Object FileTime | Select-Object -First 1
+    $sid = $s.Name
+    $shortSid = if ($sid.Length -gt 8) { $sid.Substring(0, 8) + '…' } else { $sid }
+
+    # Resolve machine: prefer explicit header, fall back to device_id
+    $machine = $latest.Machine
+    if ($machine -eq '(unknown)' -and $latest.DeviceId) {
+        $machine = Resolve-MachineFromDevice $latest.DeviceId
+    }
+
+    # Compute session duration
+    $duration = $latest.FileTime - $oldest.FileTime
+    $durationStr = if ($duration.TotalHours -ge 1) {
+        "{0:N1}h" -f $duration.TotalHours
+    } else {
+        "{0:N0}m" -f $duration.TotalMinutes
+    }
+
+    # Token estimate (sum of request body sizes as proxy)
+    $totalSize = ($s.Group | Measure-Object Size -Sum).Sum
+    $avgMsgs = [math]::Round(($s.Group | Measure-Object MsgCount -Average).Average)
+    $maxMsgs = ($s.Group | Measure-Object MsgCount -Maximum).Maximum
+
+    # Model transitions
+    $modelSeq = $s.Group | Sort-Object FileTime | Select-Object -ExpandProperty Model -Unique
+    $modelStr = $modelSeq -join ' → '
+
+    # Workspaces used
+    $wsList = $s.Group | Select-Object -ExpandProperty Workspace -Unique
+
+    # Time gap analysis
+    $sorted = $s.Group | Sort-Object FileTime
+    $gaps = @()
+    for ($i = 1; $i -lt $sorted.Count; $i++) {
+        $gap = $sorted[$i].FileTime - $sorted[$i-1].FileTime
+        if ($gap.TotalMinutes -gt 30) {
+            $gaps += $gap
+        }
+    }
+
+    $isActive = ($latest.FileTime -gt (Get-Date).AddHours(-1))
+
+    Write-Host ("Session {0}  {1}" -f $shortSid, $(if ($isActive) { '[ACTIVE]' } else { '[idle]' })) -ForegroundColor $(if ($isActive) { 'Green' } else { 'Gray' })
+    Write-Host ("  Machine:     {0}" -f $machine)
+    Write-Host ("  Workspace:   {0}" -f ($wsList -join ', '))
+    Write-Host ("  Model:       {0}" -f $modelStr)
+    Write-Host ("  CC:          {0} ({1})" -f $latest.CCVersion, $latest.Entrypoint)
+    Write-Host ("  First req:   {0}" -f $oldest.Timestamp)
+    Write-Host ("  Last req:    {0}" -f $latest.Timestamp)
+    Write-Host ("  Duration:    {0}" -f $durationStr)
+    Write-Host ("  Requests:    {0}  (avg {1} msgs, max {2} msgs)" -f $s.Count, $avgMsgs, $maxMsgs)
+    Write-Host ("  Total data:  {0:N1} KB" -f ($totalSize / 1KB))
+    if ($gaps.Count -gt 0) {
+        Write-Host ("  Long gaps:   {0} gaps > 30min" -f $gaps.Count) -ForegroundColor DarkGray
+    }
+    Write-Host ""
+}

--- a/scripts/traffic-summary.ps1
+++ b/scripts/traffic-summary.ps1
@@ -1,0 +1,109 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+Summarize claudish proxy traffic from capture files.
+
+.DESCRIPTION
+Reads req-*.json capture files from the last N hours and produces a
+structured summary: by machine, by workspace, by model, by session.
+
+.PARAMETER Hours
+Look back window in hours (default: 2).
+
+.PARAMETER Dir
+Capture directory (default: D:\claudish-captures).
+
+.EXAMPLE
+.\traffic-summary.ps1
+.\traffic-summary.ps1 -Hours 24
+#>
+[CmdletBinding()]
+param(
+    [int]$Hours = 2,
+    [string]$Dir = 'D:\claudish-captures'
+)
+
+Import-Module (Join-Path $PSScriptRoot 'CaptureUtils.psm1') -Force
+
+$requests = @(Get-CaptureRequests -Dir $Dir -Hours $Hours)
+
+if ($requests.Count -eq 0) {
+    Write-Host "No capture files found in the last $Hours hours."
+    exit 0
+}
+
+Write-Host ""
+Write-Host "=== Claudish Traffic Summary (last ${Hours}h) ===" -ForegroundColor Cyan
+Write-Host "Capture files processed: $($requests.Count)" -ForegroundColor Gray
+Write-Host ""
+
+# ── By Machine ──────────────────────────────────────────────
+$byMachine = $requests | Group-Object Machine | Sort-Object Count -Descending
+
+Write-Host "--- By Machine ---" -ForegroundColor Yellow
+foreach ($g in $byMachine) {
+    $models = ($g.Group | Group-Object Model | Sort-Object Count -Descending |
+        ForEach-Object { "$($_.Name) ($($_.Count))" }) -join ', '
+    $workspaces = ($g.Group | Select-Object -ExpandProperty Workspace -Unique) -join ', '
+    $latest = ($g.Group | Sort-Object FileTime -Descending | Select-Object -First 1).Timestamp
+
+    Write-Host ("  {0,-16} {1,4} reqs  models: {2}" -f $g.Name, $g.Count, $models)
+    Write-Host ("  {0,16}         workspaces: {1}" -f '', $workspaces) -ForegroundColor DarkGray
+    Write-Host ("  {0,16}         last: {1}" -f '', $latest) -ForegroundColor DarkGray
+}
+Write-Host ""
+
+# ── By Model ────────────────────────────────────────────────
+$byModel = $requests | Group-Object Model | Sort-Object Count -Descending
+
+Write-Host "--- By Model ---" -ForegroundColor Yellow
+foreach ($g in $byModel) {
+    $machines = ($g.Group | Select-Object -ExpandProperty Machine -Unique) -join ', '
+    Write-Host ("  {0,-20} {1,4} reqs  machines: {2}" -f $g.Name, $g.Count, $machines)
+}
+Write-Host ""
+
+# ── Active Workspaces ───────────────────────────────────────
+$byWorkspace = $requests | Where-Object { $_.Workspace -ne '(no workspace)' } |
+    Group-Object Workspace | Sort-Object Count -Descending
+
+Write-Host "--- Active Workspaces ---" -ForegroundColor Yellow
+foreach ($g in $byWorkspace) {
+    $machines = ($g.Group | Select-Object -ExpandProperty Machine -Unique) -join ', '
+    $sessions = ($g.Group | Where-Object { $_.SessionId } | Select-Object -ExpandProperty SessionId -Unique).Count
+    $latest = ($g.Group | Sort-Object FileTime -Descending | Select-Object -First 1).Timestamp
+    $models = ($g.Group | Group-Object Model | Sort-Object Count -Descending |
+        ForEach-Object { $_.Name }) -join ', '
+
+    Write-Host ("  {0,-40} {1,3} reqs  {2} sessions" -f $g.Name, $g.Count, $sessions)
+    Write-Host ("  {0,40}         machines: {1}" -f '', $machines) -ForegroundColor DarkGray
+    Write-Host ("  {0,40}         models: {1}" -f '', $models) -ForegroundColor DarkGray
+    Write-Host ("  {0,40}         last: {1}" -f '', $latest) -ForegroundColor DarkGray
+}
+Write-Host ""
+
+# ── Active Sessions ─────────────────────────────────────────
+$activeSessions = $requests | Where-Object { $_.SessionId } |
+    Group-Object SessionId | Sort-Object { ($_.Group | Sort-Object FileTime -Descending | Select-Object -First 1).FileTime } -Descending
+
+Write-Host "--- Active Sessions ---" -ForegroundColor Yellow
+foreach ($g in $activeSessions) {
+    $latest = $g.Group | Sort-Object FileTime -Descending | Select-Object -First 1
+    $oldest = $g.Group | Sort-Object FileTime | Select-Object -First 1
+    $models = ($g.Group | Group-Object Model | Sort-Object Count -Descending |
+        ForEach-Object { $_.Name }) -join ' → '
+    $sid = $g.Name
+    $shortSid = if ($sid.Length -gt 8) { $sid.Substring(0, 8) + '…' } else { $sid }
+
+    Write-Host ("  Session {0}" -f $shortSid) -ForegroundColor White
+    Write-Host ("    Machine:    {0}" -f $latest.Machine)
+    Write-Host ("    Workspace:  {0}" -f $latest.Workspace)
+    Write-Host ("    Models:     {0}" -f $models)
+    Write-Host ("    CC version: {0}" -f $latest.CCVersion)
+    Write-Host ("    Entrypoint: {0}" -f $latest.Entrypoint)
+    Write-Host ("    First req:  {0}" -f $oldest.Timestamp)
+    Write-Host ("    Last req:   {0}" -f $latest.Timestamp)
+    Write-Host ("    Requests:   {0}  (avg {1} msgs/req)" -f $g.Count,
+        [math]::Round(($g.Group | Measure-Object MsgCount -Average).Average))
+    Write-Host ""
+}

--- a/start-claudish-proxy.ps1
+++ b/start-claudish-proxy.ps1
@@ -1,0 +1,38 @@
+# Claudish Proxy - Windows Service Wrapper
+# Run via Scheduled Task at system startup
+# Logs to ~/.claudish/logs/proxy-*.log
+
+$ErrorActionPreference = "Stop"
+$LogFile = "$env:USERPROFILE\.claudish\logs\proxy-$(Get-Date -Format 'yyyy-MM-dd').log"
+$LogDir = Split-Path $LogFile -Parent
+
+if (-not (Test-Path $LogDir)) {
+    New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+}
+
+function Write-Log {
+    param([string]$Message)
+    $ts = Get-Date -Format "yyyy-MM-dd HH:mm:ss"
+    "$ts  $Message" | Add-Content -Path $LogFile -Encoding utf8NoBOM
+}
+
+Write-Log "Claudish proxy service starting..."
+Write-Log "Working dir: $PSScriptRoot"
+Write-Log "Bun path: $(Get-Command bun -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source)"
+
+Set-Location $PSScriptRoot
+
+# Kill any existing proxy on port 3000
+$existing = Get-NetTCPConnection -LocalPort 3000 -ErrorAction SilentlyContinue | Select-Object -ExpandProperty OwningProcess -Unique
+if ($existing) {
+    Write-Log "Killing existing process(es) on port 3000: $($existing -join ', ')"
+    $existing | ForEach-Object { Stop-Process -Id $_ -Force -ErrorAction SilentlyContinue }
+    Start-Sleep -Seconds 2
+}
+
+# Start the proxy
+Write-Log "Starting: bun packages/cli/src/standalone-proxy.ts --port 3000"
+bun packages/cli/src/standalone-proxy.ts --port 3000 2>&1 | ForEach-Object {
+    Write-Log $_
+}
+Write-Log "Claudish proxy exited."

--- a/start-claudish-proxy.ps1
+++ b/start-claudish-proxy.ps1
@@ -31,8 +31,8 @@ if ($existing) {
 }
 
 # Start the proxy
-Write-Log "Starting: bun packages/cli/src/standalone-proxy.ts --port 3000"
-bun packages/cli/src/standalone-proxy.ts --port 3000 2>&1 | ForEach-Object {
+Write-Log "Starting: bun packages/cli/src/fork/server/standalone-proxy.ts --port 3000"
+bun packages/cli/src/fork/server/standalone-proxy.ts --port 3000 2>&1 | ForEach-Object {
     Write-Log $_
 }
 Write-Log "Claudish proxy exited."


### PR DESCRIPTION
## Summary

Consolidated fork improvements covering stream parsing, web search interception, and proxy robustness. All changes are backwards-compatible and gated behind opt-in env vars where appropriate.

### Stream Robustness (5 commits)
- **fix(stream): guarantee finalize() terminates stream** — try/catch/finally pattern in all stream parsers prevents hung streams when finalize() body throws
- **fix(stream): graceful handling of socket close / fetch errors mid-stream** — injects actionable error text instead of raw SSE error events
- **fix(stream): fix out-of-order content block lifecycle** — closes reasoning/text blocks before tool blocks to prevent "Content block not found" client errors
- **fix(stream): classify empty-response cause** — distinguishes transient vs overflow vs content-filter instead of blanket "compact" push
- **fix(stream): stop appending empty-response error after valid text content** — snapshot `textStarted` before clearing in finalize() (cluster-wide regression fix)

### Non-Streaming Support
- **fix(handler): serve non-streaming clients (stream:false) as JSON message** — `collectAnthropicSseToMessage()` buffers SSE into a single Anthropic message. Unblocks `/compact` on all proxied models (was working only on Opus/native before).

### Web Search Interception
- **feat(web-tools): route web search/fetch via MCP SearXNG** — intercepts provider web-search tool calls and GLM `<searchWeb>` tags, executes via SearXNG or MCP endpoint
- **fix(web-tools): intercept sub-agents + enhance htmlToText** — sub-agent WebSearch/WebFetch requests intercepted at proxy level; remaps to client tool_use when WebSearch is declared
- **fix(stream): WebFetch socket closure + empty response + tool_result role mismatch** — upstream fixes from earlier sessions

### Ops
- **chore: track operational utility scripts** — watchdog (hang detection + proactive restart) and capture compression scripts

### Regression Tests
- `format-translation.test.ts`: 77 tests (4 new: transient/overflow/content-filter classification + valid-text-not-empty)
- `collect-sse-message.test.ts`: 7 tests (text, tool_use, mixed blocks, empty body, malformed SSE, unparseable JSON)

## Files Changed
- `packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts` — finalize() robustness, hasContent snapshot, error classification
- `packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts` — out-of-order block fix, duplicate stop prevention
- `packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts` — finalize() try/catch/finally hang guard
- `packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts` — finalize() try/catch/finally hang guard
- `packages/cli/src/handlers/shared/collect-sse-message.ts` — new: SSE→message collector for non-streaming clients
- `packages/cli/src/handlers/shared/collect-sse-message.test.ts` — new: 7 regression tests
- `packages/cli/src/handlers/shared/mcp-searxng-client.ts` — new: MCP streamable-http JSON-RPC client
- `packages/cli/src/handlers/shared/web-search-executor.ts` — new: SearXNG search/fetch fallback chains
- `packages/cli/src/handlers/composed-handler.ts` — non-streaming JSON response path
- `packages/cli/src/proxy-server.ts` — sub-agent web tool interception
- `packages/cli/src/format-translation.test.ts` — 4 new regression tests

## Testing
- 84 tests pass (77 format-translation + 7 collect-sse-message)
- Live-tested on production proxy (GLM-5.1, qwen3.6, Opus, Sonnet)
- Verified: `/compact` works on all proxied models, no spurious "empty response" on valid content

🤖 Generated with [Claude Code](https://claude.com/claude-code)