### PR TITLE
fix(transform): strip Claude Code's billing header so prefix caching survives

### DIFF
--- a/packages/cli/src/transform.test.ts
+++ b/packages/cli/src/transform.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { stripBillingHeader, transformOpenAIToClaude } from "./transform.js";
+
+const CAPTURED_BILLING_HEADER =
+  "x-anthropic-billing-header: cc_version=2.1.107.3d9; cc_entrypoint=cli; cch=74943;";
+const REAL_SYSTEM_CONTENT = "You are Claude Code, Anthropic's official CLI for Claude.";
+
+function capturedSystem(header = CAPTURED_BILLING_HEADER) {
+  return [
+    {
+      type: "text",
+      text: header,
+    },
+    {
+      type: "text",
+      text: REAL_SYSTEM_CONTENT,
+      cache_control: {
+        type: "ephemeral",
+      },
+    },
+  ];
+}
+
+describe("billing header removal", () => {
+  test("removes a header-only array block without leaving an empty string", () => {
+    const { claudeRequest } = transformOpenAIToClaude({
+      system: capturedSystem(),
+    });
+
+    expect(claudeRequest.system).not.toContain("x-anthropic-billing-header");
+    expect(claudeRequest.system).toBe(REAL_SYSTEM_CONTENT);
+    expect(claudeRequest.system.split("\n\n")).toEqual([REAL_SYSTEM_CONTENT]);
+  });
+
+  test("keeps req.system byte-identical across requests whose only difference is the per-turn cch hash", () => {
+    const firstRequest = {
+      system: capturedSystem(),
+    };
+    const secondRequest = {
+      system: capturedSystem(CAPTURED_BILLING_HEADER.replace("cch=74943", "cch=74944")),
+    };
+
+    const firstSystem = transformOpenAIToClaude(firstRequest).claudeRequest.system;
+    const secondSystem = transformOpenAIToClaude(secondRequest).claudeRequest.system;
+
+    expect(firstSystem).toBe(secondSystem);
+    expect(new TextEncoder().encode(firstSystem)).toEqual(new TextEncoder().encode(secondSystem));
+  });
+
+  test("strips an inline header from a string system while preserving surrounding lines", () => {
+    const system = `First system line\n${CAPTURED_BILLING_HEADER}\nLast system line`;
+
+    const { claudeRequest } = transformOpenAIToClaude({ system });
+
+    expect(claudeRequest.system).toBe("First system line\nLast system line");
+  });
+
+  test("passes a system with no billing header through completely unchanged", () => {
+    const system = "First line\n\nSecond line with punctuation: cc_version=unchanged;\n";
+
+    const { claudeRequest } = transformOpenAIToClaude({ system });
+
+    expect(claudeRequest.system).toBe(system);
+  });
+
+  test("strips a header at the end of content with no trailing newline", () => {
+    const system = `Stable system content\n${CAPTURED_BILLING_HEADER}`;
+
+    const { claudeRequest } = transformOpenAIToClaude({ system });
+
+    expect(claudeRequest.system).toBe("Stable system content\n");
+    expect(claudeRequest.system).not.toContain("x-anthropic-billing-header");
+  });
+
+  test("stripBillingHeader returns text with no header unchanged", () => {
+    const text = "System content without a billing header.\nPreserve this exactly.\n";
+
+    expect(stripBillingHeader(text)).toBe(text);
+  });
+});

--- a/packages/cli/src/transform.ts
+++ b/packages/cli/src/transform.ts
@@ -345,6 +345,35 @@ export function removeUriFormat(schema: any): any {
 }
 
 /**
+ * Claude Code prepends a billing header to the system prompt as its own text
+ * block:
+ *
+ *   x-anthropic-billing-header: cc_version=2.1.107.3d9; cc_entrypoint=cli; cch=74943;
+ *
+ * `cch=` is a PER-TURN hash, so the first bytes of a ~31k-token system prompt
+ * differ on every single request. Any backend doing prefix caching therefore
+ * re-reads the entire prefix each turn. @mtparet measured it against vLLM in
+ * #101: 48 tokens cached before, 31,728 after.
+ *
+ * Stripped HERE rather than in filterIdentity() because filterIdentity is only
+ * honoured by the OpenAI-shaped adapters and Gemini. AnthropicApiFormat ignores
+ * its filter argument entirely, and CodexAPIFormat assigns `system` straight to
+ * `payload.instructions` — so MiniMax, Kimi, GLM, Z.AI, vertex-anthropic, Codex
+ * and OllamaCloud would all keep leaking the hash.
+ *
+ * transformOpenAIToClaude runs once per ComposedHandler request and NEVER for
+ * NativeHandler, which is what makes this safe without an `instanceof` guard:
+ * native Anthropic traffic keeps the header, and Anthropic is the party the
+ * header is actually for.
+ */
+const BILLING_HEADER_RE = /x-anthropic-billing-header:[^\n]*\n?/gi;
+
+export function stripBillingHeader(text: string): string {
+  if (!text || !text.includes("x-anthropic-billing-header")) return text;
+  return text.replace(BILLING_HEADER_RE, "");
+}
+
+/**
  * Main transformation function from OpenAI to Claude format
  */
 export function transformOpenAIToClaude(claudeRequestInput: any): {
@@ -381,8 +410,14 @@ export function transformOpenAIToClaude(claudeRequestInput: any): {
         // Fallback
         return JSON.stringify(item);
       })
