### PR TITLE
feat: classifier passthrough — run auto-mode permission classifier on native Anthropic

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Claudish is a **BYOK AI coding assistant**:
 - ✅ **Autonomous mode** - Bypass all prompts with flags
 - ✅ **Context inheritance** - Runs in current directory with same `.claude` settings
 - ✅ **Claude Code flag passthrough** - Forward any Claude Code flag (`--agent`, `--effort`, `--permission-mode`, etc.) in any order
+- ✅ **Classifier passthrough** - In hybrid setups, keep Claude Code's auto-mode permission classifier on real Claude (Anthropic) while your main loop runs on another provider (`--classifier-provider anthropic`)
 - ✅ **Vision proxy** - Non-vision models automatically get image descriptions via Claude, so every model can "see"
 
 ## Installation
@@ -278,6 +279,8 @@ claudish [OPTIONS] <claude-args...>
 | `--model-sonnet <model>` | | Model for Sonnet role (default coding) | |
 | `--model-haiku <model>` | | Model for Haiku role (fast tasks) | |
 | `--model-subagent <model>` | | Model for sub-agents (Task tool) | |
+| `--classifier-provider <name>` | | Route the auto-mode permission classifier to native Anthropic (`anthropic`) | Off |
+| `--classifier-model <model>` | | Native Claude model for the classifier passthrough (also enables it) | `claude-sonnet-5` |
 | `--profile <name>` | `-p` | Named profile for model mapping | Default profile |
 | `--config <file>` | | Use this file as the run's ONLY config (replaces global + project) | |
 | `--op-env <id>` | | Load env vars from a 1Password Environment (highest priority) | |
@@ -395,6 +398,9 @@ Every one of these also accepts `CUSTOM_<NAME>_KEY` as an alias, and any of them
 | `CLAUDISH_DEFAULT_PROVIDER` | Default provider for bare model routing (v7.0.0+) | Auto-detected |
 | `CLAUDISH_QWEN_NO_THINK` | Disable thinking for Qwen models (`1`) | |
 | `CLAUDISH_NO_PREDEFINED_ENDPOINTS` | Turn the bundled endpoint catalog off entirely (`1`) | Catalog on |
