### PR TITLE
ci: run typecheck, lint and the hermetic test suite on every PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,63 @@
+name: Tests
+
+# The hermetic test gate.
+#
+# WHY THIS EXISTS: until now no workflow ran `bun test` at all. The green check
+# on a PR came from the review bot, so a merge could publish to npm with the
+# suite never having run. A regex that silently deleted Gemini answers shipped
+# for seven months and five releases behind exactly that gap.
+#
+# WHY NO API KEY SECRETS ARE SET HERE — this is load-bearing, not an oversight.
+# Real-API tests gate on `test-helpers/credential-gate.ts`, which asks
+# claudish's OWN CredentialAuthority whether a provider can be served (env →
+# config `apiKeys` → 1Password). With no credentials present that answer is
+# `false` everywhere, so every live test skips itself and what remains is
+# exactly the deterministic tier: adapters, stream parsers, routing, fixtures.
+# Measured locally in a credential-free environment: 1855 pass / 25 skip /
+# 0 fail in ~56s, versus ~235s and real billing when keys ARE present.
+#
+# Adding a key secret here would silently convert this gate into the flaky,
+# billable live suite. Live coverage belongs in smoke-test.yml, which is
+# manually dispatched and holds the secrets on purpose.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A superseded push should not keep burning a runner.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: typecheck · lint · hermetic tests
+    runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # Root install — `workspaces: ["packages/*"]`, so this covers cli AND
+      # macos-bridge. The root scripts below span both packages; running
+      # `--cwd packages/cli` instead would silently drop macos-bridge.
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      # Fails on ERRORS only. The suite currently carries ~797 warnings
+      # (noExplicitAny, noExcessiveCognitiveComplexity) which are pre-existing
+      # style debt, not defects — biome exits 0 for those, so this gate catches
+      # genuine regressions without demanding a 300-file cleanup first.
+      - name: Lint
+        run: bun run lint
+
+      - name: Hermetic tests
+        run: bun run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,15 +48,20 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      # PINNED, not `latest`. Measured on run 31174096977: a newer bun's
+      # `bun install` REWRITES packages/cli/package.json (expanding the `files`
+      # array), which biome then fails as a format error — a red gate caused by
+      # an upstream release rather than by the code under test. `latest` also
+      # means a bun release can break CI overnight with no commit to blame.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.10"
 
       # Root install — `workspaces: ["packages/*"]`, so this covers cli AND
       # macos-bridge. The root scripts below span both packages; running
       # `--cwd packages/cli` instead would silently drop macos-bridge.
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Typecheck
         run: bun run typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,20 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: DEBUG - what did install change?
+        run: |
+          echo "--- git status after install ---"
+          git status --short
+          echo "--- git diff (package.json only) ---"
+          git diff -- packages/cli/package.json | head -30
+          echo "--- files array as it sits on disk ---"
+          grep -n -A 7 '"files"' packages/cli/package.json | head -9
+          echo "--- biome version ---"
+          bunx biome --version
+          echo "--- what biome checks, count by dir ---"
+          bunx --cwd packages/cli biome check . --reporter=json 2>/dev/null \
+            | bun -e 'let s="";for await(const c of console)s+=c;const d=JSON.parse(s).diagnostics??[];const f=new Set(d.map(x=>x.location?.path?.file));console.log("files with diagnostics:",f.size)' || true
+
       - name: Typecheck
         run: bun run typecheck
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,20 +63,6 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: DEBUG - what did install change?
-        run: |
-          echo "--- git status after install ---"
-          git status --short
-          echo "--- git diff (package.json only) ---"
-          git diff -- packages/cli/package.json | head -30
-          echo "--- files array as it sits on disk ---"
-          grep -n -A 7 '"files"' packages/cli/package.json | head -9
-          echo "--- biome version ---"
-          bunx biome --version
-          echo "--- what biome checks, count by dir ---"
-          bunx --cwd packages/cli biome check . --reporter=json 2>/dev/null \
-            | bun -e 'let s="";for await(const c of console)s+=c;const d=JSON.parse(s).diagnostics??[];const f=new Set(d.map(x=>x.location?.path?.file));console.log("files with diagnostics:",f.size)' || true
-
       - name: Typecheck
         run: bun run typecheck
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,5 +59,18 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      # CLAUDISH_SKIP_LIVE_E2E is REQUIRED here, and not just an optimisation.
+      # channel/e2e-channel.test.ts probes for a usable Claude Code at MODULE
+      # LOAD by spawning `claude --version` and awaiting only its `exit` event.
+      # A runner has no `claude` binary, so spawn emits `error` instead, the
+      # promise never settles, and the whole suite hangs until the job is
+      # killed (observed: >12 min on run 31172281077 before cancellation).
+      # The file's own flag short-circuits that probe.
+      #
+      # The timeout is the backstop: a future hang should fail in 10 minutes,
+      # not burn a 6-hour runner slot. A healthy run is ~60s.
       - name: Hermetic tests
         run: bun run test
