### PR TITLE
fix(stream-parsers): tear down from a finally so a failed finalize cannot hang the turn

### DIFF
--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -94,6 +94,64 @@ async function parseClaudeSseStream(response: Response): Promise<ClaudeEvent[]> 
   return events;
 }
 
+/**
+ * Consume a parser response with a wall-clock timeout while tracking the real
+ * intervals it creates. The wrappers delegate to the native timer functions;
+ * they only record whether parser teardown cleared its keepalive interval.
+ */
+async function parseWithTimeoutAndIntervalTracking(
+  createResponse: () => Response,
+  timeoutMs = 500
+): Promise<{
+  events: ClaudeEvent[] | null;
+  timedOut: boolean;
+  intervalsStarted: number;
+  intervalsStillActive: number;
+}> {
+  const originalSetInterval = globalThis.setInterval;
+  const originalClearInterval = globalThis.clearInterval;
+  const activeIntervals = new Set<ReturnType<typeof globalThis.setInterval>>();
+  let intervalsStarted = 0;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutMarker = Symbol("stream parse timeout");
+
+  globalThis.setInterval = ((...args: Parameters<typeof globalThis.setInterval>) => {
+    const interval = originalSetInterval(...args);
+    intervalsStarted++;
+    activeIntervals.add(interval);
+    return interval;
+  }) as typeof globalThis.setInterval;
+  globalThis.clearInterval = ((...args: Parameters<typeof globalThis.clearInterval>) => {
+    const [interval] = args;
+    if (interval !== undefined) {
+      activeIntervals.delete(interval as ReturnType<typeof globalThis.setInterval>);
+    }
+    return originalClearInterval(...args);
+  }) as typeof globalThis.clearInterval;
+
+  try {
+    const response = createResponse();
+    const result = await Promise.race([
+      parseClaudeSseStream(response),
+      new Promise<typeof timeoutMarker>((resolve) => {
+        timeout = setTimeout(() => resolve(timeoutMarker), timeoutMs);
+      }),
+    ]);
+
+    return {
+      events: result === timeoutMarker ? null : result,
+      timedOut: result === timeoutMarker,
+      intervalsStarted,
+      intervalsStillActive: activeIntervals.size,
+    };
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    globalThis.setInterval = originalSetInterval;
+    globalThis.clearInterval = originalClearInterval;
+    for (const interval of activeIntervals) originalClearInterval(interval);
+  }
+}
+
 /** Extract all text content from parsed Claude events */
 function extractText(events: ClaudeEvent[]): string {
   return events
@@ -2334,5 +2392,89 @@ describe("Regression: truncated turns are reported as max_tokens", () => {
 
     expect(extractToolNames(events)).toEqual(["Read"]);
     expect(messageDelta?.data.delta.stop_reason).toBe("tool_use");
+  });
+});
+
+describe("Regression: finalize teardown survives callback failures", () => {
+  test("openai-sse closes the stream and clears its ping when onTokenUpdate throws", async () => {
+    const parserMod = await import("./handlers/shared/stream-parsers/openai-sse.js");
+    const adapterMod = await import("./adapters/base-api-format.js");
+    const adapter = new adapterMod.DefaultAPIFormat("test-model");
+    let callbackCalls = 0;
+
+    const result = await parseWithTimeoutAndIntervalTracking(() => {
+      const fixture = fixtureToResponse(join(FIXTURES_DIR, "SEED-openai-text-only.sse"));
+      return parserMod.createStreamingResponseHandler(
+        createMockContext(),
+        fixture,
+        adapter,
+        "test-model",
+        null,
+        () => {
+          callbackCalls++;
+          throw new Error("token callback failed");
+        }
+      );
+    });
+
+    expect(result.timedOut).toBe(false);
+    expect(result.events).not.toBeNull();
+    expect(result.intervalsStarted).toBe(1);
+    expect(result.intervalsStillActive).toBe(0);
+    expect(callbackCalls).toBe(1);
+  });
+
+  test("gemini-sse closes the stream and clears its ping when onTokenUpdate throws", async () => {
+    const parserMod = await import("./handlers/shared/stream-parsers/gemini-sse.js");
+    const adapterMod = await import("./adapters/gemini-api-format.js");
+    const adapter = new adapterMod.GeminiAPIFormat("gemini-3.6-flash");
+    let callbackCalls = 0;
+
+    const result = await parseWithTimeoutAndIntervalTracking(() => {
+      const fixture = fixtureToResponse(
+        join(FIXTURES_DIR, "gemini-3.6-flash-antigravity-ok-answer.sse")
+      );
+      return parserMod.createGeminiSseStream(createMockContext(), fixture, {
+        modelName: "gemini-3.6-flash",
+        adapter,
+        unwrapResponse: true,
+        onTokenUpdate: () => {
+          callbackCalls++;
+          throw new Error("token callback failed");
+        },
+      });
+    });
+
+    expect(result.timedOut).toBe(false);
+    expect(result.events).not.toBeNull();
+    expect(result.intervalsStarted).toBe(1);
+    expect(result.intervalsStillActive).toBe(0);
+    expect(callbackCalls).toBe(1);
+  });
+
+  test("ollama-jsonl closes the stream, clears its ping, and emits one message_stop when onTokenUpdate throws", async () => {
+    const parserMod = await import("./handlers/shared/stream-parsers/ollama-jsonl.js");
+    let callbackCalls = 0;
+
+    const result = await parseWithTimeoutAndIntervalTracking(() => {
+      const fixture = new Response(
+        `${JSON.stringify({ message: { content: "Hello" }, done: false })}\n${JSON.stringify({ done: true, prompt_eval_count: 12, eval_count: 3 })}\n`,
+        { status: 200, headers: { "Content-Type": "application/x-ndjson" } }
+      );
+      return parserMod.createOllamaJsonlStream(createMockContext(), fixture, {
+        modelName: "test-model",
+        onTokenUpdate: () => {
+          callbackCalls++;
+          throw new Error("token callback failed");
+        },
+      });
+    });
+
+    expect(result.timedOut).toBe(false);
+    expect(result.events).not.toBeNull();
+    expect(result.intervalsStarted).toBe(1);
+    expect(result.intervalsStillActive).toBe(0);
+    expect(callbackCalls).toBe(1);
+    expect(result.events?.filter((event) => event.data?.type === "message_stop")).toHaveLength(1);
   });
 });

