### PR TITLE
test: stop depending on ambient catalog cache, and pin content_filter → refusal

### DIFF
--- a/packages/cli/src/adapters/effort-mapping.test.ts
+++ b/packages/cli/src/adapters/effort-mapping.test.ts
@@ -11,7 +11,14 @@
  * ai-docs/sessions/dev-research-reasoning-effort-20260629-010035-c1b698d0/report.md §3.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, rmSync, rmdirSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+import {
+  ALL_MODELS_CACHE_PATH,
+  type DiskCacheV2,
+  writeAllModelsCache,
+} from "../providers/all-models-cache.js";
 import { type AdapterResult, BaseAPIFormat, type EffortLevel } from "./base-api-format.js";
 import { CodexAPIFormat } from "./codex-api-format.js";
 import { DeepSeekModelDialect } from "./deepseek-model-dialect.js";
@@ -21,6 +28,41 @@ import { GrokModelDialect } from "./grok-model-dialect.js";
 import { MiniMaxModelDialect } from "./minimax-model-dialect.js";
 import { OpenAIAPIFormat } from "./openai-api-format.js";
 import { QwenModelDialect } from "./qwen-model-dialect.js";
+
+const SYNTHETIC_FUGU_MODEL_ID = "fugu-acme-ultra";
+
+function seedDefaultCatalog(entries: DiskCacheV2["entries"]): () => void {
+  const cacheDir = dirname(ALL_MODELS_CACHE_PATH);
+  const cacheDirExisted = existsSync(cacheDir);
+  const previousContents = existsSync(ALL_MODELS_CACHE_PATH)
+    ? readFileSync(ALL_MODELS_CACHE_PATH, "utf-8")
+    : null;
+
+  writeAllModelsCache(
+    {
+      version: 2,
+      lastUpdated: new Date().toISOString(),
+      entries,
+      models: [],
+    },
+    ALL_MODELS_CACHE_PATH
+  );
+
+  return () => {
+    if (previousContents === null) {
+      rmSync(ALL_MODELS_CACHE_PATH, { force: true });
+      if (!cacheDirExisted) {
+        try {
+          rmdirSync(cacheDir);
+        } catch {
+          // Another test may have created something in the shared cache dir.
+        }
+      }
+      return;
+    }
+    writeFileSync(ALL_MODELS_CACHE_PATH, previousContents, "utf-8");
+  };
+}
 
 // ─── Part 1: shared resolveEffortLevel ────────────────────────────────────
 