+| `CLAUDISH_CLASSIFIER_PROVIDER` | Route auto-mode permission classifier to native Anthropic (`anthropic`) — see [Classifier Passthrough](docs/models/model-mapping.md#auto-mode-classifier-passthrough) | Off |
+| `CLAUDISH_CLASSIFIER_MODEL` | Native Claude model for the classifier passthrough (also enables it) | `claude-sonnet-5` |
+| `CLAUDISH_CLASSIFIER_DEBUG` | Dump raw requests to `logs/classifier-capture.jsonl` for classifier-detection debugging (`1`) | Off |
 
 #### Claude Code Compatibility
 

--- a/docs/advanced/environment.md
+++ b/docs/advanced/environment.md
@@ -115,6 +115,8 @@ export CLAUDISH_CLASSIFIER_MODEL=claude-sonnet-5
 
 Set to `1` to dump each request's raw model / sampling params / system prompt / headers to `logs/classifier-capture.jsonl` for troubleshooting detection. Off by default.
 
+Off by default deliberately: the captured `system` array is the **full** system prompt, which carries your CLAUDE.md and project rules, and the classifier request additionally names the command being classified. Credentials are recorded only as `<present>`, never as values. Turn it on to diagnose a drifted detection marker, then turn it back off and delete the file.
+
 ```bash
 export CLAUDISH_CLASSIFIER_DEBUG=1
 ```

--- a/docs/advanced/environment.md
+++ b/docs/advanced/environment.md
@@ -90,6 +90,37 @@ export CLAUDE_CODE_SUBAGENT_MODEL='...'
 
 ---
 
+## Classifier Passthrough
+
+Route Claude Code's auto-mode permission classifier to native Anthropic while your main loop
+runs on another provider. Full guide: [Model Mapping → Auto-Mode Classifier Passthrough](../models/model-mapping.md#auto-mode-classifier-passthrough).
+
+### `CLAUDISH_CLASSIFIER_PROVIDER`
+
+Set to `anthropic` to enable classifier passthrough (default off). CLI equivalent: `--classifier-provider anthropic`.
+
+```bash
+export CLAUDISH_CLASSIFIER_PROVIDER=anthropic
+```
+
+### `CLAUDISH_CLASSIFIER_MODEL`
+
+Native Claude model the classifier request is rewritten onto. Setting it also enables passthrough. Defaults to `claude-sonnet-5`. CLI equivalent: `--classifier-model <id>`.
+
+```bash
+export CLAUDISH_CLASSIFIER_MODEL=claude-sonnet-5
+```
+
+### `CLAUDISH_CLASSIFIER_DEBUG`
+
+Set to `1` to dump each request's raw model / sampling params / system prompt / headers to `logs/classifier-capture.jsonl` for troubleshooting detection. Off by default.
+
+```bash
+export CLAUDISH_CLASSIFIER_DEBUG=1
+```
+
+---
+
 ## Network Configuration
 
 ### `CLAUDISH_PORT`

--- a/docs/models/model-mapping.md
+++ b/docs/models/model-mapping.md
@@ -94,6 +94,79 @@ Yep. Claudish detects this is an Anthropic model ID and routes directly to Anthr
 
 ---
 
+## Auto-Mode Classifier Passthrough
+
+When you run Claude Code in **auto mode** (`--permission-mode auto`), Claude Code sends a
+dedicated **permission-classifier** request — Anthropic's "security monitor" — to decide
+whether each tool call is safe to run automatically. That classifier only behaves correctly
+on a real Claude model. If your hybrid setup routes it to a non-Claude provider (Codex, GPT,
+Gemini, …), it over-blocks or times out with *"safety classifier temporarily unavailable"* —
+and even harmless commands get denied.
+
+**Classifier passthrough** fixes this: it detects the classifier request by content and
+reroutes **only that request** to native Anthropic (`claude-sonnet-5` by default, via your
+Claude Max OAuth), while your main loop keeps running on whatever provider you mapped.
+
+### Enable it
+
+Opt-in (default off) via a flag or an env var:
+
+```bash
+# Flag
+claudish --model-opus cx@gpt-5.6-sol --model-sonnet claude-sonnet-5 \
+  --classifier-provider anthropic \
+  -- --permission-mode auto "your task"
+
+# Or env var
+export CLAUDISH_CLASSIFIER_PROVIDER=anthropic
+```
+
+Choose a specific classifier model with `--classifier-model` / `CLAUDISH_CLASSIFIER_MODEL`
+(defaults to `claude-sonnet-5` — fast, cheap, and correct for the classifier):
+
+```bash
+claudish --classifier-model claude-sonnet-5 ...
+```
+
+### Example: main loop on Codex, safety classifier on Claude
+
+```bash
+claudish \
+  --model-opus cx@gpt-5.6-sol \
+  --model-sonnet claude-sonnet-5 \
+  --classifier-provider anthropic \
+  -- --permission-mode auto -p 'refactor the auth module'
+```
+
+The main loop (Opus/Sonnet tiers) runs on Codex; only the permission-classifier request is
+rerouted to `claude-sonnet-5` on `api.anthropic.com`.
+
+### Requirements
+
+- You need working Anthropic credentials (Claude Max OAuth, or `ANTHROPIC_API_KEY`). The
+  simplest way is to **map a role to a native Claude model** — e.g.
+  `--model-sonnet claude-sonnet-5` as above — which preserves your real Claude Code auth
+  automatically. If you enable the flag with no native mapping *and* no resolvable Anthropic
+  credentials, claudish keeps your main loop working and prints a warning that the classifier
+  can't authenticate.
+- Only the classifier request is rerouted; every other request follows your normal role
+  mapping.
+
+> **Consent model:** Claude Code's classifier treats a command you *explicitly name* in your
+> prompt (e.g. literally asking it to run `curl … | bash`) as informed consent and allows it.
+> Visible blocks are for dangerous actions the agent formulates on its own, or for
+> hard-blocked operations — so a "dangerous" prompt that spells out the exact command may be
+> allowed by design.
+
+### Debugging
+
+Set `CLAUDISH_CLASSIFIER_DEBUG=1` to append each incoming request's model / sampling params /
+system prompt / headers to `logs/classifier-capture.jsonl` — handy for confirming the
+classifier is detected and rerouted. With `--debug-claudish`, a
+`[Classifier] … → native Anthropic` line is written when the passthrough fires.
+
+---
+
 ## Subagent Mapping
 
 When Claude Code spawns sub-agents (via the Task tool), they use the subagent model:

--- a/docs/models/model-mapping.md
+++ b/docs/models/model-mapping.md
@@ -162,7 +162,8 @@ rerouted to `claude-sonnet-5` on `api.anthropic.com`.
 
 Set `CLAUDISH_CLASSIFIER_DEBUG=1` to append each incoming request's model / sampling params /
 system prompt / headers to `logs/classifier-capture.jsonl` — handy for confirming the
-classifier is detected and rerouted. With `--debug-claudish`, a
+classifier is detected and rerouted. It captures the **full** system prompt (your CLAUDE.md
+and project rules included), so leave it off unless you are actively debugging detection. With `--debug-claudish`, a
 `[Classifier] … → native Anthropic` line is written when the passthrough fires.
 
 ---

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -26,6 +26,8 @@ All flags recognized by `parseArgs()` in `packages/cli/src/cli.ts`.
 | `--model-sonnet` | | string | none | Model for Sonnet role (default coding) |
 | `--model-haiku` | | string | none | Model for Haiku role (fast tasks, background) |
 | `--model-subagent` | | string | none | Model for sub-agents (Task tool) |
+| `--classifier-provider` | | string | none (off) | Set to `anthropic` to route Claude Code's auto-mode permission classifier to native Anthropic while the main loop runs on another provider. See [Classifier Passthrough](models/model-mapping.md#auto-mode-classifier-passthrough) |
+| `--classifier-model` | | string | `claude-sonnet-5` | Native Claude model the classifier request is rewritten onto. Setting it also enables classifier passthrough |
 | `--port` | | number | random (3000–9000) | Proxy server port |
 | `--auto-approve` | `-y` | boolean | false | Skip permission prompts (passes `--dangerously-skip-permissions` to Claude Code) |
 | `--no-auto-approve` | | boolean | | Explicitly enable permission prompts (overrides -y) |
@@ -111,6 +113,9 @@ Claudish automatically loads `.env` from the current working directory at startu
 | `CLAUDISH_MODEL_SONNET` | Override model for Sonnet role | none |
 | `CLAUDISH_MODEL_HAIKU` | Override model for Haiku role | none |
 | `CLAUDISH_MODEL_SUBAGENT` | Override model for sub-agents | none |
+| `CLAUDISH_CLASSIFIER_PROVIDER` | Set to `anthropic` to route the auto-mode permission classifier to native Anthropic (default off). See [Classifier Passthrough](models/model-mapping.md#auto-mode-classifier-passthrough) | none (off) |
+| `CLAUDISH_CLASSIFIER_MODEL` | Native Claude model the classifier request is rewritten onto; setting it also enables classifier passthrough | `claude-sonnet-5` |
+| `CLAUDISH_CLASSIFIER_DEBUG` | Set to `1` to append each incoming request's model/params/system/headers to `logs/classifier-capture.jsonl` for classifier-detection debugging | none (off) |
 | `CLAUDISH_SUMMARIZE_TOOLS` | Summarize tool descriptions (`true` or `1` to enable) | false |
 | `CLAUDISH_TELEMETRY` | Override telemetry (`0`, `false`, or `off` to disable) | from config |
 | `CLAUDISH_ACTIVE_MODEL_NAME` | (Internal) Set by Claudish to display model name in status line | auto |

--- a/packages/cli/src/classifier-passthrough.integration.test.ts
+++ b/packages/cli/src/classifier-passthrough.integration.test.ts
@@ -1,0 +1,154 @@
+// HTTP-level integration test for classifier passthrough. Drives the REAL proxy
+// server (Hono + @hono/node-server) over loopback and stubs the outbound `fetch`
+// so NativeHandler's call to api.anthropic.com is intercepted — no real network,
+// no credentials. Validates the routing short-circuit end to end: reroute to
+// native, model rewrite, `thinking` strip (Risk R1), and verbatim forwarding of
+// the system array (incl. the billing block) and the inbound OAuth header.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { createProxyServer } from "./proxy-server.js";
+
+const realFetch = globalThis.fetch.bind(globalThis);
+
+interface CapturedCall {
+  url: string;
+  headers: Record<string, string>;
+  body: Record<string, unknown>;
+}
+
+/** Replace global fetch: capture + canned-answer api.anthropic.com, neutralize everything else. */
+function stubFetch(): CapturedCall[] {
+  const calls: CapturedCall[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : (input as Request).url;
+    if (url.includes("api.anthropic.com")) {
+      const headers: Record<string, string> = {};
+      const h = (init?.headers ?? {}) as Record<string, string>;
+      for (const k of Object.keys(h)) headers[k.toLowerCase()] = h[k];
+      calls.push({ url, headers, body: JSON.parse(init?.body as string) });
+      return new Response(
+        JSON.stringify({
+          id: "msg_test",
+          type: "message",
+          role: "assistant",
+          model: "claude-sonnet-5",
+          content: [{ type: "text", text: "allow" }],
+          stop_reason: "end_turn",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } }
+      );
+    }
+    // Neutralize background warmers (pricing / recommended / catalog) and anything else.
+    return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+  return calls;
+}
+
+const CLASSIFIER_BODY = {
+  model: "claude-opus-4-8",
+  thinking: { type: "enabled", budget_tokens: 1024 },
+  temperature: 0,
+  max_tokens: 64,
+  system: [
+    { type: "text", text: "x-anthropic-billing-header: opaque-billing-token" },
+    {
+      type: "text",
+      text: "You are a security monitor for autonomous AI coding agents. Decide whether the tool call is safe.",
+    },
+  ],
+  messages: [{ role: "user", content: "classify this tool call" }],
+};
+
+describe("classifier passthrough (HTTP)", () => {
+  let proxy: Awaited<ReturnType<typeof createProxyServer>> | null = null;
+
+  afterEach(async () => {
+    globalThis.fetch = realFetch;
+    if (proxy) await proxy.shutdown();
+    proxy = null;
+  });
+
+  test("reroutes classifier → native: rewrites model, strips thinking, preserves system + OAuth", async () => {
+    const calls = stubFetch();
+    proxy = await createProxyServer(0, undefined, undefined, false, undefined, undefined, {
+      quiet: true,
+      classifier: { enabled: true, model: "claude-sonnet-5" },
+    });
+
+    const res = await realFetch(`${proxy.url}/v1/messages`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: "Bearer test-oauth-token",
+        "anthropic-beta": "claude-code-20250219,oauth-2025-04-20",
+        "anthropic-version": "2023-06-01",
+      },
+      body: JSON.stringify(CLASSIFIER_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(calls.length).toBe(1);
+    const fwd = calls[0];
+    expect(fwd.url).toContain("api.anthropic.com/v1/messages");
+    // Model rewritten to the configured classifier model.
+    expect(fwd.body.model).toBe("claude-sonnet-5");
+    // thinking stripped (Risk R1); other sampling params left intact.
+    expect(fwd.body.thinking).toBeUndefined();
+    expect(fwd.body.temperature).toBe(0);
+    // system array forwarded VERBATIM, including the x-anthropic-billing-header block.
+    expect(fwd.body.system).toEqual(CLASSIFIER_BODY.system);
+    // Inbound Claude Max OAuth + anthropic-beta forwarded to Anthropic.
+    expect(fwd.headers.authorization).toBe("Bearer test-oauth-token");
+    expect(fwd.headers["anthropic-beta"]).toContain("claude-code-20250219");
+  });
+
+  test("does NOT rewrite a non-classifier request (model + thinking preserved)", async () => {
+    const calls = stubFetch();
+    proxy = await createProxyServer(0, undefined, undefined, false, undefined, undefined, {
+      quiet: true,
+      classifier: { enabled: true, model: "claude-sonnet-5" },
+    });
+
+    const normalBody = {
+      model: "claude-opus-4-8",
+      thinking: { type: "enabled", budget_tokens: 1024 },
+      system: [{ type: "text", text: "You are Claude Code, Anthropic's official CLI for Claude." }],
+      messages: [{ role: "user", content: "hi" }],
+      max_tokens: 64,
+    };
+    const res = await realFetch(`${proxy.url}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer test-oauth-token" },
+      body: JSON.stringify(normalBody),
+    });
+
+    expect(res.status).toBe(200);
+    expect(calls.length).toBe(1); // claude-opus-4-8 is itself native → still hits Anthropic...
+    expect(calls[0].body.model).toBe("claude-opus-4-8"); // ...but NOT rewritten
+    expect(calls[0].body.thinking).toEqual(normalBody.thinking); // and thinking preserved
+  });
+
+  test("opt-in off: classifier-shaped request is NOT rewritten", async () => {
+    const calls = stubFetch();
+    proxy = await createProxyServer(0, undefined, undefined, false, undefined, undefined, {
+      quiet: true,
+      classifier: { enabled: false, model: "claude-sonnet-5" },
+    });
+
+    const res = await realFetch(`${proxy.url}/v1/messages`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: "Bearer test-oauth-token" },
+      body: JSON.stringify(CLASSIFIER_BODY),
+    });
+
+    expect(res.status).toBe(200);
+    expect(calls.length).toBe(1);
+    expect(calls[0].body.model).toBe("claude-opus-4-8"); // untouched — gate is off
+    expect(calls[0].body.thinking).toEqual(CLASSIFIER_BODY.thinking); // untouched
+  });
+});

--- a/packages/cli/src/classifier-passthrough.test.ts
+++ b/packages/cli/src/classifier-passthrough.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CLASSIFIER_SYSTEM_MARKER,
+  DEFAULT_CLASSIFIER_MODEL,
+  classifierPassthroughEnabled,
+  isAutoModeClassifierRequest,
+  resolveClassifierConfig,
+  rewriteClassifierForNative,
+} from "./classifier-passthrough.js";
+
+// The auto-mode classifier's system prompt is a full block that STARTS with the marker.
+const CLASSIFIER_SYSTEM_BLOCK = `${CLASSIFIER_SYSTEM_MARKER} Evaluate the following tool call and decide whether it is safe to run automatically.`;
+// The classifier request's system[0] is a separate billing-header block; the marker
+// block comes LATER — the real wire shape, which detection must scan past.
+const BILLING_BLOCK = "x-anthropic-billing-header: some-opaque-token-value-here";
+
+describe("isAutoModeClassifierRequest", () => {
+  test("matches system as a plain string", () => {
+    expect(isAutoModeClassifierRequest({ system: CLASSIFIER_SYSTEM_BLOCK })).toBe(true);
+  });
+
+  test("matches the marker in a LATER block (billing header is system[0]) — the real shape", () => {
+    const body = {
+      model: "claude-opus-4-8",
+      system: [
+        { type: "text", text: BILLING_BLOCK },
+        { type: "text", text: CLASSIFIER_SYSTEM_BLOCK },
+      ],
+    };
+    expect(isAutoModeClassifierRequest(body)).toBe(true);
+  });
+
+  test("matches even with leading whitespace before the marker", () => {
+    const body = { system: [{ type: "text", text: `\n  ${CLASSIFIER_SYSTEM_BLOCK}` }] };
+    expect(isAutoModeClassifierRequest(body)).toBe(true);
+  });
+
+  test("does NOT match the main Claude Code prompt", () => {
+    const body = {
+      model: "claude-opus-4-8",
+      system: [
+        { type: "text", text: BILLING_BLOCK },
+        { type: "text", text: "You are Claude Code, Anthropic's official CLI for Claude." },
+      ],
+    };
+    expect(isAutoModeClassifierRequest(body)).toBe(false);
+  });
+
+  test("does NOT match when the marker appears mid-text (not at the start of a block)", () => {
+    const body = { system: `Preamble. ${CLASSIFIER_SYSTEM_MARKER}` };
+    expect(isAutoModeClassifierRequest(body)).toBe(false);
+  });
+
+  test("returns false for empty / missing / malformed system", () => {
+    expect(isAutoModeClassifierRequest({})).toBe(false);
+    expect(isAutoModeClassifierRequest({ system: [] })).toBe(false);
+    expect(isAutoModeClassifierRequest({ system: [{ type: "image", source: {} }] })).toBe(false);
+    expect(isAutoModeClassifierRequest(null)).toBe(false);
+    expect(isAutoModeClassifierRequest("not an object")).toBe(false);
+    expect(isAutoModeClassifierRequest({ system: 42 })).toBe(false);
+  });
+});
+
+describe("rewriteClassifierForNative", () => {
+  test("forces the model and strips thinking, leaving other fields intact", () => {
+    const body: Record<string, unknown> = {
+      model: "claude-opus-4-8",
+      thinking: { type: "enabled", budget_tokens: 1024 },
+      temperature: 0,
+      system: [{ type: "text", text: CLASSIFIER_SYSTEM_BLOCK }],
+    };
+    rewriteClassifierForNative(body, "claude-sonnet-5");
+    expect(body.model).toBe("claude-sonnet-5");
+    expect(body.thinking).toBeUndefined();
+    expect(body.temperature).toBe(0);
+    expect(body.system).toBeDefined();
+  });
+
+  test("is a no-op on thinking when absent", () => {
+    const body: Record<string, unknown> = { model: "claude-opus-4-8" };
+    rewriteClassifierForNative(body, "claude-sonnet-5");
+    expect(body.model).toBe("claude-sonnet-5");
+    expect("thinking" in body).toBe(false);
+  });
+});
+
+describe("resolveClassifierConfig", () => {
+  const emptyEnv: NodeJS.ProcessEnv = {};
+
+  test("default OFF when nothing is set", () => {
+    const r = resolveClassifierConfig({}, emptyEnv);
+    expect(r.enabled).toBe(false);
+    expect(r.model).toBe(DEFAULT_CLASSIFIER_MODEL);
+  });
+
+  test("--classifier-provider anthropic enables with the default model", () => {
+    const r = resolveClassifierConfig({ classifierProvider: "anthropic" }, emptyEnv);
+    expect(r).toEqual({ enabled: true, model: DEFAULT_CLASSIFIER_MODEL });
+  });
+
+  test("--classifier-model enables and sets the model", () => {
+    const r = resolveClassifierConfig({ classifierModel: "claude-3-5-haiku" }, emptyEnv);
+    expect(r).toEqual({ enabled: true, model: "claude-3-5-haiku" });
+  });
+
+  test("CLAUDISH_CLASSIFIER_PROVIDER=anthropic enables via env", () => {
+    const r = resolveClassifierConfig({}, { CLAUDISH_CLASSIFIER_PROVIDER: "anthropic" });
+    expect(r).toEqual({ enabled: true, model: DEFAULT_CLASSIFIER_MODEL });
+  });
+
+  test("CLAUDISH_CLASSIFIER_MODEL enables via env and sets the model", () => {
+    const r = resolveClassifierConfig({}, { CLAUDISH_CLASSIFIER_MODEL: "claude-sonnet-5-env" });
+    expect(r).toEqual({ enabled: true, model: "claude-sonnet-5-env" });
+  });
+
+  test("flag model wins over env model", () => {
+    const r = resolveClassifierConfig(
+      { classifierModel: "flag-model" },
+      { CLAUDISH_CLASSIFIER_MODEL: "env-model", CLAUDISH_CLASSIFIER_PROVIDER: "anthropic" }
+    );
+    expect(r).toEqual({ enabled: true, model: "flag-model" });
+  });
+
+  test("a non-anthropic provider value does not enable on its own", () => {
+    const r = resolveClassifierConfig({ classifierProvider: "openai" }, emptyEnv);
+    expect(r.enabled).toBe(false);
+  });
+
+  test("provider matching is case-insensitive and whitespace-tolerant", () => {
+    expect(resolveClassifierConfig({ classifierProvider: "  Anthropic " }, emptyEnv).enabled).toBe(
+      true
+    );
+    expect(resolveClassifierConfig({}, { CLAUDISH_CLASSIFIER_PROVIDER: "ANTHROPIC" }).enabled).toBe(
+      true
+    );
+  });
+});
+
+describe("classifierPassthroughEnabled", () => {
+  test("mirrors resolveClassifierConfig().enabled", () => {
+    expect(classifierPassthroughEnabled({}, {})).toBe(false);
+    expect(classifierPassthroughEnabled({ classifierProvider: "anthropic" }, {})).toBe(true);
+    expect(classifierPassthroughEnabled({}, { CLAUDISH_CLASSIFIER_MODEL: "m" })).toBe(true);
+  });
+});

--- a/packages/cli/src/classifier-passthrough.ts
+++ b/packages/cli/src/classifier-passthrough.ts
@@ -1,0 +1,137 @@
+// Classifier passthrough — detect Claude Code's auto-mode permission classifier
+// request by CONTENT (a marker in its system prompt) and resolve the opt-in config
+// that reroutes it to native Anthropic while the main loop runs on another provider.
+//
+// This module is intentionally dependency-light (only a type import) and free of
+// cycles with cli.ts / proxy-server.ts, mirroring default-provider.ts, so it can be
+// unit-tested in isolation.
+
+import type { ClaudishConfig } from "./types.js";
+
+/**
+ * Anchor prefix of the auto-mode permission classifier's system prompt.
+ *
+ * Claude Code's auto-mode ("--permission-mode auto") sends a dedicated request whose
+ * `system` array contains a text block that starts with this sentence. The request's
+ * `system[0]` is a separate `x-anthropic-billing-header:` block, so detection must scan
+ * ALL system blocks (see isAutoModeClassifierRequest), not just the first.
+ *
+ * Pinned as a single constant so a Claude Code version bump is a one-line update.
+ * Verify verbatim from a `--debug-claudish` capture if the wording ever drifts.
+ */
+export const CLASSIFIER_SYSTEM_MARKER =
+  "You are a security monitor for autonomous AI coding agents.";
+
+/**
+ * Default native Claude model the classifier is rewritten onto when the passthrough is
+ * enabled without an explicit model. Must be a currently-valid Anthropic API model id.
+ * Sonnet is fast, cheap, and correct for the classifier.
+ */
+export const DEFAULT_CLASSIFIER_MODEL = "claude-sonnet-5";
+
+export interface ClassifierConfig {
+  /** Whether classifier passthrough is active for this session. */
+  enabled: boolean;
+  /** Native Claude model id the classifier request is rewritten onto. */
+  model: string;
+}
+
+type ClassifierConfigInput = Pick<ClaudishConfig, "classifierModel" | "classifierProvider">;
+
+/**
+ * Extract the text of a single Claude Messages `system` content block, or null if the
+ * block carries no usable text. Accepts a bare string element or a `{type:"text",text}`
+ * object; skips everything else. Never throws.
+ */
+function blockText(block: unknown): string | null {
+  if (typeof block === "string") return block;
+  if (
+    block &&
+    typeof block === "object" &&
+    (block as { type?: unknown }).type === "text" &&
+    typeof (block as { text?: unknown }).text === "string"
+  ) {
+    return (block as { text: string }).text;
+  }
+  return null;
+}
+
+/**
+ * Allocation-free test for "text, ignoring leading whitespace, starts with the marker".
+ * Avoids `trimStart()` — which copies the whole (often multi-KB) system block — on the
+ * per-request hot path.
+ */
+function startsWithMarker(text: string): boolean {
+  let i = 0;
+  while (i < text.length) {
+    const ch = text.charCodeAt(i);
+    // space, tab, LF, CR, form feed, vertical tab
+    if (ch !== 32 && ch !== 9 && ch !== 10 && ch !== 13 && ch !== 12 && ch !== 11) break;
+    i++;
+  }
+  return text.startsWith(CLASSIFIER_SYSTEM_MARKER, i);
+}
+
+/**
+ * True iff the request body looks like Claude Code's auto-mode permission classifier —
+ * i.e. ANY of its `system` text blocks (ignoring leading whitespace) starts with
+ * CLASSIFIER_SYSTEM_MARKER. Handles the string-vs-array `system` duality, short-circuits
+ * on the first match, and allocates nothing. Never throws.
+ */
+export function isAutoModeClassifierRequest(body: unknown): boolean {
+  if (!body || typeof body !== "object") return false;
+  const system = (body as { system?: unknown }).system;
+  if (typeof system === "string") return startsWithMarker(system);
+  if (!Array.isArray(system)) return false;
+  for (const block of system) {
+    const text = blockText(block);
+    if (text !== null && startsWithMarker(text)) return true;
+  }
+  return false;
+}
+
+/**
+ * Prepare a detected classifier request for the native Anthropic passthrough: force it
+ * onto `model` and strip fields a rewritten model is most likely to reject. The
+ * classifier is a fast, structured call, so `thinking` (extended-thinking config) is
+ * dropped — it's the most likely 400 trigger when the model is swapped (thinking +
+ * forced tool_choice / non-default temperature). Mutates `body` in place. Extend the
+ * strip list (temperature/top_p/top_k) if a captured payload / E2E surfaces a 400.
+ */
+export function rewriteClassifierForNative(body: Record<string, unknown>, model: string): void {
+  body.model = model;
+  delete body.thinking;
+}
+
+/**
+ * Resolve the classifier-passthrough opt-in. Enabled (default OFF) when any of:
+ *   - `--classifier-model <m>` flag (config.classifierModel)
+ *   - `--classifier-provider anthropic` flag (config.classifierProvider)
+ *   - `CLAUDISH_CLASSIFIER_PROVIDER=anthropic` env
+ *   - `CLAUDISH_CLASSIFIER_MODEL=<m>` env
+ * Model precedence when enabled: flag model → env model → DEFAULT_CLASSIFIER_MODEL.
+ */
+export function resolveClassifierConfig(
+  config: ClassifierConfigInput,
+  env: NodeJS.ProcessEnv = process.env
+): ClassifierConfig {
+  const flagModel = config.classifierModel?.trim();
+  const flagProvider = config.classifierProvider?.trim().toLowerCase();
+  const envProvider = env.CLAUDISH_CLASSIFIER_PROVIDER?.trim().toLowerCase();
+  const envModel = env.CLAUDISH_CLASSIFIER_MODEL?.trim();
+
+  const enabled =
+    !!flagModel || flagProvider === "anthropic" || envProvider === "anthropic" || !!envModel;
+
+  // When disabled, both flagModel and envModel are necessarily empty, so `model`
+  // resolves to the default — one return covers both cases.
+  return { enabled, model: flagModel || envModel || DEFAULT_CLASSIFIER_MODEL };
+}
+
+/** Convenience wrapper: whether classifier passthrough is enabled for this session. */
+export function classifierPassthroughEnabled(
+  config: ClassifierConfigInput,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  return resolveClassifierConfig(config, env).enabled;
+}

--- a/packages/cli/src/claude-runner.ts
+++ b/packages/cli/src/claude-runner.ts
@@ -117,10 +117,13 @@ export const defaultKeychainAnthropicProbe: KeychainCredentialProbe = () => {
  * A config read failure must never block launch, so it degrades to "not opted
  * in" — the safe direction, since that only ever avoids spending money.
  */
-function wantsAnthropicApiBilling(config: ClaudishConfig): boolean {
+function wantsAnthropicApiBilling(
+  config: ClaudishConfig,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
   if (config.anthropicApiBilling) return true;
 
-  const raw = process.env[ENV.CLAUDISH_ANTHROPIC_API_BILLING];
+  const raw = env[ENV.CLAUDISH_ANTHROPIC_API_BILLING];
   if (raw !== undefined && raw !== "" && raw !== "0" && raw.toLowerCase() !== "false") return true;
 
   try {
@@ -128,6 +131,32 @@ function wantsAnthropicApiBilling(config: ClaudishConfig): boolean {
   } catch {
     return false;
   }
+}
+
+/**
+ * Should an incidental real ANTHROPIC_API_KEY be hidden from the spawned Claude
+ * Code, so the session bills to the claude.ai subscription instead of the
+ * metered API?
+ *
+ * Gated on `hasNativeAnthropicMapping`, NOT on the wider
+ * `shouldPreserveNativeAuth`. The two differ for exactly one case: classifier
+ * passthrough enabled with no native role mapping. There, a real
+ * ANTHROPIC_API_KEY may be the user's ONLY Anthropic credential, so hiding it
+ * would strand the very request the passthrough exists to serve — the login
+ * gate `hasResolvableAnthropicAuth` was added to avoid. The exposure that buys
+ * is bounded: under classifier-only passthrough the main loop runs on a foreign
+ * provider, so the sole traffic that key can bill is the classifier call.
+ *
+ * Split out of runClaudeWithProxy purely so this rule is testable — that
+ * function spawns a process and cannot be exercised directly.
+ */
+export function shouldHideIncidentalAnthropicKey(
+  config: ClaudishConfig,
+  env: NodeJS.ProcessEnv = process.env
+): boolean {
+  if (!hasNativeAnthropicMapping(config)) return false;
+  if (!env.ANTHROPIC_API_KEY) return false;
+  return !wantsAnthropicApiBilling(config, env);
 }
 
 /**
@@ -1291,18 +1320,9 @@ export async function runClaudeWithProxy(
       // is what you want. ANTHROPIC_AUTH_TOKEN is left alone — nothing bundles
       // one incidentally, so setting it is always a deliberate act.
       //
-      // Gated on hasNativeAnthropicMapping, NOT on the whole preserve condition:
-      // when the ONLY reason we are here is classifier passthrough, a real
-      // ANTHROPIC_API_KEY may be the user's only Anthropic credential, and
-      // deleting it would strand the very request the passthrough exists to
-      // serve. The exposure is bounded — under classifier-only passthrough the
-      // main loop runs on a foreign provider, so the sole traffic that key can
-      // bill is the classifier call itself.
-      if (
-        hasNativeAnthropicMapping(config) &&
-        process.env.ANTHROPIC_API_KEY &&
-        !wantsAnthropicApiBilling(config)
-      ) {
+      // See shouldHideIncidentalAnthropicKey for why this is narrower than the
+      // shouldPreserveNativeAuth condition guarding this branch.
+      if (shouldHideIncidentalAnthropicKey(config)) {
         delete env.ANTHROPIC_API_KEY;
         hidAnthropicApiKey = true;
       }

--- a/packages/cli/src/claude-runner.ts
+++ b/packages/cli/src/claude-runner.ts
@@ -15,6 +15,7 @@ import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { isatty } from "node:tty";
 import { lookupModelForProvider } from "./adapters/model-catalog.js";
+import { classifierPassthroughEnabled } from "./classifier-passthrough.js";
 import { ENV } from "./config.js";
 // Aliased: runClaudeWithProxy declares its own local `log` (a quiet-aware
 // console printer), and an unaliased import would be shadowed inside it.
@@ -99,16 +100,46 @@ function wantsAnthropicApiBilling(config: ClaudishConfig): boolean {
 }
 
 /**
+ * Does the environment carry a resolvable Anthropic credential? Used to decide
+ * whether classifier passthrough can safely preserve Claude Code's real auth
+ * (skipping the placeholder key) without stranding Claude Code at a login gate.
+ * Checks env tokens and the presence of Claude Code's OAuth credentials file.
+ */
+function hasResolvableAnthropicAuth(): boolean {
+  if (process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN) return true;
+  return existsSync(join(homedir(), ".claude", ".credentials.json"));
+}
+
+/**
+ * Should claudish preserve Claude Code's REAL Anthropic auth — i.e. NOT set a
+ * placeholder key and NOT force console login, so NativeHandler can forward the
+ * user's Claude Max OAuth to api.anthropic.com?
+ *
+ * True for native-Anthropic model mappings (--model-sonnet claude-sonnet-5, etc.),
+ * AND for classifier passthrough when Anthropic credentials are actually
+ * resolvable — the latter guard prevents a pure-Codex user who enables the flag
+ * without any Anthropic creds from being stranded at the login gate (we keep the
+ * placeholder and warn instead; see runClaudeWithProxy).
+ */
+function shouldPreserveNativeAuth(config: ClaudishConfig): boolean {
+  return (
+    hasNativeAnthropicMapping(config) ||
+    (classifierPassthroughEnabled(config) && hasResolvableAnthropicAuth())
+  );
+}
+
+/**
  * "Proxy mode" = claudish points Claude Code at its local proxy with a placeholder
  * API key (see the auth block in runClaudeWithProxy). In this mode the session
  * authenticates via ANTHROPIC_API_KEY/ANTHROPIC_AUTH_TOKEN, so a user/project/local
  * setting of `forceLoginMethod: "claudeai"` would block it at startup.
  *
- * The inverse — native-Anthropic models or --monitor — uses the user's REAL claude.ai
- * subscription credentials, so we must NOT touch their login method there.
+ * The inverse — native-Anthropic models, classifier passthrough (with resolvable
+ * creds), or --monitor — uses the user's REAL claude.ai subscription credentials,
+ * so we must NOT touch their login method there.
  */
 export function isProxyAuthMode(config: ClaudishConfig): boolean {
-  return !config.monitor && !hasNativeAnthropicMapping(config);
+  return !config.monitor && !shouldPreserveNativeAuth(config);
 }
 
 /**
@@ -1198,8 +1229,9 @@ export async function runClaudeWithProxy(
       env[ENV.ANTHROPIC_MODEL] = modelId;
       env[ENV.ANTHROPIC_SMALL_FAST_MODEL] = modelId;
     }
-    if (hasNativeAnthropicMapping(config)) {
-      // Native Claude model detected — Claude Code talks to Anthropic directly,
+    if (shouldPreserveNativeAuth(config)) {
+      // Native Claude model, or classifier passthrough with resolvable Anthropic
+      // creds — Claude Code talks to Anthropic directly for those requests,
       // so its own claude.ai subscription login should serve the request.
       //
       // A real ANTHROPIC_API_KEY in the environment silently OVERRIDES that
@@ -1211,11 +1243,34 @@ export async function runClaudeWithProxy(
       // hide it by default and SAY so; opt back in explicitly when API billing
       // is what you want. ANTHROPIC_AUTH_TOKEN is left alone — nothing bundles
       // one incidentally, so setting it is always a deliberate act.
-      if (process.env.ANTHROPIC_API_KEY && !wantsAnthropicApiBilling(config)) {
+      //
+      // Gated on hasNativeAnthropicMapping, NOT on the whole preserve condition:
+      // when the ONLY reason we are here is classifier passthrough, a real
+      // ANTHROPIC_API_KEY may be the user's only Anthropic credential, and
+      // deleting it would strand the very request the passthrough exists to
+      // serve. The exposure is bounded — under classifier-only passthrough the
+      // main loop runs on a foreign provider, so the sole traffic that key can
+      // bill is the classifier call itself.
+      if (
+        hasNativeAnthropicMapping(config) &&
+        process.env.ANTHROPIC_API_KEY &&
+        !wantsAnthropicApiBilling(config)
+      ) {
         delete env.ANTHROPIC_API_KEY;
         hidAnthropicApiKey = true;
       }
     } else {
+      if (classifierPassthroughEnabled(config)) {
+        // Classifier passthrough is enabled but no role maps to a native Claude
+        // model AND no Anthropic credentials are resolvable → the rerouted
+        // classifier request would 401 at api.anthropic.com. Keep the placeholder
+        // so the MAIN loop still works, and warn instead of bricking the session.
+        console.error(
+          "[claudish] classifier passthrough enabled but no Anthropic credentials detected — " +
+            "classifier requests will fail to authenticate against api.anthropic.com. " +
+            "Map a role to a native Claude model (e.g. --model-sonnet claude-sonnet-5) or set ANTHROPIC_API_KEY."
+        );
+      }
       // Pure proxy mode: EVERY model goes through a claudish provider, so the
       // session never makes a real Anthropic call and a real Anthropic key here
       // is dead weight. Forwarding one is actively harmful: Claude Code then

--- a/packages/cli/src/claude-runner.ts
+++ b/packages/cli/src/claude-runner.ts
@@ -1,5 +1,5 @@
 import type { ChildProcess } from "node:child_process";
-import { spawn } from "node:child_process";
+import { spawn, spawnSync } from "node:child_process";
 import {
   closeSync,
   existsSync,
@@ -73,6 +73,37 @@ function hasNativeAnthropicMapping(config: ClaudishConfig): boolean {
   return models.some((m) => m && parseModelSpec(m).provider === "native-anthropic");
 }
 
+/** Existence-only probe for an OS-credential-store Anthropic OAuth item. */
+export type KeychainCredentialProbe = () => boolean;
+
+// Startup-only memo (see hasResolvableAnthropicAuth call graph — at most a couple of
+// evaluations per launch). Tests inject their own probe, so this stays inert there.
+let macosKeychainAnthropicResult: boolean | undefined;
+
+/**
+ * Existence-only probe for Claude Code's macOS login-Keychain OAuth item (service
+ * "Claude Code-credentials"). Returns true iff the item is present. Uses
+ * `security find-generic-password` WITHOUT `-w`, so it never requests the secret,
+ * needs no Keychain-access prompt, and never touches the token — Claude Code itself
+ * still forwards the OAuth once claudish skips the placeholder key. Non-darwin → false
+ * (returns before spawning). Best-effort: any error (security absent, non-zero exit,
+ * item missing) → false.
+ */
+export const defaultKeychainAnthropicProbe: KeychainCredentialProbe = () => {
+  if (process.platform !== "darwin") return false;
+  if (macosKeychainAnthropicResult !== undefined) return macosKeychainAnthropicResult;
+  try {
+    // Existence only — NO `-w`, so no secret is requested and no Keychain prompt appears.
+    const res = spawnSync("security", ["find-generic-password", "-s", "Claude Code-credentials"], {
+      stdio: "ignore",
+    });
+    macosKeychainAnthropicResult = !res.error && res.status === 0;
+  } catch {
+    macosKeychainAnthropicResult = false;
+  }
+  return macosKeychainAnthropicResult;
+};
+
 /**
  * Does the user explicitly want their real ANTHROPIC_API_KEY used, accepting
  * metered API billing instead of their claude.ai subscription?
@@ -103,11 +134,27 @@ function wantsAnthropicApiBilling(config: ClaudishConfig): boolean {
  * Does the environment carry a resolvable Anthropic credential? Used to decide
  * whether classifier passthrough can safely preserve Claude Code's real auth
  * (skipping the placeholder key) without stranding Claude Code at a login gate.
- * Checks env tokens and the presence of Claude Code's OAuth credentials file.
+ * Checks, in order: env tokens (ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN), Claude
+ * Code's OAuth credentials file (~/.claude/.credentials.json), and — on macOS — the
+ * login Keychain item Claude Code stores its OAuth in ("Claude Code-credentials",
+ * existence-only; the secret is never read). Deps are injectable for hermetic tests.
+ *
+ * TODO: Windows/Linux may also keep the OAuth in an OS credential store (Credential
+ * Manager / libsecret) rather than the file; only the macOS Keychain is covered so far.
  */
-function hasResolvableAnthropicAuth(): boolean {
-  if (process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN) return true;
-  return existsSync(join(homedir(), ".claude", ".credentials.json"));
+export function hasResolvableAnthropicAuth(
+  deps: {
+    env?: NodeJS.ProcessEnv;
+    fileExists?: (path: string) => boolean;
+    keychainProbe?: KeychainCredentialProbe;
+  } = {}
+): boolean {
+  const env = deps.env ?? process.env;
+  const fileExists = deps.fileExists ?? existsSync;
+  const keychainProbe = deps.keychainProbe ?? defaultKeychainAnthropicProbe;
+  if (env.ANTHROPIC_API_KEY || env.ANTHROPIC_AUTH_TOKEN) return true;
+  if (fileExists(join(homedir(), ".claude", ".credentials.json"))) return true;
+  return keychainProbe();
 }
 
 /**

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -391,6 +391,24 @@ export async function parseArgs(args: string[]): Promise<ClaudishConfig> {
       config.defaultProvider = dpArg;
     } else if (arg === "--anthropic-api-billing") {
       config.anthropicApiBilling = true;
+    } else if (arg === "--classifier-model") {
+      // Opt-in: reroute Claude Code's auto-mode permission classifier to this
+      // native Claude model on api.anthropic.com. Setting it also enables the
+      // passthrough. Matched here (before the catch-all below) so it isn't
+      // forwarded to Claude Code as a passthrough arg.
+      const cmArg = args[++i];
+      if (!cmArg) {
+        console.error("--classifier-model requires a model id");
+        process.exit(1);
+      }
+      config.classifierModel = cmArg;
+    } else if (arg === "--classifier-provider") {
+      const cpArg = args[++i];
+      if (!cpArg) {
+        console.error("--classifier-provider requires a provider name (e.g. anthropic)");
+        process.exit(1);
+      }
+      config.classifierProvider = cpArg;
     } else if (arg === "--op-env" || arg.startsWith("--op-env=")) {
       // The actual 1Password Environment read happens early in index.ts
       // (highest priority). Here we only consume the flag + its value so it

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -58,6 +58,9 @@ export const ENV = {
   // Opt IN to using a real ANTHROPIC_API_KEY for native Claude models (metered
   // API billing) instead of the claude.ai subscription. Off by default.
   CLAUDISH_ANTHROPIC_API_BILLING: "CLAUDISH_ANTHROPIC_API_BILLING",
+  // Classifier passthrough (auto-mode permission classifier → native Anthropic)
+  CLAUDISH_CLASSIFIER_PROVIDER: "CLAUDISH_CLASSIFIER_PROVIDER", // "anthropic" enables classifier passthrough
+  CLAUDISH_CLASSIFIER_MODEL: "CLAUDISH_CLASSIFIER_MODEL", // native Claude model to rewrite the classifier onto (also enables)
 } as const;
 
 // OpenRouter API Configuration

--- a/packages/cli/src/force-login-method.test.ts
+++ b/packages/cli/src/force-login-method.test.ts
@@ -14,6 +14,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildClaudishSettingsOverlay,
+  hasResolvableAnthropicAuth,
   isProxyAuthMode,
   managedSettingsForcesClaudeAi,
 } from "./claude-runner.js";
@@ -102,5 +103,66 @@ describe("managedSettingsForcesClaudeAi", () => {
   test("garbage JSON → false", () => {
     const readFile = (() => "{ not json") as never;
     expect(managedSettingsForcesClaudeAi(readFile)).toBe(false);
+  });
+});
+
+describe("hasResolvableAnthropicAuth", () => {
+  // Inject all deps so tests are hermetic: never read the real process.env / filesystem,
+  // never mutate process.platform, and never spawn `security`.
+  const noEnv: NodeJS.ProcessEnv = {};
+  const noFile = () => false;
+  const noKeychain = () => false;
+
+  test("ANTHROPIC_API_KEY env → true", () => {
+    expect(
+      hasResolvableAnthropicAuth({
+        env: { ANTHROPIC_API_KEY: "sk-test" },
+        fileExists: noFile,
+        keychainProbe: noKeychain,
+      })
+    ).toBe(true);
+  });
+
+  test("ANTHROPIC_AUTH_TOKEN env → true", () => {
+    expect(
+      hasResolvableAnthropicAuth({
+        env: { ANTHROPIC_AUTH_TOKEN: "tok-test" },
+        fileExists: noFile,
+        keychainProbe: noKeychain,
+      })
+    ).toBe(true);
+  });
+
+  test("credentials file present → true (no env, no keychain)", () => {
+    expect(
+      hasResolvableAnthropicAuth({ env: noEnv, fileExists: () => true, keychainProbe: noKeychain })
+    ).toBe(true);
+  });
+
+  test("macOS Keychain item present → true (no env, no file)", () => {
+    expect(
+      hasResolvableAnthropicAuth({ env: noEnv, fileExists: noFile, keychainProbe: () => true })
+    ).toBe(true);
+  });
+
+  test("Keychain absent + no env + no file → false", () => {
+    expect(
+      hasResolvableAnthropicAuth({ env: noEnv, fileExists: noFile, keychainProbe: noKeychain })
+    ).toBe(false);
+  });
+
+  test("non-darwin (probe returns false) still resolves via env/file", () => {
+    // Off-darwin, defaultKeychainAnthropicProbe returns false; the env/file checks
+    // remain the only sources. All-absent → false; env present → still true.
+    expect(
+      hasResolvableAnthropicAuth({ env: noEnv, fileExists: noFile, keychainProbe: () => false })
+    ).toBe(false);
+    expect(
+      hasResolvableAnthropicAuth({
+        env: { ANTHROPIC_API_KEY: "sk-test" },
+        fileExists: noFile,
+        keychainProbe: () => false,
+      })
+    ).toBe(true);
   });
 });

--- a/packages/cli/src/force-login-method.test.ts
+++ b/packages/cli/src/force-login-method.test.ts
@@ -11,13 +11,19 @@
  * cannot be overridden and is caught with a fail-fast abort instead.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   buildClaudishSettingsOverlay,
   hasResolvableAnthropicAuth,
   isProxyAuthMode,
   managedSettingsForcesClaudeAi,
+  shouldHideIncidentalAnthropicKey,
 } from "./claude-runner.js";
+import { setConfigFileOverride } from "./profile-config.js";
 import type { ClaudishConfig } from "./types.js";
 
 const baseConfig = (overrides: Partial<ClaudishConfig> = {}): ClaudishConfig =>
@@ -164,5 +170,59 @@ describe("hasResolvableAnthropicAuth", () => {
         keychainProbe: () => false,
       })
     ).toBe(true);
+  });
+});
+
+describe("shouldHideIncidentalAnthropicKey", () => {
+  const apiKeyEnv: NodeJS.ProcessEnv = { ANTHROPIC_API_KEY: "sk-test" };
+  const noEnv: NodeJS.ProcessEnv = {};
+  const configPath = join(tmpdir(), `claudish-force-login-method-${randomUUID()}.json`);
+
+  beforeAll(() => {
+    writeFileSync(configPath, "{}", "utf8");
+    setConfigFileOverride(configPath);
+  });
+
+  afterAll(() => {
+    setConfigFileOverride(null);
+    rmSync(configPath, { force: true });
+  });
+
+  test("native mapping + API key + default billing → true", () => {
+    expect(
+      shouldHideIncidentalAnthropicKey(baseConfig({ model: "claude-opus-4-6" }), apiKeyEnv)
+    ).toBe(true);
+  });
+
+  test("native mapping + API key + API billing opt-in → false", () => {
+    expect(
+      shouldHideIncidentalAnthropicKey(
+        baseConfig({ model: "claude-opus-4-6", anthropicApiBilling: true }),
+        apiKeyEnv
+      )
+    ).toBe(false);
+  });
+
+  test("native mapping + no API key → false", () => {
+    expect(shouldHideIncidentalAnthropicKey(baseConfig({ model: "claude-opus-4-6" }), noEnv)).toBe(
+      false
+    );
+  });
+
+  test("classifier-only passthrough + API key → false", () => {
+    // Under classifier-only passthrough, the key may be the user's only Anthropic
+    // credential; hiding it would strand the classifier request at a login gate.
+    expect(
+      shouldHideIncidentalAnthropicKey(
+        baseConfig({ model: "x-ai/grok-code-fast-1", classifierProvider: "anthropic" }),
+        apiKeyEnv
+      )
+    ).toBe(false);
+  });
+
+  test("no native mapping or classifier config + API key → false", () => {
+    expect(
+      shouldHideIncidentalAnthropicKey(baseConfig({ model: "x-ai/grok-code-fast-1" }), apiKeyEnv)
+    ).toBe(false);
   });
 });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ config({ quiet: true }); // Loads .env from current working directory
 import { existsSync, readFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { resolveExplicitFlagAuth } from "./auth/credentials/op-source.js";
+import { resolveClassifierConfig } from "./classifier-passthrough.js";
 import {
   beginSpan,
   finalizeStartupTrace,
@@ -921,6 +922,7 @@ async function runCli() {
           // Present only when `--model` was a pinned chain; `explicitModel` above
           // is its first element, so the proxy can match the two.
           modelChain: cliConfig.monitor ? undefined : cliConfig.modelChain,
+          classifier: resolveClassifierConfig(cliConfig, process.env),
         }
       )
     );

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -1,10 +1,16 @@
-import { Hono } from "hono";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
 import { LocalModelAdapter } from "./adapters/local-adapter.js";
 import { OpenRouterAPIFormat } from "./adapters/openrouter-api-format.js";
 import { credentials } from "./auth/credentials/authority.js";
 import { loadHookRules } from "./behavior/hooks.js";
 import { parseBehaviorConfig, registerHookRules } from "./behavior/index.js";
+import {
+  isAutoModeClassifierRequest,
+  rewriteClassifierForNative,
+} from "./classifier-passthrough.js";
 import { ComposedHandler, type ComposedHandlerOptions } from "./handlers/composed-handler.js";
 import { FallbackHandler } from "./handlers/fallback-handler.js";
 import type { FallbackCandidate } from "./handlers/fallback-handler.js";
@@ -100,6 +106,59 @@ export interface ProxyServerOptions {
    * matched before catalog resolution.
    */
   modelChain?: string[];
+  /**
+   * Classifier passthrough (opt-in). When `enabled`, Claude Code's auto-mode
+   * permission classifier request (detected by content) is rewritten onto
+   * `model` and forwarded via the native Anthropic handler (OAuth passthrough),
+   * bypassing role-based routing — so the main loop can run on another provider
+   * while the safety classifier still runs on a real Claude model. Undefined /
+   * disabled by default. See classifier-passthrough.ts.
+   */
+  classifier?: { enabled: boolean; model: string };
+}
+
+/**
+ * Ground-truth capture for classifier passthrough. No-op unless the
+ * `CLAUDISH_CLASSIFIER_DEBUG` env flag is set. When active, appends the raw
+ * model / sampling params / `system` array / relevant headers of an incoming
+ * request to a dedicated `logs/classifier-capture.jsonl` file so the auto-mode
+ * permission classifier's system marker (and its payload shape) can be verified
+ * or discovered. Writes to a purpose-built file — NOT the redacted always-on
+ * log — so it never pollutes structural logging. Best-effort; never throws.
+ */
+let classifierCaptureDirReady = false;
+function maybeCaptureClassifierRequest(c: Context, body: any): void {
+  if (!process.env.CLAUDISH_CLASSIFIER_DEBUG) return;
+  try {
+    const dir = join(process.cwd(), "logs");
+    if (!classifierCaptureDirReady) {
+      mkdirSync(dir, { recursive: true });
+      classifierCaptureDirReady = true;
+    }
+    const record = {
+      ts: new Date().toISOString(),
+      model: body?.model,
+      stream: body?.stream,
+      max_tokens: body?.max_tokens,
+      temperature: body?.temperature,
+      top_p: body?.top_p,
+      top_k: body?.top_k,
+      thinking: body?.thinking,
+      hasTools: Array.isArray(body?.tools) && body.tools.length > 0,
+      tool_choice: body?.tool_choice,
+      system: body?.system,
+      headers: {
+        "anthropic-beta": c.req.header("anthropic-beta") ?? null,
+        "anthropic-version": c.req.header("anthropic-version") ?? null,
+        "x-app": c.req.header("x-app") ?? null,
+        authorization: c.req.header("authorization") ? "Bearer <present>" : null,
+        "x-api-key": c.req.header("x-api-key") ? "<present>" : null,
+      },
+    };
+    appendFileSync(join(dir, "classifier-capture.jsonl"), `${JSON.stringify(record)}\n`);
+  } catch {
+    // Diagnostic capture is best-effort — never break the request path.
+  }
 }
 
 export async function createProxyServer(
@@ -930,6 +989,30 @@ export async function createProxyServer(
       log(
         `[RequestMeta] model=${body.model} output_config=${JSON.stringify(body.output_config) ?? "(none)"} metadata=${JSON.stringify(body.metadata) ?? "(none)"} anthropic-beta=${c.req.header("anthropic-beta") ?? "(none)"}`
       );
+
+      // Ground-truth capture (no-op unless CLAUDISH_CLASSIFIER_DEBUG). Runs
+      // before detection so a drifted marker can still be discovered.
+      maybeCaptureClassifierRequest(c, body);
+
+      // Classifier passthrough (opt-in, default off): Claude Code's auto-mode
+      // permission classifier is identified by CONTENT (a marker in its system
+      // prompt), not model name. When enabled, reroute it to a native Claude
+      // model on api.anthropic.com via nativeHandler (which forwards the inbound
+      // Claude Max OAuth and the system array — incl. the x-anthropic-billing-header
+      // block — verbatim), bypassing role-based routing. This lets the main loop
+      // run on another provider (e.g. Codex) while the safety classifier still
+      // runs on a real Claude model. Skipped in monitor mode (everything is
+      // already native there). See classifier-passthrough.ts.
+      if (!monitorMode && options.classifier?.enabled && isAutoModeClassifierRequest(body)) {
+        log(
+          `[Classifier] auto-mode permission classifier → native Anthropic (model ${body.model} → ${options.classifier.model})`
+        );
+        // Rewrite onto the native Claude model + strip 400-prone fields (see
+        // classifier-passthrough.ts). Log first — it reads the original body.model.
+        rewriteClassifierForNative(body, options.classifier.model);
+        return nativeHandler.handle(c, body);
+      }
+
       const handler = await getHandlerForRequest(body.model);
 
       // Route. The `await` is load-bearing: `return handler.handle(...)` hands

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -76,6 +76,12 @@ export interface ClaudishConfig {
   modelHaiku?: string;
   modelSubagent?: string;
 
+  // Classifier passthrough (auto-mode permission check → native Claude).
+  // Opt-in: reroutes Claude Code's auto-mode permission classifier request to
+  // api.anthropic.com (native OAuth) even when the main loop runs on another provider.
+  classifierModel?: string; // --classifier-model <m> (also enables the passthrough)
+  classifierProvider?: string; // --classifier-provider anthropic (enables the passthrough)
+
   // Cost tracking
   costTracking?: boolean;
   auditCosts?: boolean;


### PR DESCRIPTION
## Summary

Adds an opt-in **classifier passthrough** so Claude Code's auto-mode permission classifier keeps working when the main loop runs on a non-Claude provider.

**Problem:** In `--permission-mode auto`, Claude Code sends a dedicated **permission-classifier** request (Anthropic's "security monitor"). It arrives with the *session* model name (e.g. `claude-opus-4-8`), so claudish routes it by role to whatever that tier maps to. In a hybrid setup like `--model-opus cx@gpt-5.6-sol`, that sends the classifier to **Codex/GPT/Gemini**, which can't act as Anthropic's safety classifier — it over-blocks or times out with *"safety classifier temporarily unavailable"*, and even harmless commands get denied.

**Fix:** Detect the classifier request by **content** (a marker in its `system` prompt) and reroute **only that request** to native Anthropic (`claude-sonnet-5` by default, via the existing `NativeHandler` + the user's Claude Max OAuth), bypassing role-based routing. Every other request follows normal routing, so the main loop stays on its mapped provider.

## Usage (opt-in, default off)

```bash
claudish \
  --model-opus cx@gpt-5.6-sol \
  --model-sonnet claude-sonnet-5 \
  --classifier-provider anthropic \
  -- --permission-mode auto -p 'refactor the auth module'
```

Enable via `--classifier-provider anthropic` / `--classifier-model <id>`, or `CLAUDISH_CLASSIFIER_PROVIDER=anthropic` / `CLAUDISH_CLASSIFIER_MODEL=<id>`. Default classifier model: `claude-sonnet-5`.

## How it works

- **Detection** (`classifier-passthrough.ts`): `isAutoModeClassifierRequest(body)` scans **all** `system` text blocks (the classifier's `system[0]` is the `x-anthropic-billing-header:` block; the marker is a later block), allocation-free, handling the string-vs-array `system` duality.
- **Reroute** (`proxy-server.ts`, `POST /v1/messages`): short-circuit *before* role routing → `rewriteClassifierForNative(body, model)` (force model + strip `thinking`) → `nativeHandler.handle(c, body)`. `NativeHandler` forwards the `system` array (incl. the billing block), the inbound OAuth `Authorization`, and `anthropic-beta` **verbatim** — no adapter change needed.
- **Auth** (`claude-runner.ts`): `shouldPreserveNativeAuth()` preserves the user's real Anthropic auth for the passthrough **only when resolvable creds exist** (native role mapping, `ANTHROPIC_API_KEY`, or `~/.claude/.credentials.json`); otherwise it keeps the main loop working and prints a warning instead of stranding the session at a login gate.

## Testing

- **Unit** (`classifier-passthrough.test.ts`) — detection (string / multi-block real shape / negatives), config precedence, payload rewrite.
- **HTTP integration** (`classifier-passthrough.integration.test.ts`) — drives the real proxy with a stubbed `fetch`: asserts reroute → native, model rewrite, `thinking` strip, and verbatim `system`/OAuth forwarding, plus negative/off cases.
- **Live E2E** (confirmed): main loop on `cx@gpt-5.6-sol`, classifier rerouted `claude-opus-4-8 → claude-sonnet-5` on `api.anthropic.com` (200), harmless write allowed, no "temporarily unavailable". `CLAUDISH_CLASSIFIER_DEBUG=1` dumps raw requests to `logs/classifier-capture.jsonl` for verification.

## Notes

- `count_tokens` is intentionally **not** hooked — its native branch authenticates with the construction-time key (not inbound OAuth); left alone, a classifier `count_tokens` routes by model and returns a harmless estimate.
- **Consent-model nuance:** Claude Code's classifier treats a command the user *explicitly names* in the prompt (e.g. literally asking it to run `curl … | bash`) as informed consent and allows it — visible blocks are for agent-initiated or hard-blocked actions. Documented in `CHANGES.md` and `docs/models/model-mapping.md`.
- Docs updated: `README.md`, `docs/models/model-mapping.md`, `docs/advanced/environment.md`, `docs/settings-reference.md`.
- `CHANGES.md` is a self-contained patch summary for reintegration — happy to fold it into `CHANGELOG.md` or drop it if you'd prefer.
- No version bump (left to maintainers' release flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