--- a/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/gemini-sse.ts
@@ -96,75 +96,91 @@ export function createGeminiSseStream(
         }
       }, 1000);
 
-      const finalize = async (reason: string, err?: string) => {
-        if (finalized) return;
-        finalized = true;
-
-        if (thinkingStarted) {
-          send("content_block_stop", { type: "content_block_stop", index: thinkingIdx });
-        }
-        if (textStarted) {
-          send("content_block_stop", { type: "content_block_stop", index: textIdx });
-        }
-        for (const t of toolCalls.values()) {
-          if (t.started && !t.closed) {
-            send("content_block_stop", { type: "content_block_stop", index: t.blockIndex });
-            t.closed = true;
-          }
-        }
-
-        if (opts.middlewareManager) {
-          await opts.middlewareManager.afterStreamComplete(opts.modelName, new Map());
-        }
-
-        const inputTokens = usage?.promptTokenCount || 0;
-        const outputTokens = usage?.candidatesTokenCount || 0;
-
-        if (usage) {
-          log(`[GeminiSSE] Usage: prompt=${inputTokens}, completion=${outputTokens}`);
-        }
-
-        if (opts.onTokenUpdate) {
-          opts.onTokenUpdate(inputTokens, outputTokens);
-        }
-
-        if (reason === "error") {
-          log(`[GeminiSSE] Stream error: ${err}`);
-          send("error", { type: "error", error: { type: "api_error", message: err } });
-        } else {
-          const hasToolCalls = toolCalls.size > 0;
-          // Anthropic's contract for a cut-off turn is "max_tokens". Reporting
-          // "end_turn" presents a truncated answer — or an empty one, when a
-          // thinking model spent the whole budget reasoning — as the model's
-          // complete final word.
-          const stopReason = truncated ? "max_tokens" : hasToolCalls ? "tool_use" : "end_turn";
-          if (truncated) {
-            log("[GeminiSSE] finishReason=MAX_TOKENS → stop_reason=max_tokens");
-          }
-          send("message_delta", {
-            type: "message_delta",
-            delta: { stop_reason: stopReason, stop_sequence: null },
-            // input_tokens rides the delta so the client learns the real context
-            // size — without it Claude Code keeps message_start's estimate and
-            // auto-compaction never arms. See message-start-usage.ts.
-            usage: {
-              ...(inputTokens > 0 ? { input_tokens: inputTokens } : {}),
-              output_tokens: outputTokens,
-            },
-          });
-          opts.onTurnEnd?.();
-          send("message_stop", { type: "message_stop" });
-        }
-
+      // Kept out of finalize() so it can run from a `finally`. finalize() guards
+      // re-entry on `finalized`, so a throw part-way through (afterStreamComplete
+      // is an await on user middleware) used to leave the controller open and the
+      // ping interval running forever — the outer catch re-called finalize() and
+      // it returned at the guard. Safe to call more than once.
+      const teardown = () => {
         if (!isClosed) {
           isClosed = true;
-          if (pingInterval) {
-            clearInterval(pingInterval);
-            pingInterval = null;
-          }
           try {
             controller.close();
           } catch {}
+        }
+        if (pingInterval) {
+          clearInterval(pingInterval);
+          pingInterval = null;
+        }
+      };
+
+      const finalize = async (reason: string, err?: string) => {
+        // A repeat call still tears down: the first may have thrown before
+        // reaching its own `finally`.
+        if (finalized) {
+          teardown();
+          return;
+        }
+        finalized = true;
+
+        try {
+          if (thinkingStarted) {
+            send("content_block_stop", { type: "content_block_stop", index: thinkingIdx });
+          }
+          if (textStarted) {
+            send("content_block_stop", { type: "content_block_stop", index: textIdx });
+          }
+          for (const t of toolCalls.values()) {
+            if (t.started && !t.closed) {
+              send("content_block_stop", { type: "content_block_stop", index: t.blockIndex });
+              t.closed = true;
+            }
+          }
+
+          if (opts.middlewareManager) {
+            await opts.middlewareManager.afterStreamComplete(opts.modelName, new Map());
+          }
+
+          const inputTokens = usage?.promptTokenCount || 0;
+          const outputTokens = usage?.candidatesTokenCount || 0;
+
+          if (usage) {
+            log(`[GeminiSSE] Usage: prompt=${inputTokens}, completion=${outputTokens}`);
+          }
+
+          if (opts.onTokenUpdate) {
+            opts.onTokenUpdate(inputTokens, outputTokens);
+          }
+
+          if (reason === "error") {
+            log(`[GeminiSSE] Stream error: ${err}`);
+            send("error", { type: "error", error: { type: "api_error", message: err } });
+          } else {
+            const hasToolCalls = toolCalls.size > 0;
+            // Anthropic's contract for a cut-off turn is "max_tokens". Reporting
+            // "end_turn" presents a truncated answer — or an empty one, when a
+            // thinking model spent the whole budget reasoning — as the model's
+            // complete final word.
+            const stopReason = truncated ? "max_tokens" : hasToolCalls ? "tool_use" : "end_turn";
+            if (truncated) {
+              log("[GeminiSSE] finishReason=MAX_TOKENS → stop_reason=max_tokens");
+            }
+            send("message_delta", {
+              type: "message_delta",
+              delta: { stop_reason: stopReason, stop_sequence: null },
+              // input_tokens rides the delta so the client learns the real context
+              // size — without it Claude Code keeps message_start's estimate and
+              // auto-compaction never arms. See message-start-usage.ts.
+              usage: {
+                ...(inputTokens > 0 ? { input_tokens: inputTokens } : {}),
+                output_tokens: outputTokens,
+              },
+            });
+            opts.onTurnEnd?.();
+            send("message_stop", { type: "message_stop" });
+          }
+        } finally {
+          teardown();
         }
       };
 

--- a/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/ollama-jsonl.ts
@@ -65,43 +65,61 @@ export function createOllamaJsonlStream(
         }
       }, 1000);
 
