### PR TITLE
fix(routing): tolerate dash-slugified GLM version names on bare model specs

### DIFF
--- a/packages/cli/src/providers/routing-rules.test.ts
+++ b/packages/cli/src/providers/routing-rules.test.ts
@@ -23,7 +23,13 @@ import {
 import { DISPLAY_NAMES } from "./auto-route.js";
 import { _resetCatalogClient } from "./catalog-client.js";
 import { DEFAULT_ROUTING_RULES } from "./default-routing-rules.js";
-import { buildRoutingChain, matchRoutingRule, mergeRoutingRules, route } from "./routing-rules.js";
+import {
+  buildRoutingChain,
+  matchRoutingRule,
+  mergeRoutingRules,
+  normalizeGlmSlug,
+  route,
+} from "./routing-rules.js";
 
 const SYNTHETIC_MODEL_ID = "acme-x1.0";
 const SYNTHETIC_MINIMAX_EXTERNAL_ID = "ACME-X1.0";
@@ -458,6 +464,35 @@ describe("loadRoutingRules merges defaults", () => {
 });
 
 // ---------------------------------------------------------------------------
+// normalizeGlmSlug — bare-name GLM slug normalization
+// ---------------------------------------------------------------------------
+
+describe("normalizeGlmSlug", () => {
+  test("rewrites dash-slugified GLM versions to dotted canonical names", () => {
+    expect(normalizeGlmSlug("glm-5-2")).toBe("glm-5.2");
+    expect(normalizeGlmSlug("glm-4-6")).toBe("glm-4.6");
+    expect(normalizeGlmSlug("glm-4-5-air")).toBe("glm-4.5-air");
+    expect(normalizeGlmSlug("glm-4-5-airx")).toBe("glm-4.5-airx");
+  });
+
+  test("leaves already-dotted GLM names unchanged", () => {
+    expect(normalizeGlmSlug("glm-5.2")).toBe("glm-5.2");
+    expect(normalizeGlmSlug("glm-4.5-air")).toBe("glm-4.5-air");
+  });
+
+  test("leaves dash-native GLM ids unchanged", () => {
+    expect(normalizeGlmSlug("glm-4-9b")).toBe("glm-4-9b");
+    expect(normalizeGlmSlug("glm-4-flash")).toBe("glm-4-flash");
+  });
+
+  test("leaves unrelated model families unchanged", () => {
+    expect(normalizeGlmSlug("claude-opus-4-8")).toBe("claude-opus-4-8");
+    expect(normalizeGlmSlug("qwen3.6-35b-a3b")).toBe("qwen3.6-35b-a3b");
+    expect(normalizeGlmSlug("gpt-4o")).toBe("gpt-4o");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // route() — credential-aware single entry point
 // ---------------------------------------------------------------------------
 
@@ -482,6 +517,7 @@ const ENV_KEYS_TO_CLEAR = [
   "OLLAMA_API_KEY",
   "OPENCODE_API_KEY",
   "OPENCODE_GO_API_KEY",
+  "WINDSURF_API_KEY",
 ];
 
 const savedEnv: Record<string, string | undefined> = {};
@@ -519,6 +555,22 @@ describe("route()", () => {
     expect(plan.kind).toBe("ok");
     if (plan.kind !== "ok") return;
     expect(plan.primary.provider).toBe("native-anthropic");
+  });
+
+  test("bare glm-5-2 routes identically to canonical glm-5.2", async () => {
+    const rules: RoutingRules = { "glm-5.2": ["glm"] };
+    const dashPlan = await route("glm-5-2", rules);
+    const dottedPlan = await route("glm-5.2", rules);
+    expect(dashPlan).toEqual(dottedPlan);
+  });
+
+  test("explicit Devin dv@glm-5-2 preserves the dash-native uid without normalization", async () => {
+    process.env.WINDSURF_API_KEY = "devin-session-token$test";
+    const plan = await route("dv@glm-5-2", DEFAULT_ROUTING_RULES);
+    expect(plan.kind).toBe("ok");
+    if (plan.kind !== "ok") return;
+    expect(plan.primary.modelSpec).toBe("dv@glm-5-2");
+    expect(plan.primary.modelSpec).not.toBe("dv@glm-5.2");
   });
 
   test("claude-opus-4-7 with only OPENROUTER_API_KEY → primary openrouter", async () => {

--- a/packages/cli/src/providers/routing-rules.ts
+++ b/packages/cli/src/providers/routing-rules.ts
@@ -361,6 +361,41 @@ async function routeBare(
  * and `loadConfig()`) unless overrides are supplied. Tests should pass overrides
  * to avoid disk lookups.
  */
+/**
+ * Rewrite a dash-slugified GLM version to its canonical dotted form
+ * (`glm-5-2` → `glm-5.2`), so a client that slugifies dots still matches the
+ * routing rule instead of falling through to `defaultProvider`.
+ *
+ * Anchored and deliberately narrow. The second group must be ALL digits to the
+ * end (or to a `-suffix`), which is what keeps dash-native open-model ids
+ * intact: `glm-4-9b` and `glm-4-flash` are untouched because "9b" and "flash"
+ * are not pure digits.
+ *
+ * Applied ONLY on the bare-name path, to keep the rewrite's blast radius as
+ * small as the problem it solves.
+ *
+ * To be precise about why that is a choice and not a load-bearing guard:
+ * routeExplicit forwards the ORIGINAL `modelSpec` to buildRoutingChain, which
+ * re-parses it and takes the model from the entry itself, ignoring the `model`
+ * argument for any entry containing "@". So normalizing the explicit path would
+ * currently be a no-op rather than a bug. Restricting it here means that stays
+ * true even if buildRoutingChain's precedence ever changes.
+ *
+ * That matters because Devin re-serves other vendors' models under uids that
+ * legitimately contain dashes, `glm-5-2` and `glm-5-2-1m` among them (see
+ * providers/devin/model-id-resolver.ts). Those are matched against Devin's LIVE
+ * served set, so a `dv@glm-5-2` that ever became `dv@glm-5.2` would request a
+ * uid that does not exist. Bare names cannot reach Devin at all — it declares
+ * no nativeModelPatterns and has no DEFAULT_ROUTING_RULES entry — so the bare
+ * path is the only place this rewrite can apply and the only place it needs to.
+ */
+export function normalizeGlmSlug(model: string): string {
+  return model.replace(
+    /^glm-(\d+)-(\d+)(-.*)?$/i,
+    (_m, major, minor, suffix) => `glm-${major}.${minor}${suffix ?? ""}`
+  );
+}
+
 export async function route(
   modelSpec: string,
   rulesOverride?: RoutingRules,
@@ -370,6 +405,7 @@ export async function route(
   const parsed = parseModelSpec(modelSpec);
 
   if (parsed.isExplicitProvider) {
+    // Not normalized here — see normalizeGlmSlug's note on explicit specs.
     return routeExplicit(modelSpec, parsed.model, parsed.provider, cachePath);
   }
 
@@ -384,7 +420,13 @@ export async function route(
       : rulesOverride !== undefined
         ? undefined
         : loadConfig().defaultProvider;
-  return routeBare(parsed.model, parsed.provider, rules, defaultProvider, cachePath);
+  return routeBare(
+    normalizeGlmSlug(parsed.model),
+    parsed.provider,
+    rules,
+    defaultProvider,
+    cachePath
+  );
 }
 
 // route() is now async; routeBare returns a Promise which is awaited by the caller.


### PR DESCRIPTION
Extracted from #142 by @jsboige. Same regex, narrower application.

## Problem

A client that slugifies dots sends `glm-5-2` instead of `glm-5.2`. That matches no routing rule, so it falls through to `defaultProvider` rather than the GLM chain.

## The regex

```js
/^glm-(\d+)-(\d+)(-.*)?$/i
```

Anchored, and the second group must be **all digits** through to the end or to a `-suffix`. That's what leaves dash-native open-model ids alone:

| input | output |
|---|---|
| `glm-5-2` | `glm-5.2` |
| `glm-4-5-air` | `glm-4.5-air` |
| `glm-4-9b` | unchanged ("9b" isn't pure digits) |
| `glm-4-flash` | unchanged |
| `claude-opus-4-8` | unchanged |

## Bare path only, and an honest note about why

#142 applied this to `parsed.model` before both `routeExplicit` and `routeBare`. I started out thinking that was a Devin bug, since Devin serves dash-native uids like `glm-5-2` and `glm-5-2-1m` (`providers/devin/model-id-resolver.ts:15`) matched against its live served set, so `dv@glm-5-2` becoming `dv@glm-5.2` would request a uid that doesn't exist.

**I was wrong, and a mutation test caught me.** I deliberately re-added the normalization to the explicit path expecting a red test, and got 61 pass. The reason is `buildRoutingChain` (`routing-rules.ts:126-128`): for any entry containing `@` it re-parses the entry and takes the model from there, ignoring the `originalModelName` argument. `routeExplicit` forwards the untouched `modelSpec`, so normalizing its `model` argument is a no-op.

So #142's version was safe. I'm still keeping it to the bare path, but as blast-radius reduction rather than a bug fix: it stays a no-op even if `buildRoutingChain`'s precedence changes later. The comment in the source says exactly this rather than claiming a guard it doesn't provide.

## Tests

6 added to the existing `routing-rules.test.ts`. Mutation-checked both ways:

- Removing the normalize from `routeBare` → **`bare glm-5-2 routes identically to canonical glm-5.2` fails.** Real guard.
- Adding it to `routeExplicit` → all tests still pass. So the `dv@glm-5-2` test pins a genuine end-to-end invariant, but it does **not** discriminate between this implementation and #142's. Flagging that rather than overselling it.

61 pass, 0 fail. `typecheck` clean.
