### PR TITLE
chore: restore the .claudemem/ ignore rule and collapse claudeup's duplicate headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,21 +90,6 @@ gtd/sessions/
 .agents/
 
 # Added by claudeup
-# Local claudemem indexes are generated from the repo and should not be committed.
-
-# Added by claudeup
-# Local claudemem indexes are generated from the repo and should not be committed.
-
-# Added by claudeup
-# Local claudemem indexes are generated from the repo and should not be committed.
-
-# Added by claudeup
-# Local claudemem indexes are generated from the repo and should not be committed.
-
-# Added by claudeup
-# Local claudemem indexes are generated from the repo and should not be committed.
-
-# Added by claudeup
 # A managed rule says this path should stay tracked in git.
 !/.claude/
 !/.claude/profiles.json
@@ -115,15 +100,10 @@ gtd/sessions/
 # Claude cache contents are local generated data and can grow quickly.
 .claude/cache/
 # Local claudemem indexes are generated from the repo and should not be committed.
+.claudemem/
 
 # Added by claudeup
 # Team MCP configuration should be committed so shared tools are discoverable.
 !/.mcp.json
 /.claude/.coaching
 /.claude/gtd
-
-# Added by claudeup
-# Local claudemem indexes are generated from the repo and should not be committed.
-
-# Added by claudeup
-# Local claudemem indexes are generated from the repo and should not be committed.


### PR DESCRIPTION
`.gitignore` had accumulated **ten** `# Added by claudeup` blocks. Seven were a header plus a comment and **no rule at all**, and the rule that comment describes, `.claudemem/`, was missing entirely. So locally generated claudemem indexes have been committable.

```
$ git show origin/main:.gitignore | grep -c 'Added by claudeup'   # 10
$ git show origin/main:.gitignore | grep -c 'claudemem/'          # 0
```

Restores `.claudemem/` under the managed-rules block where its comment already lived, and drops the seven empty blocks plus one orphaned comment line.

**Nothing real is removed.** Every deleted line is a comment or a blank:

```
$ git diff .gitignore | grep '^-' | grep -v '^---' | grep -v '^-#' | grep -v '^-$'
(no output)
```

The three remaining claudeup blocks all carry real rules and are untouched.

Worth chasing upstream: claudeup appends its header on every run without noticing the previous one, which is how ten accumulated. Whatever writes the `.claudemem/` line also stopped writing it while continuing to write its comment, so the two halves have drifted apart. Until that's fixed this will slowly regrow.

Found while doing worktree housekeeping — the line kept reappearing as modified across five branch operations, which is what prompted looking at it properly.