-      const finalize = (reason: string, err?: string) => {
-        if (isClosed) return;
+      // `isClosed` used to double as the re-entry guard, which made a throw
+      // part-way through finalize() worse than a leak: isClosed was still false,
+      // so the catch at the bottom re-ran the WHOLE body and emitted a second
+      // message_delta / message_stop. A dedicated `finalized` flag separates
+      // "already emitted the terminal events" from "controller is shut", and
+      // teardown runs from a `finally` so the ping interval always clears.
+      let finalized = false;
 
-        if (textStarted) {
-          send("content_block_stop", { type: "content_block_stop", index: 0 });
-        }
-
-        if (reason === "error") {
-          send("error", { type: "error", error: { type: "api_error", message: err } });
-        } else {
-          send("message_delta", {
-            type: "message_delta",
-            delta: { stop_reason: "end_turn", stop_sequence: null },
-            // Ollama reports the FULL context each turn in prompt_eval_count;
-            // forwarding it lets Claude Code arm auto-compaction instead of
-            // holding message_start's estimate. See message-start-usage.ts.
-            usage: {
-              ...(promptTokens > 0 ? { input_tokens: promptTokens } : {}),
-              output_tokens: completionTokens,
-            },
-          });
-          send("message_stop", { type: "message_stop" });
-        }
-
-        if (opts.onTokenUpdate) {
-          opts.onTokenUpdate(promptTokens, completionTokens);
-        }
-
+      const teardown = () => {
         if (!isClosed) {
           isClosed = true;
-          if (pingInterval) {
-            clearInterval(pingInterval);
-            pingInterval = null;
-          }
           try {
             controller.close();
           } catch {}
+        }
+        if (pingInterval) {
+          clearInterval(pingInterval);
+          pingInterval = null;
+        }
+      };
+
+      const finalize = (reason: string, err?: string) => {
+        if (finalized) {
+          teardown();
+          return;
+        }
+        finalized = true;
+
+        try {
+          if (textStarted) {
+            send("content_block_stop", { type: "content_block_stop", index: 0 });
+          }
+
+          if (reason === "error") {
+            send("error", { type: "error", error: { type: "api_error", message: err } });
+          } else {
+            send("message_delta", {
+              type: "message_delta",
+              delta: { stop_reason: "end_turn", stop_sequence: null },
+              // Ollama reports the FULL context each turn in prompt_eval_count;
+              // forwarding it lets Claude Code arm auto-compaction instead of
+              // holding message_start's estimate. See message-start-usage.ts.
+              usage: {
+                ...(promptTokens > 0 ? { input_tokens: promptTokens } : {}),
+                output_tokens: completionTokens,
+              },
+            });
+            send("message_stop", { type: "message_stop" });
+          }
+
+          if (opts.onTokenUpdate) {
+            opts.onTokenUpdate(promptTokens, completionTokens);
+          }
+        } finally {
+          teardown();
         }
       };
 

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -200,85 +200,142 @@ export function createStreamingResponseHandler(
           }
         }, 1000);
 
