### PR TITLE
fix: add missing cancel() handler to Responses SSE parser

### DIFF
--- a/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.test.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.test.ts
@@ -105,3 +105,60 @@ describe("OpenAI Responses SSE context overflow", () => {
     expect(text).not.toContain("NaN");
   });
 });
+
+test("stops keep-alive pings when the downstream reader is cancelled", async () => {
+  const capturedErrors: unknown[] = [];
+  const captureError = (error: unknown) => {
+    capturedErrors.push(error);
+  };
+  let upstreamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  let downstreamReader: ReadableStreamDefaultReader<Uint8Array> | undefined;
+
+  process.on("uncaughtException", captureError);
+  process.on("unhandledRejection", captureError);
+
+  try {
+    const upstreamResponse = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          upstreamController = controller;
+        },
+      }),
+      {
+        headers: { "content-type": "text/event-stream" },
+      }
+    );
+    const parsedResponse = createResponsesStreamHandler(
+      createMockContext(),
+      upstreamResponse,
+      {
+        modelName: "gpt-5.6-sol",
+      }
+    );
+
+    if (!parsedResponse.body) {
+      throw new Error("Expected the parsed response to have a body");
+    }
+    downstreamReader = parsedResponse.body.getReader();
+
+    const firstChunk = await downstreamReader.read();
+    expect(firstChunk.done).toBe(false);
+    expect(firstChunk.value).toBeInstanceOf(Uint8Array);
+
+    await downstreamReader.cancel();
+    await new Promise((resolve) => setTimeout(resolve, 2250));
+
+    const invalidStateErrors = capturedErrors.filter((error) =>
+      /Invalid state|already closed/i.test(error instanceof Error ? error.message : String(error))
+    );
+    expect(invalidStateErrors).toEqual([]);
+  } finally {
+    await downstreamReader?.cancel().catch(() => {});
+    try {
+      upstreamController?.close();
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    process.off("uncaughtException", captureError);
+    process.off("unhandledRejection", captureError);
+  }
+}, 10000);

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
@@ -444,6 +444,21 @@ export function createResponsesStreamHandler(
         }
       }
     },
+    // Downstream went away (client disconnect, abort, or timeout). The
+    // controller is already closed here, but none of the normal close paths
+    // above ran — so without this, `isClosed` stays false and the keep-alive
+    // `pingInterval` keeps calling `send()` → `controller.enqueue()` on a
+    // closed controller. That throws `Invalid state: Controller is already
+    // closed` from inside a timer callback, where nothing catches it, and the
+    // proxy process dies (the next request then fails with ConnectionRefused).
+    // Every sibling parser already has this handler; this one was missing it.
+    cancel() {
+      isClosed = true;
+      if (pingInterval) {
+        clearInterval(pingInterval);
+        pingInterval = null;
+      }
+    },
   });
 
   return new Response(stream, {


### PR DESCRIPTION
## The bug

The Responses parser — the `cx@` / Codex / `gpt-5.x` path — was the **only** stream parser with a keep-alive `setInterval` and no `cancel()` handler:

| parser | `cancel()` |
|---|---|
| `anthropic-sse.ts` | `:300` |
| `gemini-sse.ts` | `:291` |
| `ollama-jsonl.ts` | `:157` |
| `openai-sse.ts` | `:685` |
| `openai-responses-sse.ts` | **missing** |

`isClosed` was set only on the parser's own close paths (354/402/439). When the *downstream* cancels — client disconnect, abort, or timeout — the controller closes without any of those running, so `isClosed` stayed `false`. The 1-second ping timer then kept calling `send()` → `controller.enqueue()` on a closed controller:

```
TypeError: Invalid state: Controller is already closed
    at send        (openai-responses-sse.ts:95)
    at <anonymous> (openai-responses-sse.ts:135)
```

Thrown from inside a timer callback, where nothing catches it — so the **proxy process dies**. The *next* request then fails with `ConnectionRefused`, which reads as a network fault rather than a crash. That indirection is what made this hard to spot.

## Why the Codex path specifically

A reasoning model with a large prompt has a long gap before first token, so the ping fires repeatedly in exactly the window where a client-side abort is likely. Reproduced twice in one session with a ~2,500-line payload; the same session's GLM and Kimi runs were unaffected because their parsers already have the handler.

## The fix

```js
cancel() {
  isClosed = true;
  if (pingInterval) { clearInterval(pingInterval); pingInterval = null; }
},
```

Mirrors the four sibling parsers, using this file's own null-setting idiom.

## Verification

Test authored via Codex CLI and **mutation-checked** — with `cancel()` removed it fails with the exact stack trace above; restored, it passes:

- `openai-responses-sse.test.ts` — **3 pass** (2 pre-existing + 1 new)
- `format-translation.test.ts` — **65 pass**, the full SSE replay harness

Purely additive: +15 source, +57 test.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)