### PR TITLE
ci: install magmux, and fix the e2e dependency gap it exposed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,16 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # team-grid.e2e.test.ts resolves magmux via findMagmuxForTest(), which
+      # checks packages/cli/node_modules/@claudish/magmux-<platform>-<arch>/bin
+      # then /opt/homebrew/bin then /usr/local/bin. The npm optionalDependency
+      # packages install as EMPTY DIRECTORIES — no bin/magmux inside — so the
+      # only candidate that ever resolves is the Homebrew copy. Locally that is
+      # already present, which is why the gap only showed up on a runner.
+      # This is the install path team-grid.ts itself points users at.
+      - name: Install magmux (e2e dependency)
+        run: brew install MadAppGang/tap/magmux
+
       - name: Typecheck
         run: bun run typecheck
 


### PR DESCRIPTION
Follow-up to #159. The gate is on main and currently red on two genuine findings; this clears one of them.

## magmux is never installed by `bun install`

`findMagmuxForTest()` checks, in order:

1. `packages/cli/node_modules/@claudish/magmux-<platform>-<arch>/bin/magmux`
2. `/opt/homebrew/bin/magmux`
3. `/usr/local/bin/magmux`

Candidate 1 **never resolves**. The npm optionalDependency packages install as *empty directories* — verified both in a clean clone and in this working tree, neither contains `bin/magmux`:

```
$ find packages/cli/node_modules/@claudish/magmux-darwin-arm64 -maxdepth 2
packages/cli/node_modules/@claudish/magmux-darwin-arm64        ← nothing inside

$ candidate check
    packages/cli/node_modules/@claudish/magmux-darwin-arm64/bin/magmux
 ✅ /opt/homebrew/bin/magmux
    /usr/local/bin/magmux
```

So magmux has only ever resolved from the **Homebrew** copy. A dev machine has it; a runner does not. That is why `team-grid.e2e.test.ts` passes locally and fails in CI with `magmux not found for e2e tests`.

This PR installs it via the same path `team-grid.ts:220` already tells users to run.

**Worth a separate look:** that the published `@claudish/magmux-*` packages are empty is a packaging bug independent of CI. Nothing is consuming them successfully today — the fallback has been masking it.

## Still red after this: the catalog-dependent tests

Four tests fail on any machine without a warm `~/.claudish` catalog cache. Bisected:

```
f3a7bd3 (pre-v7.43.0), fresh HOME → 140 pass, 0 fail
v7.43.0,               fresh HOME → 136 pass, 4 fail
```

Cause is the cherry-picked `6e55266 "read the model facts the catalog already ships"` — routing now reads canonical wire ids from the catalog, so without one `mm@minimax-m2.5` is not normalised to `mm@MiniMax-M2.5`, which those tests assert unconditionally.

**Not a product bug.** Verified against the live MiniMax API — both casings return `status: 0`, so the un-normalised id is accepted. No `v7.43.1` needed; the fix is test-side (seed a catalog fixture rather than depend on ambient cache), and is queued.

Note for anyone reproducing: use a **fresh** `mktemp -d` as HOME. A reused temp HOME accumulates a catalog after the first run and masks the failure — that is exactly how it escaped the v7.43.0 release checks.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)