@@ -128,6 +170,29 @@ describe("OpenAI gates", () => {
 // ─── Part 2A (Sakana/Fugu): clamp-up via the OpenAI path ──────────────────
 
 describe("Sakana Fugu (OpenAI-compatible path) clamps UP to high", () => {
+  let cleanupCatalog: (() => void) | undefined;
+
+  beforeEach(() => {
+    cleanupCatalog = seedDefaultCatalog([
+      {
+        modelId: SYNTHETIC_FUGU_MODEL_ID,
+        aliases: [],
+        sources: {},
+        reasoning: {
+          supported: true,
+          control: "effort",
+          efforts: ["max", "xhigh", "high"],
+          defaultEffort: "high",
+        },
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    cleanupCatalog?.();
+    cleanupCatalog = undefined;
+  });
+
   test.each([
     ["fugu", "none", "high"],
     ["fugu", "minimal", "high"],
@@ -137,11 +202,10 @@ describe("Sakana Fugu (OpenAI-compatible path) clamps UP to high", () => {
     ["fugu", "xhigh", "xhigh"],
     ["fugu", "max", "xhigh"],
     ["fugu-ultra", "low", "high"],
-    // fugu-ultra advertises `max` in the catalog (efforts: max|xhigh|high), so
-    // the catalog-driven clamp passes it through instead of normalising it down.
-    // Not a behaviour regression: Sakana documents `xhigh == max`, so both send
-    // the same thing. `fugu` (non-ultra) has no `max` and still clamps to xhigh.
-    ["fugu-ultra", "max", "max"],
+    // The synthetic catalog entry advertises `max`, so the catalog-driven clamp
+    // passes it through. Without the fixture (or without catalog lookup), the
+    // Fugu name fallback would normalise `max` down to `xhigh` and this fails.
+    [SYNTHETIC_FUGU_MODEL_ID, "max", "max"],
     ["sakana/fugu-ultra-20260615", "medium", "high"],
   ])("%s effort '%s' → reasoning_effort '%s'", (model, input, expected) => {
     expect(openaiEffort(model, input)).toBe(expected);

--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -2261,6 +2261,39 @@ describe("Regression: truncated turns are reported as max_tokens", () => {
     expect(extractText(events)).toBe("OK");
   });
 
+  test("OpenAI content_filter preserves text and emits refusal", async () => {
+    const createStreamingResponseHandler = await getOpenAiParser();
+    const adapter = await getOpenRouterAdapter();
+
+    // Synthetic protocol-shape case: a provider refusal is not a turn the model chose to end.
+    const contentChunk = {
+      choices: [{ index: 0, delta: { content: "visible before refusal" }, finish_reason: null }],
+    };
+    const refusalChunk = {
+      choices: [{ index: 0, delta: {}, finish_reason: "content_filter" }],
+    };
+    const fixture = new Response(
+      `data: ${JSON.stringify(contentChunk)}\n\ndata: ${JSON.stringify(refusalChunk)}\n\ndata: [DONE]\n\n`,
+      {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }
+    );
+
+    const response = createStreamingResponseHandler(
+      createMockContext(),
+      fixture,
+      adapter,
+      "google/gemini-3.1-pro-preview",
+      null
+    );
+    const events = await parseClaudeSseStream(response);
+    const messageDelta = events.find((event) => event.data?.type === "message_delta");
+
+    expect(messageDelta?.data.delta.stop_reason).toBe("refusal");
+    expect(extractText(events)).toBe("visible before refusal");
+  });
+
   test("OpenAI tool_calls finish remains tool_use", async () => {
     const createStreamingResponseHandler = await getOpenAiParser();
     const adapter = await getOpenRouterAdapter();

--- a/packages/cli/src/providers/routing-rules.test.ts
+++ b/packages/cli/src/providers/routing-rules.test.ts
@@ -9,16 +9,57 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, rmdirSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 
 import { __resetSniffForTests } from "../auth/credentials/op-source.js";
 import type { RoutingRules } from "../profile-config.js";
-import { type DiskCacheV2, writeAllModelsCache } from "./all-models-cache.js";
+import {
+  ALL_MODELS_CACHE_PATH,
+  type DiskCacheV2,
+  writeAllModelsCache,
+} from "./all-models-cache.js";
 import { DISPLAY_NAMES } from "./auto-route.js";
+import { _resetCatalogClient } from "./catalog-client.js";
 import { DEFAULT_ROUTING_RULES } from "./default-routing-rules.js";
 import { buildRoutingChain, matchRoutingRule, mergeRoutingRules, route } from "./routing-rules.js";
+
+const SYNTHETIC_MODEL_ID = "acme-x1.0";
+const SYNTHETIC_MINIMAX_EXTERNAL_ID = "ACME-X1.0";
+
+function seedDefaultCatalog(entries: DiskCacheV2["entries"]): () => void {
+  const cacheDir = dirname(ALL_MODELS_CACHE_PATH);
+  const cacheDirExisted = existsSync(cacheDir);
+  const previousContents = existsSync(ALL_MODELS_CACHE_PATH)
+    ? readFileSync(ALL_MODELS_CACHE_PATH, "utf-8")
+    : null;
+
+  writeAllModelsCache(
+    {
+      version: 2,
+      lastUpdated: new Date().toISOString(),
+      entries,
+      models: [],
+    },
+    ALL_MODELS_CACHE_PATH
+  );
+
+  return () => {
+    if (previousContents === null) {
+      rmSync(ALL_MODELS_CACHE_PATH, { force: true });
+      if (!cacheDirExisted) {
+        try {
+          rmdirSync(cacheDir);
+        } catch {
+          // Another test may have created something in the shared cache dir.
+        }
+      }
+      return;
+    }
+    writeFileSync(ALL_MODELS_CACHE_PATH, previousContents, "utf-8");
+  };
+}
 
 function makeTempCatalog(
   model: {
@@ -231,35 +272,58 @@ describe("matchRoutingRule", () => {
 // ---------------------------------------------------------------------------
 
 describe("buildRoutingChain", () => {
+  let cleanupCatalog: (() => void) | undefined;
+
+  beforeEach(() => {
+    cleanupCatalog = seedDefaultCatalog([
+      {
+        modelId: SYNTHETIC_MODEL_ID,
+        aliases: [],
+        sources: {},
+        aggregators: [
+          {
+            provider: "minimax",
+            externalId: SYNTHETIC_MINIMAX_EXTERNAL_ID,
+            confidence: "scrape_verified",
+          },
+        ],
+      },
+    ]);
+    _resetCatalogClient();
+  });
+
+  afterEach(() => {
+    _resetCatalogClient();
+    cleanupCatalog?.();
+    cleanupCatalog = undefined;
+  });
+
   test("plain provider name 'minimax' resolves via PROVIDER_SHORTCUTS and uses originalModelName", () => {
-    const routes = buildRoutingChain(["minimax"], "minimax-m2.5");
+    const routes = buildRoutingChain(["minimax"], SYNTHETIC_MODEL_ID);
     expect(routes).toHaveLength(1);
     const route = routes[0];
     expect(route.provider).toBe("minimax");
-    // PROVIDER_TO_PREFIX["minimax"] = "mm". The MODEL id comes from the
-    // catalog's minimax aggregator (externalId "MiniMax-M2.5",
-    // confidence api_official — MiniMax's own spelling), not from whatever
-    // casing the user typed. That is the point of catalog-driven resolution:
-    // the provider's API is case-sensitive, so echoing user input was a coin
-    // flip. Falls back to the input unchanged on a cold cache.
-    expect(route.modelSpec).toBe("mm@MiniMax-M2.5");
+    // PROVIDER_TO_PREFIX["minimax"] = "mm". The synthetic catalog deliberately
+    // gives the provider external id different casing from the user's input, so
+    // this exact check fails if catalog-driven normalization is removed.
+    expect(route.modelSpec).toBe(`mm@${SYNTHETIC_MINIMAX_EXTERNAL_ID}`);
     expect(route.displayName).toBe(DISPLAY_NAMES.minimax ?? "minimax");
   });
 
   test("plain provider shortcut 'mm' resolves to canonical 'minimax'", () => {
-    const routes = buildRoutingChain(["mm"], "minimax-m2.5");
+    const routes = buildRoutingChain(["mm"], SYNTHETIC_MODEL_ID);
     expect(routes).toHaveLength(1);
     expect(routes[0].provider).toBe("minimax");
-    expect(routes[0].modelSpec).toBe("mm@MiniMax-M2.5");
+    expect(routes[0].modelSpec).toBe(`mm@${SYNTHETIC_MINIMAX_EXTERNAL_ID}`);
   });
 
-  test("explicit 'mm@minimax-m2.5' parses provider and model, ignores originalModelName", () => {
-    const routes = buildRoutingChain(["mm@minimax-m2.5"], "some-other-model");
+  test("explicit 'mm@acme-x1.0' parses provider and model, ignores originalModelName", () => {
+    const routes = buildRoutingChain([`mm@${SYNTHETIC_MODEL_ID}`], "some-other-model");
     expect(routes).toHaveLength(1);
     const route = routes[0];
     expect(route.provider).toBe("minimax");
     // An explicitly pinned model is still normalised to the provider's own id.
-    expect(route.modelSpec).toBe("mm@MiniMax-M2.5");
+    expect(route.modelSpec).toBe(`mm@${SYNTHETIC_MINIMAX_EXTERNAL_ID}`);
   });
 
   test("explicit 'kimi@kimi-k2.5' parses correctly", () => {


### PR DESCRIPTION
Turns the CI gate from #159 green.

## The defect

Three of the four failures were one bug: tests asserting **catalog-normalised** values without ever seeding a catalog.

`buildRoutingChain` and the Sakana Fugu effort clamp passed only because a developer's `~/.claudish` holds a warm `all-models` cache. On a fresh HOME the code correctly falls back to the input unchanged, and the assertions fail. The test's own comment already said so —

> Falls back to the input unchanged on a cold cache.

— it just never seeded one, while sibling `describe` blocks in the same file do.

Introduced by `6e55266` in v7.43.0. Invisible at release because local runs inherit the cache. A **reused** temp HOME masks it too, after the first run — which is how it survived my own hermetic checks.

## Why not just seed `MiniMax-M2.5`

That would fix CI and keep a pinned real model id in an assertion — already rotting. `minimax-m2.5` has dropped out of the curated recommended set (now `minimax-m3`, `minimax-m2.7-highspeed`) while surviving in the broader slim catalog, so the test was passing on the side of a split that hadn't moved yet.

The tests now seed a **synthetic** entry (`acme-x1.0` → `ACME-X1.0`) via the `writeAllModelsCache` seam and assert the *rule* — the provider's canonical `externalId` beats the user's casing — with no real model id anywhere.

## Mutation-checked, not just green

Green tests prove nothing on their own, so each was verified to fail when its subject is disabled:

| Mutation | Result |
|---|---|
| `modelName = modelName` (normalisation off) in `routing-rules.ts` | 3 fail ✅ |
| `const refused = false` in `openai-sse.ts` | 1 fail ✅ |

## Also

Adds the missing regression test for the `content_filter → refusal` mapping shipped in v7.42.0 — the one change from that release that went out verified-by-hand but untested.

## Verification

Under true CI conditions — fresh `mktemp -d` HOME, no credentials, no `claude` on PATH:

```
typecheck  0
lint       0
tests      1841 pass / 25 skip / 0 fail
```

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)