+      // Strip before the empty-filter below, so a block that held ONLY the
+      // billing header is dropped rather than left as an empty string. An
+      // empty text block is a 400 on Anthropic-compat endpoints.
+      .map((text: string) => stripBillingHeader(text))
       .filter((text: string) => text && text.trim() !== "")
       .join("\n\n");
+  } else if (typeof req.system === "string") {
+    req.system = stripBillingHeader(req.system);
   }
 
   if (!Array.isArray(req.messages)) {


### PR DESCRIPTION
Closes the bug reported independently by @mtparet in #101 and @jsboige in #126. Neither is on main, and both are right that it needs fixing.

## The bug

Claude Code prepends its billing header to the system prompt as its own text block. Real capture, already in this repo at `experiments/tool-replacement-proxy-2026-04/evidence/evidence-req-advisor-enabled.json`:

```json
"system": [
  { "type": "text", "text": "x-anthropic-billing-header: cc_version=2.1.107.3d9; cc_entrypoint=cli; cch=74943;" },
  ...
]
```

`cch=` is a **per-turn hash**. It sits at the head of a ~31k-token system prompt, so the first bytes differ on every single request and any backend doing prefix caching re-reads the entire prefix each turn.

@mtparet measured it against vLLM: **48 tokens cached before, 31,728 after.** That's the strongest evidence attached to either PR.

## Why here and not in `filterIdentity`

Both original PRs put the strip in `filterIdentity`. That only covers part of the fleet:

| Adapter | Honours `filterIdentityFn`? |
|---|---|
| OpenAI-shaped (`base-api-format.ts:526`) | yes |
| Gemini (`gemini-api-format.ts:202`) | yes, calls it directly |
| **AnthropicApiFormat** | **no** — ignores the argument |
| **CodexAPIFormat** | **no** — `payload.instructions = claudeRequest.system` |
| **OllamaCloud** | **no** |

So MiniMax, Kimi direct, GLM, Z.AI, vertex-anthropic, Codex and OllamaCloud would all keep leaking the hash. #101's own motivating model, `minimax-m2.5`, is in that set when routed through `mm@` rather than a custom vLLM endpoint. Tests would have been green and six providers would still be broken.

`transformOpenAIToClaude` runs once per ComposedHandler request (`composed-handler.ts:244`) and **never** for `NativeHandler`. That structure is what makes this safe without #126's `instanceof NativeHandler` guard, and native Anthropic traffic correctly keeps its header — Anthropic is who the header is for.

## Two details

**Delete, don't blank.** The strip runs before the existing empty-entry filter, so a block holding only the header is removed rather than left as `{type:"text", text:""}`. #126 blanked it, which is harmless today only by accident; an empty text block is a 400 on Anthropic-compat endpoints.

**Regex.** Uses @mtparet's `x-anthropic-billing-header:[^\n]*\n?` rather than #126's `cc_version=[^\n]*`, which assumes that token appears first in the header.

## Tests

New `packages/cli/src/transform.test.ts`, 6 tests. The load-bearing one asserts that two requests differing **only** in the `cch=` value produce byte-identical `req.system` — that's the actual point of the fix.

Verified against a neutered `stripBillingHeader`: **4 of 6 fail** without the change (the 2 that pass are the no-header negative cases, correct either way). With it: **6 pass, 0 fail.** `typecheck` clean, `lint` exit 0.

Fixture uses the real captured header, not an invented one.
