### PR TITLE
fix(anthropic-sse): emit the terminal tail when upstream abandons a stream

### DIFF
--- a/packages/cli/src/format-translation.test.ts
+++ b/packages/cli/src/format-translation.test.ts
@@ -319,6 +319,233 @@ describe("Anthropic SSE Passthrough (createAnthropicPassthroughStream)", () => {
   });
 });
 
+describe("Regression: Anthropic SSE abandoned streams emit a terminal tail", () => {
+  const encoder = new TextEncoder();
+
+  async function getParser() {
+    const mod = await import("./handlers/shared/stream-parsers/anthropic-sse.js");
+    return mod.createAnthropicPassthroughStream;
+  }
+
+  function frame(event: string, data: unknown): string {
+    return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  }
+
+  function messageStart(model = "test-model"): string {
+    return frame("message_start", {
+      type: "message_start",
+      message: {
+        id: "msg_test",
+        type: "message",
+        role: "assistant",
+        content: [],
+        model,
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 12, output_tokens: 0 },
+      },
+    });
+  }
+
+  function responseThatDrops(frames: string[]): Response {
+    let nextFrame = 0;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const emitNext = () => {
+          if (nextFrame < frames.length) {
+            controller.enqueue(encoder.encode(frames[nextFrame++]));
+            timer = setTimeout(emitNext, 0);
+            return;
+          }
+          timer = setTimeout(() => controller.error(new Error("upstream socket closed")), 0);
+        };
+
+        emitNext();
+      },
+      cancel() {
+        if (timer) clearTimeout(timer);
+      },
+    });
+
+    return new Response(stream, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    });
+  }
+
+  test("mid-stream socket close preserves partial text, emits message_stop, and terminates", async () => {
+    const createAnthropicPassthroughStream = await getParser();
+    const fixture = responseThatDrops([
+      messageStart(),
+      frame("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      frame("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "partial " },
+      }),
+      frame("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "answer" },
+      }),
+    ]);
+    let turnEndCalls = 0;
+    let tokenUpdate: [number, number] | null = null as [number, number] | null;
+
+    const response = createAnthropicPassthroughStream(createMockContext(), fixture, {
+      modelName: "test-model",
+      onTurnEnd: () => {
+        turnEndCalls++;
+      },
+      onTokenUpdate: (input, output) => {
+        tokenUpdate = [input, output];
+      },
+    });
+
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const events = await Promise.race([
+        parseClaudeSseStream(response),
+        new Promise<never>((_, reject) => {
+          timeout = setTimeout(() => reject(new Error("abandoned stream did not terminate")), 500);
+        }),
+      ]);
+
+      expect(extractText(events)).toBe("partial answer");
+      expect(events.some((event) => event.data?.type === "message_stop")).toBe(true);
+      expect(turnEndCalls).toBe(1);
+      expect(tokenUpdate).toEqual([12, 0]);
+    } finally {
+      if (timeout) clearTimeout(timeout);
+    }
+  });
+
+  test("healthy stream remains byte-identical with one message_delta and one message_stop", async () => {
+    const createAnthropicPassthroughStream = await getParser();
+    const healthyStream = [
+      messageStart(),
+      frame("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      }),
+      frame("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "complete" },
+      }),
+      frame("content_block_stop", { type: "content_block_stop", index: 0 }),
+      frame("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 1 },
+      }),
+      frame("message_stop", { type: "message_stop" }),
+    ].join("");
+
+    const response = createAnthropicPassthroughStream(
+      createMockContext(),
+      new Response(healthyStream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      }),
+      { modelName: "test-model" }
+    );
+    const output = await response.text();
+    const initialPing = 'event: ping\ndata: {"type":"ping"}\n\n';
+
+    expect(output).toBe(`${initialPing}${healthyStream}`);
+
+    const events = await parseClaudeSseStream(new Response(output));
+    expect(events.filter((event) => event.data?.type === "message_delta")).toHaveLength(1);
+    expect(events.filter((event) => event.data?.type === "message_stop")).toHaveLength(1);
+  });
+
+  test("synthetic tail honors an upstream tool_use stop reason", async () => {
+    const createAnthropicPassthroughStream = await getParser();
+    const fixture = responseThatDrops([
+      messageStart(),
+      frame("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "tool_use", stop_sequence: null },
+        usage: { output_tokens: 4 },
+      }),
+    ]);
+    const response = createAnthropicPassthroughStream(createMockContext(), fixture, {
+      modelName: "test-model",
+    });
+
+    const events = await parseClaudeSseStream(response);
+    const messageDeltas = events.filter((event) => event.data?.type === "message_delta");
+
+    expect(messageDeltas).toHaveLength(2);
+    expect(messageDeltas.at(-1)?.data?.delta?.stop_reason).toBe("tool_use");
+  });
+
+  test("synthetic tail closes an open content block before message_stop", async () => {
+    const createAnthropicPassthroughStream = await getParser();
+    const fixture = responseThatDrops([
+      messageStart(),
+      frame("content_block_start", {
+        type: "content_block_start",
+        index: 3,
+        content_block: { type: "text", text: "" },
+      }),
+    ]);
+    const response = createAnthropicPassthroughStream(createMockContext(), fixture, {
+      modelName: "test-model",
+    });
+
+    const events = await parseClaudeSseStream(response);
+    const blockStopIndex = events.findIndex(
+      (event) => event.data?.type === "content_block_stop" && event.data?.index === 3
+    );
+    const messageStopIndex = events.findIndex((event) => event.data?.type === "message_stop");
+
+    expect(blockStopIndex).toBeGreaterThan(-1);
+    expect(messageStopIndex).toBeGreaterThan(blockStopIndex);
+  });
+
+  test("drop before message_start produces a complete parseable synthetic turn", async () => {
+    const createAnthropicPassthroughStream = await getParser();
+    const response = createAnthropicPassthroughStream(createMockContext(), responseThatDrops([]), {
+      modelName: "test-model",
+    });
+
+    const events = await parseClaudeSseStream(response);
+
+    expect(events.find((event) => event.data?.type === "message_start")?.data?.message?.model).toBe(
+      "test-model"
+    );
+    expect(events.some((event) => event.data?.type === "message_delta")).toBe(true);
+    expect(events.some((event) => event.data?.type === "message_stop")).toBe(true);
+  });
+
+  test("synthetic frames remain valid JSON when modelName contains a quote and backslash", async () => {
+    const createAnthropicPassthroughStream = await getParser();
+    const modelName = 'provider/model"quoted\\path';
+    const response = createAnthropicPassthroughStream(createMockContext(), responseThatDrops([]), {
+      modelName,
+    });
+
+    const output = await response.text();
+    const dataLines = output
+      .split("\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => line.slice(6));
+    const parsed = dataLines.map((line) => JSON.parse(line));
+
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(parsed.find((data) => data.type === "message_start")?.message?.model).toBe(modelName);
+  });
+});
+
 // ─── Adapter Message Conversion Tests ───────────────────────────────────────
 
 describe("Adapter: convertMessagesToOpenAI", () => {

--- a/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/anthropic-sse.ts
@@ -174,6 +174,48 @@ export function createAnthropicPassthroughStream(
    */
   let pendingEventLine: string | null = null;
 
+  // ── terminal-event bookkeeping ────────────────────────────────────────────
+  // Scoped here rather than inside start()'s try block, because the catch has to
+  // be able to FINISH a turn the upstream abandoned, and everything it needs to
+  // do that used to live where it could not reach it. One instance per request:
+  // createAnthropicPassthroughStream is called per request.
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let stopReason: string | null = null;
+  /** Upstream opened the message. If not, a synthetic close needs its own message_start. */
+  let sawMessageStart = false;
+  /** Upstream already closed the message — never emit a second terminal pair. */
+  let sawMessageStop = false;
+  /** EMITTED index (post thinking-block renumbering) of an open content block, else null. */
+  let openBlockIndex: number | null = null;
+
+  /**
+   * Record just enough of the message lifecycle to close the turn honestly.
+   *
+   * Called from every site that emits a data frame — there are three, because the
+   * thinking filter's renumbering path enqueues directly rather than through
+   * `enqueueData`. `emittedIndex` is the index as the CLIENT sees it, which is why
+   * it is passed in rather than read off `data`.
+   */
+  const noteLifecycle = (data: any, emittedIndex: number | null): void => {
+    switch (data?.type) {
+      case "message_start":
+        sawMessageStart = true;
+        break;
+      case "message_stop":
+        sawMessageStop = true;
+        break;
+      case "content_block_start":
+        if (emittedIndex !== null) openBlockIndex = emittedIndex;
+        break;
+      case "content_block_stop":
+        openBlockIndex = null;
+        break;
+      default:
+        break;
+    }
+  };
+
   /** Emit a held `event:` line. Call immediately before emitting its data line. */
   const flushPendingEvent = (controller: any): void => {
     if (pendingEventLine !== null && !isClosed) {
@@ -194,6 +236,66 @@ export function createAnthropicPassthroughStream(
     }
     flushPendingEvent(controller);
     controller.enqueue(encoder.encode(out));
+    noteLifecycle(data, typeof data?.index === "number" ? data.index : null);
+  };
+
+  /**
+   * Close a turn the upstream abandoned.
+   *
+   * Anthropic's contract is that a message ends with `message_delta` + `message_stop`.
+   * When the socket drops mid-answer the proxy used to just close the controller, so
+   * Claude Code received a stream that stopped without ever ending and sat on the turn
+   * forever. This emits the missing tail.
+   *
+   * Everything is built with JSON.stringify rather than string interpolation: custom
+   * endpoints allow arbitrary model names, and one quote or backslash in a hand-built
+   * literal produces JSON the client cannot parse — which would turn a recoverable
+   * truncation into a hard failure.
+   *
+   * `stopReason` is the value upstream actually reported, falling back to a DERIVED one
+   * rather than a hardcoded "end_turn": a turn that lost only its terminal frames may
+   * still have delivered a complete tool_use block, and reporting "end_turn" there makes
+   * the client discard the tool call.
+   */
+  const finalizeAbandonedStream = (controller: any): void => {
+    if (isClosed || sawMessageStop) return;
+    const send = (event: string, data: unknown): void => {
+      controller.enqueue(encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`));
+    };
+    try {
+      if (!sawMessageStart) {
+        send("message_start", {
+          type: "message_start",
+          message: {
+            id: `msg_${Date.now()}`,
+            type: "message",
+            role: "assistant",
+            content: [],
+            model: opts.modelName,
+            stop_reason: null,
+            stop_sequence: null,
+            usage: { input_tokens: inputTokens, output_tokens: outputTokens },
+          },
+        });
+      }
+      if (openBlockIndex !== null) {
+        send("content_block_stop", { type: "content_block_stop", index: openBlockIndex });
+        openBlockIndex = null;
+      }
+      send("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: stopReason ?? "end_turn", stop_sequence: null },
+        usage: {
+          ...(inputTokens > 0 ? { input_tokens: inputTokens } : {}),
+          output_tokens: outputTokens,
+        },
+      });
+      send("message_stop", { type: "message_stop" });
+      sawMessageStop = true;
+    } catch {
+      // The controller may already be errored by whatever aborted the stream.
+      // Failing to emit the tail must not mask the original error.
+    }
   };
 
   return c.body(
@@ -216,13 +318,10 @@ export function createAnthropicPassthroughStream(
         try {
           const reader = response.body!.getReader();
           let buffer = "";
-          let inputTokens = 0;
-          let outputTokens = 0;
 
           let totalLines = 0;
           let textChunks = 0;
           let toolUseBlocks = 0;
-          let stopReason: string | null = null;
 
           // Thinking-block filtering state
           let insideThinkingBlock = false;
@@ -314,6 +413,10 @@ export function createAnthropicPassthroughStream(
                     if (!isClosed) {
                       flushPendingEvent(controller);
                       controller.enqueue(encoder.encode(`${modifiedLine}\n`));
+                      // Third emit site — enqueued directly rather than through
+                      // enqueueData, so lifecycle has to be recorded here too, and
+                      // with the RENUMBERED index the client actually received.
+                      noteLifecycle(data, reindexed);
                     }
 
                     // Still do usage tracking below with the ORIGINAL data
@@ -471,6 +574,18 @@ export function createAnthropicPassthroughStream(
           }
         } catch (e) {
           log(`[AnthropicSSE] Stream error: ${e}`);
+          // The upstream socket dropped mid-answer (Z.AI, MiniMax and Kimi all do
+          // this under load). Closing the controller here without a terminal event
+          // handed Claude Code a stream that stopped but never ended, and the turn
+          // hung. Emit the tail first, then close, and still run the turn-end hooks
+          // so Layer 4 and the token file see a completed turn rather than nothing.
+          finalizeAbandonedStream(controller);
+          try {
+            opts.onTurnEnd?.();
+          } catch {}
+          try {
+            opts.onTokenUpdate?.(inputTokens, outputTokens);
+          } catch {}
           if (!isClosed) {
             isClosed = true;
             if (pingInterval) {


### PR DESCRIPTION
Reported by @jsboige in #143. Same diagnosis, different implementation — see below.

## The bug

`anthropic-sse.ts`'s catch block closed the controller with **no terminal event**:

```js
} catch (e) {
  log(`[AnthropicSSE] Stream error: ${e}`);
  if (!isClosed) { isClosed = true; ...; controller.close(); }
}
```

Anthropic's contract is that a message ends with `message_delta` + `message_stop`. Without them Claude Code receives a stream that **stopped but never ended**, and sits on the turn forever. Z.AI, MiniMax and Kimi all drop the socket mid-answer under load.

Unlike the other parsers (fixed in #166), this one had no `finalize` at all.

## Three things done differently from #143

**1. `JSON.stringify`, not string interpolation.** #143 built the synthetic `message_start` by interpolating `${opts.modelName}` into a hand-written JSON literal. Custom endpoints allow arbitrary model names, so one quote or backslash produces JSON the client cannot parse — turning a recoverable truncation into a hard failure. Pinned by a test that puts both characters in `modelName`.

**2. Real `stop_reason`, not hardcoded `end_turn`.** #143, #133 and #127 all hardcoded it. A turn that lost only its terminal frames may still have delivered a complete `tool_use` block, and reporting `end_turn` makes the client discard the tool call. This uses what upstream reported and derives only as a fallback.

**3. The turn-end hooks still run.** #143 returned early past `onTurnEnd`/`onTokenUpdate`, so Layer 4's `finishTurn()` never fired and partial usage never reached the token file — trading a hang for a quieter leak.

## One subtlety worth flagging in review

`noteLifecycle()` is called from **all three** sites that emit a data frame, not just `enqueueData`. The thinking filter's renumbering path (`anthropic-sse.ts`, the `thinkingBlocksSuppressed` branch) enqueues directly, and it passes the **renumbered** index — so a synthetic `content_block_stop` names the block the client actually opened, not the one upstream sent.

Lifecycle state moved to the per-request closure scope because the catch could not otherwise reach it. `createAnthropicPassthroughStream` is called once per request, so this is not shared across turns.

## Tests

Six, in `format-translation.test.ts`. Mutation-checked — with `finalizeAbandonedStream` removed, **5 of 6 fail**:

```
(fail) mid-stream socket close preserves partial text, emits message_stop, and terminates
(fail) synthetic tail honors an upstream tool_use stop reason
(fail) synthetic tail closes an open content block before message_stop
(fail) drop before message_start produces a complete parseable synthetic turn
(fail) synthetic frames remain valid JSON when modelName contains a quote and backslash
```

The sixth — *healthy stream remains byte-identical with one terminal pair* — passes either way **by design**. It's the regression guard proving normal traffic is untouched, which is the property that matters most for a byte-level passthrough.

337 pass / 0 fail across `handlers/`. `typecheck` clean, `lint` exit 0.