+        // Teardown is separated from finalize() on purpose. finalize() guards
+        // re-entry on state.finalized, so once it has started, a throw part-way
+        // through used to mean the stream was never closed and the ping interval
+        // was never cleared: the outer catch re-called finalize(), which returned
+        // immediately at the guard. The client then sat on an open HTTP 200
+        // forever. Teardown therefore runs from a `finally`, and stays safe to
+        // call twice.
+        const teardown = () => {
+          if (!isClosed) {
+            try {
+              controller.enqueue(encoder.encode("data: [DONE]\n\n\n"));
+            } catch {}
+            try {
+              controller.close();
+            } catch {}
+            isClosed = true;
+          }
+          if (ping) {
+            clearInterval(ping);
+            ping = null;
+          }
+        };
+
         const finalize = async (reason: string, err?: string) => {
-          if (state.finalized) return;
+          // A second call still has to tear down: the first may have thrown
+          // before reaching its own `finally`.
+          if (state.finalized) {
+            teardown();
+            return;
+          }
           state.finalized = true;
 
-          // Debug: Log accumulated text for analysis
-          if (state.accumulatedText.length > 0) {
-            const preview = state.accumulatedText.slice(0, 500).replace(/\n/g, "\\n");
-            log(
-              `[Streaming] Accumulated text (${state.accumulatedText.length} chars): ${preview}...`
-            );
-          }
+          try {
+            // Debug: Log accumulated text for analysis
+            if (state.accumulatedText.length > 0) {
+              const preview = state.accumulatedText.slice(0, 500).replace(/\n/g, "\\n");
+              log(
+                `[Streaming] Accumulated text (${state.accumulatedText.length} chars): ${preview}...`
+              );
+            }
 
-          // Check for text-based tool calls before finalizing
-          // Some models (like Qwen) output tool calls as text instead of structured tool_calls
-          const textToolCalls = extractToolCallsFromText(state.accumulatedText);
-          log(`[Streaming] Text-based tool calls found: ${textToolCalls.length}`);
-          if (textToolCalls.length > 0) {
-            log(
-              `[Streaming] Found ${textToolCalls.length} text-based tool call(s), converting to structured format`
-            );
+            // Check for text-based tool calls before finalizing
+            // Some models (like Qwen) output tool calls as text instead of structured tool_calls
+            const textToolCalls = extractToolCallsFromText(state.accumulatedText);
+            log(`[Streaming] Text-based tool calls found: ${textToolCalls.length}`);
+            if (textToolCalls.length > 0) {
+              log(
+                `[Streaming] Found ${textToolCalls.length} text-based tool call(s), converting to structured format`
+              );
 
-            // Close any open text block first
+              // Close any open text block first
+              if (state.textStarted) {
+                send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
+                state.textStarted = false;
+              }
+
+              // Send each extracted tool call as a proper tool_use block
+              for (const tc of textToolCalls) {
+                const toolIdx = state.curIdx++;
+                const toolId = `tool_${Date.now()}_${toolIdx}`;
+
+                send("content_block_start", {
+                  type: "content_block_start",
+                  index: toolIdx,
+                  content_block: { type: "tool_use", id: toolId, name: tc.name },
+                });
+                send("content_block_delta", {
+                  type: "content_block_delta",
+                  index: toolIdx,
+                  delta: {
+                    type: "input_json_delta",
+                    partial_json: repairArgs(tc.name, JSON.stringify(tc.arguments)),
+                  },
+                });
+                send("content_block_stop", { type: "content_block_stop", index: toolIdx });
+              }
+            }
+
+            if (state.reasoningStarted) {
+              send("content_block_stop", { type: "content_block_stop", index: state.reasoningIdx });
+            }
             if (state.textStarted) {
               send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
-              state.textStarted = false;
             }
 
-            // Send each extracted tool call as a proper tool_use block
-            for (const tc of textToolCalls) {
-              const toolIdx = state.curIdx++;
-              const toolId = `tool_${Date.now()}_${toolIdx}`;
-
-              send("content_block_start", {
-                type: "content_block_start",
-                index: toolIdx,
-                content_block: { type: "tool_use", id: toolId, name: tc.name },
-              });
-              send("content_block_delta", {
-                type: "content_block_delta",
-                index: toolIdx,
-                delta: {
-                  type: "input_json_delta",
-                  partial_json: repairArgs(tc.name, JSON.stringify(tc.arguments)),
-                },
-              });
-              send("content_block_stop", { type: "content_block_stop", index: toolIdx });
-            }
-          }
-
-          if (state.reasoningStarted) {
-            send("content_block_stop", { type: "content_block_stop", index: state.reasoningIdx });
-          }
-          if (state.textStarted) {
-            send("content_block_stop", { type: "content_block_stop", index: state.textIdx });
-          }
-
-          // Handle buffered-but-unsent structured tool calls.
-          // Some models (e.g., Gemini via LiteLLM) send tool calls with finish_reason="stop"
-          // instead of "tool_calls", so the normal validation path (line ~695) is never reached.
-          // We must send these buffered tools here so Claude Code can execute them.
-          for (const t of Array.from(state.tools.values())) {
-            if (!t.closed && t.buffered && !t.started) {
-              if (toolSchemas && toolSchemas.length > 0) {
-                const validation = validateToolArguments(
-                  t.name,
-                  t.arguments,
-                  toolSchemas,
-                  state.accumulatedText
-                );
-
-                if (validation.valid || (validation.repaired && validation.repairedArgs)) {
-                  const argsJson = repairArgs(
+            // Handle buffered-but-unsent structured tool calls.
+            // Some models (e.g., Gemini via LiteLLM) send tool calls with finish_reason="stop"
+            // instead of "tool_calls", so the normal validation path (line ~695) is never reached.
+            // We must send these buffered tools here so Claude Code can execute them.
+            for (const t of Array.from(state.tools.values())) {
+              if (!t.closed && t.buffered && !t.started) {
+                if (toolSchemas && toolSchemas.length > 0) {
+                  const validation = validateToolArguments(
                     t.name,
-                    JSON.stringify(
-                      validation.repaired ? validation.repairedArgs : validation.parsedArgs
-                    )
+                    t.arguments,
+                    toolSchemas,
+                    state.accumulatedText
                   );
+
+                  if (validation.valid || (validation.repaired && validation.repairedArgs)) {
+                    const argsJson = repairArgs(
+                      t.name,
+                      JSON.stringify(
+                        validation.repaired ? validation.repairedArgs : validation.parsedArgs
+                      )
+                    );
+                    log(
+                      `[Streaming] Sending buffered tool call (finish_reason!=tool_calls): ${t.name} with args: ${argsJson}`
+                    );
+                    send("content_block_start", {
+                      type: "content_block_start",
+                      index: t.blockIndex,
+                      content_block: { type: "tool_use", id: t.id, name: t.name },
+                    });
+                    send("content_block_delta", {
+                      type: "content_block_delta",
+                      index: t.blockIndex,
+                      delta: { type: "input_json_delta", partial_json: argsJson },
+                    });
+                    send("content_block_stop", {
+                      type: "content_block_stop",
+                      index: t.blockIndex,
+                    });
+                    t.started = true;
+                    t.closed = true;
+                  } else {
+                    log(
+                      `[Streaming] Buffered tool call ${t.name} failed validation, skipping: ${validation.missingParams.join(", ")}`
+                    );
+                    t.closed = true;
+                  }
+                } else {
+                  // No schemas to validate against — send as-is
+                  const argsJson = repairArgs(t.name, t.arguments || "{}");
                   log(
-                    `[Streaming] Sending buffered tool call (finish_reason!=tool_calls): ${t.name} with args: ${argsJson}`
+                    `[Streaming] Sending buffered tool call (no validation): ${t.name} with args: ${argsJson}`
                   );
                   send("content_block_start", {
                     type: "content_block_start",
@@ -296,122 +353,90 @@ export function createStreamingResponseHandler(
                   });
                   t.started = true;
                   t.closed = true;
-                } else {
-                  log(
-                    `[Streaming] Buffered tool call ${t.name} failed validation, skipping: ${validation.missingParams.join(", ")}`
-                  );
-                  t.closed = true;
                 }
-              } else {
-                // No schemas to validate against — send as-is
-                const argsJson = repairArgs(t.name, t.arguments || "{}");
-                log(
-                  `[Streaming] Sending buffered tool call (no validation): ${t.name} with args: ${argsJson}`
-                );
-                send("content_block_start", {
-                  type: "content_block_start",
-                  index: t.blockIndex,
-                  content_block: { type: "tool_use", id: t.id, name: t.name },
-                });
-                send("content_block_delta", {
-                  type: "content_block_delta",
-                  index: t.blockIndex,
-                  delta: { type: "input_json_delta", partial_json: argsJson },
-                });
-                send("content_block_stop", {
-                  type: "content_block_stop",
-                  index: t.blockIndex,
-                });
-                t.started = true;
+              }
+            }
+
+            // Close any remaining started-but-unclosed tool calls
+            for (const t of Array.from(state.tools.values())) {
+              if (t.started && !t.closed) {
+                send("content_block_stop", { type: "content_block_stop", index: t.blockIndex });
                 t.closed = true;
               }
             }
-          }
 
-          // Close any remaining started-but-unclosed tool calls
-          for (const t of Array.from(state.tools.values())) {
-            if (t.started && !t.closed) {
-              send("content_block_stop", { type: "content_block_stop", index: t.blockIndex });
-              t.closed = true;
+            if (middlewareManager) {
+              await middlewareManager.afterStreamComplete(target, streamMetadata);
             }
-          }
 
-          if (middlewareManager) {
-            await middlewareManager.afterStreamComplete(target, streamMetadata);
-          }
-
-          if (reason === "error") {
-            send("error", { type: "error", error: { type: "api_error", message: err } });
-          } else {
-            // Set stop_reason based on whether we sent ANY tool calls (text-based or structured)
-            const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started);
-            // A turn the PROVIDER cut off must not be reported as a turn the model
-            // chose to end. Anthropic's contract for a cut-off turn is "max_tokens";
-            // reporting "end_turn" presents a truncated (or, when reasoning consumed
-            // the whole budget, an EMPTY) answer as the model's complete final word.
-            // Mirrors openai-responses-sse.ts, which already does this.
-            // `content_filter` is the same class: the provider refused, which is
-            // Anthropic's "refusal", not a turn the model chose to end.
-            // openai-responses-sse.ts already maps both this way.
-            const truncated = state.finishReason === "length";
-            const refused = state.finishReason === "content_filter";
-            const stopReason = refused
-              ? "refusal"
-              : truncated
-                ? "max_tokens"
-                : textToolCalls.length > 0 || hasStructuredTools
-                  ? "tool_use"
-                  : "end_turn";
-            if (truncated || refused) {
-              log(
-                `[Streaming] Upstream finish_reason=${state.finishReason} → stop_reason=${stopReason} (${state.accumulatedText.length} chars produced)`
-              );
-            }
-            send("message_delta", {
-              type: "message_delta",
-              delta: { stop_reason: stopReason, stop_sequence: null },
-              // input_tokens must ride the delta too: Claude Code takes the
-              // context size from the last assistant message, and message_start
-              // could only carry an estimate. Omitting it left the client
-              // believing every conversation was 100 tokens, which silently
-              // disabled auto-compaction on every openai-sse provider.
-              usage: {
-                ...(state.usage?.prompt_tokens ? { input_tokens: state.usage.prompt_tokens } : {}),
-                output_tokens: state.usage?.completion_tokens || 0,
-              },
-            });
-            behavior?.onTurnEnd?.();
-            send("message_stop", { type: "message_stop" });
-          }
-
-          // Update token counts - use actual usage if available, otherwise estimate
-          if (onTokenUpdate) {
-            if (state.usage) {
-              log(
-                `[Streaming] Final usage: prompt=${state.usage.prompt_tokens || 0}, completion=${state.usage.completion_tokens || 0}`
-              );
-              onTokenUpdate(state.usage.prompt_tokens || 0, state.usage.completion_tokens || 0);
+            if (reason === "error") {
+              send("error", { type: "error", error: { type: "api_error", message: err } });
             } else {
-              // Estimate tokens for local models that don't return usage data
-              // Rough estimate: ~4 characters per token
-              const estimatedOutputTokens = Math.ceil(state.accumulatedText.length / 4);
-              log(
-                `[Streaming] No usage data from provider, estimating: ~${estimatedOutputTokens} output tokens`
-              );
-              // Carry the previous context size forward rather than a literal
-              // 100 — the status line reads this value, and 100 would make the
-              // bar collapse to "empty" on any turn the provider skips usage.
-              onTokenUpdate(priorInputTokens || 100, estimatedOutputTokens);
+              // Set stop_reason based on whether we sent ANY tool calls (text-based or structured)
+              const hasStructuredTools = Array.from(state.tools.values()).some((t) => t.started);
+              // A turn the PROVIDER cut off must not be reported as a turn the model
+              // chose to end. Anthropic's contract for a cut-off turn is "max_tokens";
+              // reporting "end_turn" presents a truncated (or, when reasoning consumed
+              // the whole budget, an EMPTY) answer as the model's complete final word.
+              // Mirrors openai-responses-sse.ts, which already does this.
+              // `content_filter` is the same class: the provider refused, which is
+              // Anthropic's "refusal", not a turn the model chose to end.
+              // openai-responses-sse.ts already maps both this way.
+              const truncated = state.finishReason === "length";
+              const refused = state.finishReason === "content_filter";
+              const stopReason = refused
+                ? "refusal"
+                : truncated
+                  ? "max_tokens"
+                  : textToolCalls.length > 0 || hasStructuredTools
+                    ? "tool_use"
+                    : "end_turn";
+              if (truncated || refused) {
+                log(
+                  `[Streaming] Upstream finish_reason=${state.finishReason} → stop_reason=${stopReason} (${state.accumulatedText.length} chars produced)`
+                );
+              }
+              send("message_delta", {
+                type: "message_delta",
+                delta: { stop_reason: stopReason, stop_sequence: null },
+                // input_tokens must ride the delta too: Claude Code takes the
+                // context size from the last assistant message, and message_start
+                // could only carry an estimate. Omitting it left the client
+                // believing every conversation was 100 tokens, which silently
+                // disabled auto-compaction on every openai-sse provider.
+                usage: {
+                  ...(state.usage?.prompt_tokens
+                    ? { input_tokens: state.usage.prompt_tokens }
+                    : {}),
+                  output_tokens: state.usage?.completion_tokens || 0,
+                },
+              });
+              behavior?.onTurnEnd?.();
+              send("message_stop", { type: "message_stop" });
             }
-          }
 
-          if (!isClosed) {
-            try {
-              controller.enqueue(encoder.encode("data: [DONE]\n\n\n"));
-            } catch (e) {}
-            controller.close();
-            isClosed = true;
-            if (ping) clearInterval(ping);
+            // Update token counts - use actual usage if available, otherwise estimate
+            if (onTokenUpdate) {
+              if (state.usage) {
+                log(
+                  `[Streaming] Final usage: prompt=${state.usage.prompt_tokens || 0}, completion=${state.usage.completion_tokens || 0}`
+                );
+                onTokenUpdate(state.usage.prompt_tokens || 0, state.usage.completion_tokens || 0);
+              } else {
+                // Estimate tokens for local models that don't return usage data
+                // Rough estimate: ~4 characters per token
+                const estimatedOutputTokens = Math.ceil(state.accumulatedText.length / 4);
+                log(
+                  `[Streaming] No usage data from provider, estimating: ~${estimatedOutputTokens} output tokens`
+                );
+                // Carry the previous context size forward rather than a literal
+                // 100 — the status line reads this value, and 100 would make the
+                // bar collapse to "empty" on any turn the provider skips usage.
+                onTokenUpdate(priorInputTokens || 100, estimatedOutputTokens);
+              }
+            }
+          } finally {
+            teardown();
           }
         };
 


### PR DESCRIPTION
Extracted from #142 by @jsboige, which found this but bundled it with changes we can't take. This is the fix on its own.

## The bug

`finalize()` sets its re-entry guard as the first thing it does:

```js
const finalize = async (reason, err) => {
  if (state.finalized) return;
  state.finalized = true;
  ...
```

but the teardown, `controller.close()` plus `clearInterval(ping)`, sat at the **end of the function body** rather than in a `finally`.

So anything that threw in between left the stream open. The outer catch called `finalize()` again, it returned immediately at the guard, and nothing ever closed the controller or cleared the keepalive interval. The client sat on an open HTTP 200 forever and the `setInterval` leaked.

Both call sites are one line apart, which is what makes it reachable:

```js
await finalize("unexpected");
} catch (e) {
  await finalize("error", String(e));
}
```

There are real throw sites inside the body. `gemini-sse` awaits `opts.middlewareManager.afterStreamComplete()`, which runs user middleware. All three call `onTokenUpdate`.

## The fix

A `teardown()` closure in each parser, called from a `finally`. A repeat `finalize()` call now also tears down, since the first call may have thrown before reaching its own `finally`.

`ollama-jsonl` had a worse variant. It used `isClosed` as **both** the re-entry guard and the closed flag, so a throw left `isClosed` false and the catch re-ran the whole body, emitting a second `message_delta` and `message_stop`. It now has a dedicated `finalized` flag.

## Tests

Each parser gets a throwing `onTokenUpdate` injected, then we assert the stream still terminates, the ping interval is cleared, and `ollama` emits exactly one `message_stop`. Real streams and real timers, no module mocking.

Verified they fail without the change:

```
(fail) openai-sse closes the stream and clears its ping when onTokenUpdate throws
(fail) gemini-sse closes the stream and clears its ping when onTokenUpdate throws
       Expected: false   Received: true      <- timedOut, i.e. the hang
(fail) ollama-jsonl closes the stream, clears its ping, and emits one message_stop
 88 pass, 3 fail
```

With the change: **91 pass, 0 fail.** `typecheck` clean, `lint` exit 0.

## Note on the diff size

461/260 looks large for a behavioural change of about 30 lines. Wrapping the existing body in `try {` reindents it, and `biome format` did the rest. `git diff -w` is much smaller.