+        timeout-minutes: 10
+        env:
+          CLAUDISH_SKIP_LIVE_E2E: "1"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,16 @@ concurrency:
 jobs:
   test:
     name: typecheck · lint · hermetic tests
-    runs-on: ubuntu-latest
+    # macOS, not ubuntu — deliberate. Measured on ubuntu-latest (run
+    # 31173939734): the credential-equivalence suite and the magmux e2e fail
+    # wholesale because claudish's credential authority reaches for macOS
+    # facilities (keychain, `ioreg` screen-lock probe) and the magmux bridge
+    # binary is a macOS artifact the release workflow downloads separately.
+    # The suite has only ever been developed and run on darwin. Gating on the
+    # platform it is actually written for gives a HONEST signal; gating on
+    # ubuntu would mean permanently-red checks people learn to ignore.
+    # Linux portability of the test suite is a separate piece of work.
+    runs-on: macos-latest
     env:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,13 +39,7 @@
     "bun-types": "^1.3.6",
     "typescript": "^5.9.3"
   },
-  "files": [
-    "dist/",
-    "bin/",
-    "native/mtm/mtm-*",
-    "AI_AGENT_GUIDE.md",
-    "skills/"
-  ],
+  "files": ["dist/", "bin/", "native/mtm/mtm-*", "AI_AGENT_GUIDE.md", "skills/"],
   "engines": {
     "node": ">=18.0.0",
     "bun": ">=1.0.0"


### PR DESCRIPTION
## The gap

No workflow ran `bun test`. The green check on PRs #155 and #156 came from the *review bot* — it said nothing about whether the code worked. Every test signal in those releases came from someone remembering to run the suite locally.

That is the gap a regex which silently deleted Gemini answers slipped through, for seven months and five releases.

## Hermetic by omission — the load-bearing design

**No API key secrets are set in this workflow, deliberately.**

Real-API tests gate on `test-helpers/credential-gate.ts`, which asks claudish's own `CredentialAuthority` whether a provider can be served (env → config `apiKeys` → 1Password). With no credentials present that answer is `false` everywhere, so every live test skips itself and what remains is exactly the deterministic tier: adapters, stream parsers, routing rules, fixtures.

No test splitting, no tagging, no `*.live.test.ts` rename — the existing gating already produces the split for free.

Measured in a credential-free environment:

| | with credentials | without |
|---|---|---|
| result | 1875 pass / 5 skip | **1855 pass / 25 skip / 0 fail** |
| wall clock | ~235s | **~56s** |
| provider billing | real | none |

Adding a key secret here would silently convert this gate into the flaky, billable live suite. Live coverage belongs in `smoke-test.yml`, which is manually dispatched and holds the secrets on purpose.

## What it gates

`bun run typecheck` · `bun run lint` · `bun run test` — the **root** scripts, which span `packages/cli` *and* `packages/macos-bridge`. Using `--cwd packages/cli` would silently drop macos-bridge.

Lint fails on **errors only**. The tree carries ~797 warnings (`noExplicitAny`, `noExcessiveCognitiveComplexity`) that are pre-existing style debt, not defects; biome exits 0 for those, so this catches genuine regressions without demanding a 300-file cleanup first.

## Known flakiness — being measured, not assumed

Across ~13 local hermetic runs, ~3 produced a failure, always a different timing-sensitive test and only while the machine was under load from parallel work. Five consecutive runs on an idle machine: 0 failures.

The offenders are all races or process/socket spawns — e.g. `REPRO: process that completes just before timeout fires`, the magmux socket protocol test. Eight of 105 test files spawn processes or open sockets.

This PR intentionally ships the gate **unsplit** to get real data from a dedicated runner. If GitHub's 2-core runners prove flakier than an idle laptop, the follow-up is to move those 8 files into a separate non-blocking job, keeping the deterministic tier — where today's bug actually lived — as the hard gate.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)