### PR TITLE
fix(session): don't print the previous session's cost when a run dies early

### DIFF
--- a/packages/cli/src/session/session-stats.test.ts
+++ b/packages/cli/src/session/session-stats.test.ts
@@ -43,19 +43,19 @@ function writeTokenFile(overrides: Record<string, unknown> = {}): void {
 
 describe("readSessionStats", () => {
   test("returns null for a missing, unparseable, or tokenless file", () => {
-    expect(readSessionStats(65_000)).toBeNull();
+    expect(readSessionStats(65_000, { processStartMs: 0 })).toBeNull();
 
     writeFileSync(tokenFile, "not json");
-    expect(readSessionStats(65_000)).toBeNull();
+    expect(readSessionStats(65_000, { processStartMs: 0 })).toBeNull();
 
     writeTokenFile({ input_tokens: 0, output_tokens: 0, total_tokens: 0 });
-    expect(readSessionStats(65_000)).toBeNull();
+    expect(readSessionStats(65_000, { processStartMs: 0 })).toBeNull();
   });
 
   test("treats the literal unknown context window as unavailable, not NaN", () => {
     writeTokenFile({ context_window: "unknown" });
 
-    const stats = readSessionStats(65_000);
+    const stats = readSessionStats(65_000, { processStartMs: 0 });
     expect(stats?.contextWindow).toBeNull();
     expect(stats?.contextUsed).toBeNull();
   });
@@ -63,7 +63,7 @@ describe("readSessionStats", () => {
   test("never reports a negative duration when timestamps are equal or reversed", () => {
     for (const updatedAt of [1_000, 999]) {
       writeTokenFile({ started_at: 1_000, updated_at: updatedAt });
-      expect(readSessionStats(65_000)?.durationMs).toBe(0);
+      expect(readSessionStats(65_000, { processStartMs: 0 })?.durationMs).toBe(0);
     }
   });
 
@@ -77,7 +77,7 @@ describe("readSessionStats", () => {
       output_per_m: 1,
     });
 
-    const stats = readSessionStats(65_000)!;
+    const stats = readSessionStats(65_000, { processStartMs: 0 })!;
     expect(stats.inputCostUsd + stats.outputCostUsd).toBeCloseTo(stats.costUsd, 12);
     expect(stats.inputCostUsd).toBeCloseTo(3.5, 12);
     expect(stats.outputCostUsd).toBeCloseTo(3.5, 12);
@@ -85,22 +85,22 @@ describe("readSessionStats", () => {
 
   test("uses a zero cost split when rates are absent or the billed cost is zero", () => {
     writeTokenFile({ input_per_m: undefined, output_per_m: undefined, total_cost: 4 });
-    let stats = readSessionStats(65_000)!;
+    let stats = readSessionStats(65_000, { processStartMs: 0 })!;
     expect(stats.inputCostUsd).toBe(0);
     expect(stats.outputCostUsd).toBe(0);
 
     writeTokenFile({ total_cost: 0, input_per_m: 2, output_per_m: 10 });
-    stats = readSessionStats(65_000)!;
+    stats = readSessionStats(65_000, { processStartMs: 0 })!;
     expect(stats.inputCostUsd).toBe(0);
     expect(stats.outputCostUsd).toBe(0);
   });
 
   test("prefers billed input tokens and falls back for older token files", () => {
     writeTokenFile({ input_tokens: 10_000, billed_input_tokens: 90_000 });
-    expect(readSessionStats(65_000)?.billedInputTokens).toBe(90_000);
+    expect(readSessionStats(65_000, { processStartMs: 0 })?.billedInputTokens).toBe(90_000);
 
     writeTokenFile({ input_tokens: 10_000 });
-    expect(readSessionStats(65_000)?.billedInputTokens).toBe(10_000);
+    expect(readSessionStats(65_000, { processStartMs: 0 })?.billedInputTokens).toBe(10_000);
   });
 
   test("computes savings from cumulative billed input, not the final context size", () => {
@@ -114,7 +114,7 @@ describe("readSessionStats", () => {
       total_cost: 0.25,
     });
 
-    const stats = readSessionStats(65_000)!;
+    const stats = readSessionStats(65_000, { processStartMs: 0 })!;
     if (stats.savings.length === 0) return;
 
     const billedBasis = computeSavings(billedInput, output, stats.costUsd);
@@ -141,12 +141,48 @@ describe("readSessionStats", () => {
       ],
     });
 
-    const stats = readSessionStats(65_000)!;
+    const stats = readSessionStats(65_000, { processStartMs: 0 })!;
     expect(stats.toolCalls).toEqual([
       { name: "Read", count: 3 },
       { name: "Write", count: 2 },
     ]);
     expect(stats.toolCallTotal).toBe(5);
+  });
+
+  test("rejects a stale token file from a previous session on the reused port", () => {
+    writeTokenFile({ started_at: 999 });
+
+    expect(readSessionStats(65_000, { processStartMs: 1_000 })).toBeNull();
+  });
+
+  test("returns stats when the token file started at or after this process", () => {
+    writeTokenFile({ started_at: 1_000 });
+
+    const stats = readSessionStats(65_000, { processStartMs: 1_000 });
+    expect(stats?.totalTokens).toBe(120_000);
+  });
+
+  test("returns null when the token file has no started_at", () => {
+    writeTokenFile({ started_at: undefined });
+
+    expect(readSessionStats(65_000, { processStartMs: 0 })).toBeNull();
+  });
+
+  test("returns null when the token file has started_at zero", () => {
+    writeTokenFile({ started_at: 0 });
+
+    expect(readSessionStats(65_000, { processStartMs: 0 })).toBeNull();
+  });
+
+  test("rejects a populated stale token file before accepting its real tokens", () => {
+    writeTokenFile({
+      started_at: 999,
+      input_tokens: 250_000,
+      output_tokens: 50_000,
+      total_tokens: 300_000,
+    });
+
+    expect(readSessionStats(65_000, { processStartMs: 1_000 })).toBeNull();
   });
 });
 

--- a/packages/cli/src/session/session-stats.ts
+++ b/packages/cli/src/session/session-stats.ts
@@ -87,7 +87,10 @@ const num = (v: unknown): number => (typeof v === "number" && Number.isFinite(v)
  * records no tokens at all. The caller prints no panel in that case, which is correct:
  * a summary of a session that never ran is noise, not information.
  */
-export function readSessionStats(port: number): SessionStats | null {
+export function readSessionStats(
+  port: number,
+  opts?: { readonly processStartMs?: number }
+): SessionStats | null {
   let raw: unknown;
   try {
     raw = JSON.parse(readFileSync(tokenFilePath(port), "utf-8"));
@@ -96,6 +99,25 @@ export function readSessionStats(port: number): SessionStats | null {
   }
   if (!raw || typeof raw !== "object") return null;
   const d = raw as Record<string, unknown>;
+
+  // Freshness gate — the token file is keyed by PORT, and a port is reusable.
+  //
+  // TokenTracker never truncates or pre-creates the file; its only write happens
+  // on a response (token-tracker.ts:382). findAvailablePort() scans from the
+  // bottom of the range, so two back-to-back runs on an idle machine land on the
+  // same port and therefore the same path. Without this check, a run that died
+  // before its first response — bad key, 400, crash — renders the PREVIOUS
+  // session's tokens, cost, savings and duration as its own, and index.ts then
+  // derives a resume id from that stale window.
+  //
+  // `started_at` is stamped when the tracker is constructed (token-tracker.ts:82),
+  // which is necessarily after this process began. So a value earlier than our own
+  // start belongs to somebody else. A file with no `started_at` predates that field
+  // and cannot be dated, and an undatable summary is exactly the one worth
+  // suppressing — a missing panel is cheaper than a confidently wrong one.
+  const processStartMs = opts?.processStartMs ?? Date.now() - Math.round(process.uptime() * 1000);
+  const trackerStartedAt = num(d.started_at);
+  if (trackerStartedAt <= 0 || trackerStartedAt < processStartMs) return null;
 
   const inputTokens = num(d.input_tokens);
   const outputTokens = num(d.output_tokens);


### PR DESCRIPTION
The token file is keyed by **port**, and ports get reused.

`TokenTracker` never truncates or pre-creates it — the only write happens on a response (`token-tracker.ts:382`) — and `findAvailablePort()` (`index.ts:810`) scans from the bottom of the range, so two back-to-back runs on an idle machine land on the same port and therefore the same path.

So a run that died before its first response (bad key, 400, crash) read the **previous** session's file and rendered its tokens, cost, savings and duration as its own. `index.ts:952` then derived a resume id from that stale window via `findLatestSessionId(cwd, Date.now() - stats.durationMs)`.

## The gate

`readSessionStats` now checks `started_at`, which `TokenTracker` stamps at construction (`token-tracker.ts:82`) and therefore always sits at or after this process's start. Anything earlier belongs to another run.

A file with **no** `started_at` cannot be dated at all, and an undatable summary is the one most worth suppressing — a missing panel is cheaper than a confidently wrong one.

The comparison point is injectable (`opts.processStartMs`) so tests stay hermetic instead of racing the wall clock; the default derives from `process.uptime()`.

## Tests

Existing tests keep every assertion and now pass an explicit `processStartMs`. Five new cases: stale, fresh, absent `started_at`, zero `started_at`, and the ordering guarantee that a stale file **with real tokens** still cannot leak through.

Mutation-checked — with the gate removed, 4 of the 5 fail:

```
(fail) rejects a stale token file from a previous session on the reused port
(fail) returns null when the token file has no started_at
(fail) returns null when the token file has started_at zero
(fail) rejects a populated stale token file before accepting its real tokens
```

60 pass / 0 fail across `session/`. `typecheck` clean.

## Not included: the `a`/`v` filter keys

I found the other half of this while reviewing #158 — `resume-picker.tsx:1140` excludes both `a` and `v` from filter input because each is a single-letter shortcut, so filtering for `main`, `canary`, `claudish` silently drops characters.

Leaving it alone: the comment above it weighs that cost explicitly and accepts it, which makes it a design decision rather than a defect. Raising it separately instead of reversing it in a bug-fix PR.