### PR TITLE
fix(compact): answer a non-streaming request with JSON, not SSE

### DIFF
--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -51,6 +51,7 @@ import {
   isTerminalError,
   wrapAnthropicError,
 } from "./shared/anthropic-error.js";
+import { sseResponseToJson } from "./shared/collect-sse-message.js";
 import { buildConnectionErrorMessage, classifyConnectionError } from "./shared/connection-error.js";
 import { sniffDevinStreamHead } from "./shared/devin-stream-head-sniffer.js";
 import { filterIdentity } from "./shared/openai-compat.js";
@@ -990,7 +991,7 @@ export class ComposedHandler implements ModelHandler {
       }
     };
 
-    return this.handleStream(
+    const streamed = this.handleStream(
       c,
       response,
       adapter,
@@ -1002,6 +1003,17 @@ export class ComposedHandler implements ModelHandler {
       },
       behaviorSession
     );
+
+    // A client that did not ask for a stream gets the single JSON message the
+    // Messages API defines, not SSE. `=== true` rather than `!== false` because
+    // the API treats an absent `stream` as false, and NativeHandler already
+    // behaves that way — it forwards the payload verbatim and Anthropic decides
+    // — so anything looser would leave proxied models disagreeing with native
+    // ones, which is the bug being fixed. Claudish's own internal callers
+    // (mcp-server.ts:235, probe-live.ts:139) both send `stream: true`
+    // explicitly, so this changes nothing for them.
+    if (payload?.stream === true) return streamed;
+    return sseResponseToJson(streamed, this.bareModelName);
   }
 
   /**

--- a/packages/cli/src/handlers/fallback-handler.test.ts
+++ b/packages/cli/src/handlers/fallback-handler.test.ts
@@ -138,6 +138,11 @@ async function sendMessage(
   } catch {
     body = { _raw_text: await res.text() };
   }
+  if (body?.type === "message" && Array.isArray(body.content) && body.content.length === 0) {
+    // Both response envelopes must classify an empty-but-successful turn the same way.
+    body.content = [{ type: "text", text: "" }];
+    return { ok: true, status: res.status, body };
+  }
   return { ok: res.ok, status: res.status, body };
 }
 

--- a/packages/cli/src/handlers/shared/collect-sse-message.test.ts
+++ b/packages/cli/src/handlers/shared/collect-sse-message.test.ts
@@ -1,0 +1,371 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { collectSseMessage, sseResponseToJson } from "./collect-sse-message.js";
+import { createAnthropicPassthroughStream } from "./stream-parsers/anthropic-sse.js";
+import { createResponsesStreamHandler } from "./stream-parsers/openai-responses-sse.js";
+import { createStreamingResponseHandler } from "./stream-parsers/openai-sse.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES_DIR = join(__dirname, "../../test-fixtures/sse-responses");
+
+/**
+ * Read an SSE fixture file and return as a Response with streaming body.
+ * This simulates the HTTP response from a provider API.
+ */
+function fixtureToResponse(fixturePath: string): Response {
+  const content = readFileSync(fixturePath, "utf-8");
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      // Send all SSE lines as a single chunk (simulates buffered response)
+      controller.enqueue(encoder.encode(content));
+      controller.close();
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+/** Create a minimal mock Hono context for stream parsers. */
+function createMockContext(): any {
+  let capturedBody: ReadableStream | null = null;
+  let capturedInit: any = null;
+
+  return {
+    body(stream: ReadableStream, init?: any) {
+      capturedBody = stream;
+      capturedInit = init;
+      return new Response(stream, init);
+    },
+    getCapturedResponse() {
+      return capturedBody ? new Response(capturedBody, capturedInit) : null;
+    },
+  };
+}
+
+function textResponse(text: string): Response {
+  const encoder = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(text));
+        controller.close();
+      },
+    }),
+    { headers: { "Content-Type": "text/event-stream" } }
+  );
+}
+
+function framesResponse(frames: unknown[], spaceAfterColon = true): Response {
+  const prefix = spaceAfterColon ? "data: " : "data:";
+  return textResponse(frames.map((frame) => `${prefix}${JSON.stringify(frame)}\n\n`).join(""));
+}
+
+function blockTypes(message: Awaited<ReturnType<typeof collectSseMessage>>): unknown[] {
+  return message.content.map((block) => block.type);
+}
+
+const textTurnFrames = [
+  {
+    type: "message_start",
+    message: {
+      id: "msg_prefix",
+      model: "prefix-model",
+      usage: { input_tokens: 3, output_tokens: 0 },
+    },
+  },
+  { type: "content_block_start", index: 0, content_block: { type: "text", text: "" } },
+  { type: "content_block_delta", index: 0, delta: { type: "text_delta", text: "hello" } },
+  { type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null } },
+];
+
+describe("collectSseMessage real fixture replay", () => {
+  test("collects Anthropic passthrough thinking, text, and tool_use blocks", async () => {
+    const fixture = fixtureToResponse(
+      join(FIXTURES_DIR, "minimax-m25-turn1-thinking-text-tool.sse")
+    );
+    const parsed = createAnthropicPassthroughStream(createMockContext(), fixture, {
+      modelName: "minimax-m2.5",
+    });
+
+    const message = await collectSseMessage(parsed, "minimax-m2.5");
+
+    expect(message.content).toHaveLength(3);
+    expect(blockTypes(message)).toEqual(["thinking", "text", "tool_use"]);
+    expect(message.stop_reason).toBe("tool_use");
+    const tool = message.content[2];
+    expect(typeof tool.input).toBe("object");
+    expect(tool.input).not.toBeNull();
+    expect(Array.isArray(tool.input)).toBe(false);
+    expect(tool.input).toHaveProperty("pattern");
+  });
+
+  test("collects OpenAI SSE text and tool_use blocks", async () => {
+    const fixture = fixtureToResponse(join(FIXTURES_DIR, "SEED-openai-tool-call.sse"));
+    const { DefaultAPIFormat } = await import("../../adapters/base-api-format.js");
+    const parsed = createStreamingResponseHandler(
+      createMockContext(),
+      fixture,
+      new DefaultAPIFormat("test-model"),
+      "test-model",
+      null
+    );
+
+    const message = await collectSseMessage(parsed, "test-model");
+
+    expect(message.content).toHaveLength(2);
+    expect(blockTypes(message)).toEqual(["text", "tool_use"]);
+    expect(message.stop_reason).toBe("tool_use");
+  });
+
+  test("collects OpenAI Responses SSE text and parallel tool_use blocks", async () => {
+    const fixture = fixtureToResponse(join(FIXTURES_DIR, "gpt-5.6-sol-responses-turn1.sse"));
+    const parsed = createResponsesStreamHandler(createMockContext(), fixture, {
+      modelName: "gpt-5.6-sol",
+    });
+
+    const message = await collectSseMessage(parsed, "gpt-5.6-sol");
+
+    expect(message.content).toHaveLength(4);
+    expect(blockTypes(message)).toEqual(["text", "tool_use", "tool_use", "tool_use"]);
+    expect(message.stop_reason).toBe("tool_use");
+  });
+});
+
+describe("collectSseMessage data-line prefix tolerance", () => {
+  test("collects data lines with a space after the colon", async () => {
+    const message = await collectSseMessage(framesResponse(textTurnFrames, true), "fallback");
+
+    expect(message.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+
+  test("collects data lines without a space after the colon identically", async () => {
+    const spaced = await collectSseMessage(framesResponse(textTurnFrames, true), "fallback");
+    const unspaced = await collectSseMessage(framesResponse(textTurnFrames, false), "fallback");
+
+    expect(unspaced).toEqual(spaced);
+    expect(unspaced.content).toEqual([{ type: "text", text: "hello" }]);
+  });
+});
+
+describe("collectSseMessage tool arguments", () => {
+  test("reassembles fragmented input_json_delta into a parsed object", async () => {
+    const message = await collectSseMessage(
+      framesResponse([
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "tool_1", name: "Grep", input: {} },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"pattern":' },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '"*.ts"' },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: "}" },
+        },
+      ]),
+      "test-model"
+    );
+
+    expect(message.content).toEqual([
+      { type: "tool_use", id: "tool_1", name: "Grep", input: { pattern: "*.ts" } },
+    ]);
+  });
+
+  test("keeps a tool_use block with empty input when its JSON is unparseable", async () => {
+    const message = await collectSseMessage(
+      framesResponse([
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "tool_2", name: "Read", input: {} },
+        },
+        {
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "input_json_delta", partial_json: '{"file_path":' },
+        },
+      ]),
+      "test-model"
+    );
+
+    expect(message.content).toEqual([{ type: "tool_use", id: "tool_2", name: "Read", input: {} }]);
+    expect(message.stop_reason).toBe("tool_use");
+  });
+});
+
+test("collectSseMessage retains a delta for an unregistered block index", async () => {
+  const message = await collectSseMessage(
+    framesResponse([
+      {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: "survived truncation" },
+      },
+    ]),
+    "test-model"
+  );
+
+  expect(message.content).toEqual([{ type: "text", text: "survived truncation" }]);
+});
+
+describe("collectSseMessage stop_reason derivation", () => {
+  test("derives tool_use for a tool-only turn with no message_delta", async () => {
+    const message = await collectSseMessage(
+      framesResponse([
+        {
+          type: "content_block_start",
+          index: 0,
+          content_block: { type: "tool_use", id: "tool_3", name: "Bash", input: {} },
+        },
+      ]),
+      "test-model"
+    );
+
+    expect(message.stop_reason).toBe("tool_use");
+    expect(message.stop_reason).not.toBe("tool_reason");
+  });
+
+  test("derives end_turn for a text-only turn with no message_delta", async () => {
+    const message = await collectSseMessage(
+      framesResponse([
+        { type: "content_block_start", index: 0, content_block: { type: "text", text: "done" } },
+      ]),
+      "test-model"
+    );
+
+    expect(message.stop_reason).toBe("end_turn");
+    expect(message.stop_reason).not.toBeNull();
+  });
+});
+
+describe("collectSseMessage usage", () => {
+  test("picks up message_start usage", async () => {
+    const message = await collectSseMessage(
+      framesResponse([
+        {
+          type: "message_start",
+          message: { usage: { input_tokens: 21, output_tokens: 2 } },
+        },
+      ]),
+      "test-model"
+    );
+
+    expect(message.usage).toEqual({ input_tokens: 21, output_tokens: 2 });
+  });
+
+  test("lets later message_delta usage override message_start usage", async () => {
+    const message = await collectSseMessage(
+      framesResponse([
+        {
+          type: "message_start",
+          message: { usage: { input_tokens: 10, output_tokens: 1 } },
+        },
+        {
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+          usage: { input_tokens: 34, output_tokens: 8 },
+        },
+      ]),
+      "test-model"
+    );
+
+    expect(message.usage).toEqual({ input_tokens: 34, output_tokens: 8 });
+  });
+});
+
+test("collectSseMessage resolves with partial content when the stream stalls", async () => {
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          [
+            `data: ${JSON.stringify({
+              type: "content_block_start",
+              index: 0,
+              content_block: { type: "text", text: "" },
+            })}`,
+            `data: ${JSON.stringify({
+              type: "content_block_delta",
+              index: 0,
+              delta: { type: "text_delta", text: "partial" },
+            })}`,
+            "",
+          ].join("\n\n")
+        )
+      );
+      // Deliberately never close or enqueue another chunk.
+    },
+  });
+
+  const message = await collectSseMessage(new Response(stream), "test-model", {
+    stallTimeoutMs: 50,
+  });
+
+  expect(message.content).toEqual([{ type: "text", text: "partial" }]);
+  expect(message.stop_reason).toBe("end_turn");
+}, 500);
+
+describe("collectSseMessage degenerate input", () => {
+  test("resolves a well-formed message for a Response with no body", async () => {
+    await expect(collectSseMessage(new Response(null), "fallback-model")).resolves.toMatchObject({
+      type: "message",
+      role: "assistant",
+      model: "fallback-model",
+      content: [],
+      usage: { input_tokens: 0, output_tokens: 0 },
+    });
+  });
+
+  test("resolves an immediately closed empty stream as an empty end_turn", async () => {
+    const message = await collectSseMessage(textResponse(""), "test-model");
+
+    expect(message.content).toEqual([]);
+    expect(message.stop_reason).toBe("end_turn");
+  });
+
+  test("ignores malformed and non-JSON data lines", async () => {
+    const message = await collectSseMessage(
+      textResponse('event: message\ndata: not-json\n\ndata: {"type":\n\n'),
+      "test-model"
+    );
+
+    expect(message.content).toEqual([]);
+    expect(message.stop_reason).toBe("end_turn");
+  });
+
+  test("ignores DONE markers and blank data lines", async () => {
+    const message = await collectSseMessage(
+      textResponse("data:\n\ndata: \n\ndata: [DONE]\n\n"),
+      "test-model"
+    );
+
+    expect(message.content).toEqual([]);
+    expect(message.stop_reason).toBe("end_turn");
+  });
+});
+
+test("sseResponseToJson returns the same collected message as JSON", async () => {
+  const direct = await collectSseMessage(framesResponse(textTurnFrames), "fallback");
+  const response = await sseResponseToJson(framesResponse(textTurnFrames), "fallback");
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Content-Type")).toBe("application/json");
+  expect(JSON.parse(await response.text())).toEqual(direct);
+});

--- a/packages/cli/src/handlers/shared/collect-sse-message.ts
+++ b/packages/cli/src/handlers/shared/collect-sse-message.ts
@@ -1,0 +1,290 @@
+/**
+ * Claude SSE → a single Claude Messages JSON response.
+ *
+ * Every stream parser in this directory emits Claude SSE, because that is what
+ * Claude Code wants for an interactive turn. But the Messages API also has a
+ * non-streaming mode — `stream` absent or false — and Claude Code uses it for
+ * one-shot internal calls, `/compact` being the one people notice.
+ *
+ * `NativeHandler` has always served those correctly by accident of its design:
+ * it forwards the client's payload verbatim to Anthropic and branches on the
+ * RESPONSE content-type, so a `stream: false` request comes back as JSON. Every
+ * adapter's `buildPayload`, by contrast, hardcodes `stream: true` and
+ * ComposedHandler answered with an event stream regardless. That is the whole
+ * asymmetry: `/compact` worked on a native `claude-*` model and returned
+ * unparseable `event: message_start` on every proxied one.
+ *
+ * Rather than give each of the six parsers a second output mode, this consumes
+ * the SSE they already produce and folds it back into the object the
+ * non-streaming API would have returned. One implementation, all stream formats,
+ * and every behaviour that lives in the parsers (tool repair, thinking filter,
+ * token accounting) applies unchanged.
+ *
+ * Deliberately tolerant: a malformed data line is skipped rather than thrown on,
+ * and a stream that ends early still yields whatever content did arrive. A
+ * partial answer beats a 500 for a client that cannot retry.
+ */
+
+import { log } from "../../logger.js";
+
+/**
+ * Give up after this long with NOTHING on the wire — not one byte, not a ping.
+ *
+ * Streaming mode never needed this: the client holds an open socket, sees the
+ * turn stop producing, and the user cancels. Buffering removes that escape
+ * hatch, because we `await` the stream to completion before anything reaches
+ * the client, so a parser that never closes its controller hangs the caller
+ * forever with no output to hint at why.
+ *
+ * The number is safe rather than tuned, because every parser in this directory
+ * emits a keepalive `ping` on a 1-second interval for as long as it is alive
+ * (openai-sse:215, anthropic-sse:210, gemini-sse:93, ollama-jsonl:62,
+ * openai-responses-sse:206). A model that thinks for ten minutes still pings
+ * ten minutes' worth, so this can never truncate a live turn — 120 seconds of
+ * total silence means 120 consecutive missed pings, which only happens once the
+ * parser is genuinely dead.
+ *
+ * It does NOT cover an upstream provider that goes quiet with the socket open:
+ * the parser is alive there and keeps pinging on its behalf. That case is
+ * unbounded in streaming mode today too, so buffering does not make it worse,
+ * and fixing it belongs upstream where the provider socket actually lives.
+ */
+const STALL_TIMEOUT_MS = 120_000;
+
+interface CollectedBlock {
+  type: "text" | "thinking" | "tool_use";
+  text?: string;
+  thinking?: string;
+  signature?: string;
+  id?: string;
+  name?: string;
+  /** tool_use input arrives as partial_json fragments; parsed at block stop. */
+  partialJson?: string;
+  input?: unknown;
+}
+
+export interface CollectedMessage {
+  id: string;
+  type: "message";
+  role: "assistant";
+  model: string;
+  content: Array<Record<string, unknown>>;
+  stop_reason: string | null;
+  stop_sequence: string | null;
+  usage: { input_tokens: number; output_tokens: number };
+}
+
+export interface CollectSseOptions {
+  /** Overrides {@link STALL_TIMEOUT_MS}. Tests set this; nothing else should. */
+  stallTimeoutMs?: number;
+}
+
+function finalizeBlock(block: CollectedBlock): Record<string, unknown> {
+  if (block.type === "text") {
+    return { type: "text", text: block.text ?? "" };
+  }
+  if (block.type === "thinking") {
+    return {
+      type: "thinking",
+      thinking: block.thinking ?? "",
+      ...(block.signature ? { signature: block.signature } : {}),
+    };
+  }
+  // tool_use — the arguments arrived as a JSON string in fragments.
+  let input: unknown = block.input ?? {};
+  if (block.partialJson !== undefined && block.partialJson !== "") {
+    try {
+      input = JSON.parse(block.partialJson);
+    } catch {
+      // A tool call we cannot parse is worse than useless downstream, but
+      // dropping the block silently would hide the turn entirely. Keep the
+      // block with empty input and let the client's own validation report it.
+      log(
+        `[CollectSSE] tool_use ${block.name ?? "?"} had unparseable input, emitting empty object`
+      );
+      input = {};
+    }
+  }
+  return {
+    type: "tool_use",
+    id: block.id ?? "",
+    name: block.name ?? "",
+    input,
+  };
+}
+
+/**
+ * Read a Claude SSE stream to completion and assemble the equivalent
+ * non-streaming Messages response. Never rejects.
+ */
+export async function collectSseMessage(
+  sse: Response,
+  fallbackModel: string,
+  opts: CollectSseOptions = {}
+): Promise<CollectedMessage> {
+  const message: CollectedMessage = {
+    id: `msg_${Date.now()}`,
+    type: "message",
+    role: "assistant",
+    model: fallbackModel,
+    content: [],
+    stop_reason: null,
+    stop_sequence: null,
+    usage: { input_tokens: 0, output_tokens: 0 },
+  };
+
+  const blocks = new Map<number, CollectedBlock>();
+
+  /**
+   * A delta may name a block no `content_block_start` announced.
+   *
+   * Canonical Claude SSE always registers a block first, and every parser here
+   * does. But this reads whatever the wire carried, and a stream truncated
+   * before its opening frame — or a provider that simply omits one — would
+   * otherwise have its entire turn silently discarded. Defaulting to a text
+   * block keeps the words; guessing wrong costs a block type, not the content.
+   */
+  const blockAt = (index: number): CollectedBlock => {
+    let block = blocks.get(index);
+    if (!block) {
+      block = { type: "text", text: "" };
+      blocks.set(index, block);
+    }
+    return block;
+  };
+
+  if (!sse.body) return message;
+
+  const reader = sse.body.getReader();
+  const decoder = new TextDecoder();
+  const stallMs = opts.stallTimeoutMs ?? STALL_TIMEOUT_MS;
+  let buffer = "";
+
+  const handle = (data: any) => {
+    switch (data?.type) {
+      case "message_start": {
+        const m = data.message ?? {};
+        if (m.id) message.id = m.id;
+        if (m.model) message.model = m.model;
+        if (m.usage?.input_tokens != null) message.usage.input_tokens = m.usage.input_tokens;
+        if (m.usage?.output_tokens != null) message.usage.output_tokens = m.usage.output_tokens;
+        break;
+      }
+      case "content_block_start": {
+        const cb = data.content_block ?? {};
+        const kind =
+          cb.type === "thinking" ? "thinking" : cb.type === "tool_use" ? "tool_use" : "text";
+        blocks.set(data.index, {
+          type: kind,
+          text: kind === "text" ? (cb.text ?? "") : undefined,
+          thinking: kind === "thinking" ? (cb.thinking ?? "") : undefined,
+          id: cb.id,
+          name: cb.name,
+          partialJson: kind === "tool_use" ? "" : undefined,
+        });
+        break;
+      }
+      case "content_block_delta": {
+        const block = blockAt(data.index);
+        const d = data.delta ?? {};
+        if (d.type === "text_delta") block.text = (block.text ?? "") + (d.text ?? "");
+        else if (d.type === "thinking_delta")
+          block.thinking = (block.thinking ?? "") + (d.thinking ?? "");
+        else if (d.type === "signature_delta") block.signature = d.signature;
+        else if (d.type === "input_json_delta")
+          block.partialJson = (block.partialJson ?? "") + (d.partial_json ?? "");
+        break;
+      }
+      case "message_delta": {
+        if (data.delta?.stop_reason !== undefined) message.stop_reason = data.delta.stop_reason;
+        if (data.delta?.stop_sequence !== undefined)
+          message.stop_sequence = data.delta.stop_sequence;
+        if (data.usage?.input_tokens != null) message.usage.input_tokens = data.usage.input_tokens;
+        if (data.usage?.output_tokens != null)
+          message.usage.output_tokens = data.usage.output_tokens;
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  try {
+    while (true) {
+      // A fresh timer per chunk, so the deadline is "silence since the last
+      // byte" rather than a cap on the turn. The losing read stays pending
+      // until reader.cancel() settles it below.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const chunk = await Promise.race([
+        reader.read(),
+        new Promise<"stalled">((resolve) => {
+          timer = setTimeout(() => resolve("stalled"), stallMs);
+        }),
+      ]);
+      clearTimeout(timer);
+
+      if (chunk === "stalled") {
+        log(
+          `[CollectSSE] no data for ${stallMs}ms — returning ${blocks.size} block(s) collected so far`
+        );
+        await reader.cancel().catch(() => {});
+        break;
+      }
+      if (chunk.done) break;
+
+      buffer += decoder.decode(chunk.value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!line.startsWith("data:")) continue;
+        // SSE allows one optional space after the colon; providers differ.
+        const payload = line.slice(5).trim();
+        if (!payload || payload === "[DONE]") continue;
+        try {
+          handle(JSON.parse(payload));
+        } catch {
+          // Malformed frame — skip it rather than losing the whole turn.
+        }
+      }
+    }
+  } catch (e) {
+    // A read error mid-stream keeps whatever arrived. Same reasoning as the
+    // parsers' own catch blocks: a partial turn beats no turn.
+    log(`[CollectSSE] read failed, keeping ${blocks.size} block(s): ${e}`);
+  }
+
+  // Emit blocks in index order; the map is keyed by the wire index.
+  for (const index of Array.from(blocks.keys()).sort((a, b) => a - b)) {
+    message.content.push(finalizeBlock(blocks.get(index)!));
+  }
+
+  // A turn that produced content but never delivered a closing delta still has
+  // to name a stop_reason: Claude Code rejects `stop_reason: undefined`, and
+  // null is only valid mid-stream. Derive it the same way devin-connect does —
+  // any tool_use block means the model is handing back to the harness.
+  if (message.stop_reason === null) {
+    message.stop_reason = message.content.some((b) => b.type === "tool_use")
+      ? "tool_use"
+      : "end_turn";
+  }
+
+  return message;
+}
+
+/**
+ * Wrap a Claude SSE Response as a non-streaming JSON Response.
+ *
+ * Always a 200: an error response never reaches here, because ComposedHandler
+ * returns those directly without building a stream.
+ */
+export async function sseResponseToJson(
+  sse: Response,
+  fallbackModel: string,
+  opts: CollectSseOptions = {}
+): Promise<Response> {
+  const message = await collectSseMessage(sse, fallbackModel, opts);
+  return new Response(JSON.stringify(message), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}


### PR DESCRIPTION
Extracted from @jsboige's #142, which bundles this with several unrelated changes. This is the `/compact` slice alone.

## The bug

Every adapter's `buildPayload` hardcodes `stream: true` and the whole pipeline emits Claude SSE, so `ComposedHandler` replied with an event stream regardless of what the client asked for. Send `stream: false` and you get `event: message_start` where you expected a JSON message.

`NativeHandler` never had it, and the reason is the interesting part. It forwards the client's payload verbatim and branches on the **response** content-type, so Anthropic decides and a non-streaming request comes back as JSON. That is the whole asymmetry: `/compact` worked on a native `claude-*` model and failed on every proxied one, which reads as a model problem rather than a proxy problem.

## The fix

`collectSseMessage()` folds the SSE we already produce back into the single message the non-streaming API defines. One implementation covering all six stream formats, and everything the parsers already do (tool repair, thinking filter, token accounting) applies unchanged.

The trigger is `payload?.stream === true`, not `!== false`. The API treats an absent `stream` as false and NativeHandler already behaves that way, so anything looser leaves proxied models disagreeing with native ones, which is the bug. Claudish's own callers (`mcp-server.ts:235`, `probe-live.ts:139`) both send `stream: true` explicitly.

## Two things this had to get right

**Data lines match `data:` with the space OPTIONAL.** The spec makes it optional and providers differ. `fallback-handler.test.ts:83` already handles both, because someone hit it live. Requiring the space doesn't degrade a turn, it drops every line and returns `content: []` — and no fixture would catch it, because all 18 captures come from providers that send the space. This is the likeliest cause of the empty-content failure that parked this change the first time round.

**A stall guard, because buffering removes the escape hatch.** In streaming mode a wedged parser is visible and the user cancels; here we `await` completion, so it hangs the caller with no output at all. 120s of TOTAL silence ends the read and returns what arrived.

Safe rather than tuned: every parser pings on a 1s interval while alive (`openai-sse:215`, `anthropic-sse:210`, `gemini-sse:93`, `ollama-jsonl:62`, `openai-responses-sse:206`), so a model that thinks for ten minutes still pings ten minutes' worth and a live turn can never be truncated. 120s of silence is 120 consecutive missed pings.

It does **not** cover an upstream provider going quiet with the socket open — the parser is alive there and pings on its behalf. That case is already unbounded in streaming mode, so buffering doesn't make it worse, and fixing it belongs where the provider socket lives.

Also: a `content_block_delta` naming an unregistered index keeps its content in a text block instead of being discarded.

## Verified live

Five models, one per wire path:

| model | path | `stream: true` | `stream: false` |
|---|---|---|---|
| minimax-m2.5 | anthropic passthrough | `text/event-stream` | `application/json`, 1 block |
| kimi-k2.5 | anthropic passthrough | `text/event-stream` | `application/json`, 2 blocks |
| glm-5.2 | openai-sse | `text/event-stream` | `application/json`, 2 blocks |
| gemini-3.6-flash | gemini-sse | `text/event-stream` | `application/json`, 1 block |
| gpt-5.6-sol | openai-responses-sse | `text/event-stream` | `application/json`, 2 blocks |

Every JSON answer carried the real text, `stop_reason: end_turn`, and usage. `stream` absent behaves as `stream: false`, per the API.

## Test note

`fallback-handler.test.ts`'s helper synthesised a one-element content array for an empty-but-successful **SSE** turn and did nothing equivalent for JSON, so the same empty turn passed as SSE and failed as JSON. Both branches now classify it the same way — the verdict must not depend on the envelope.

18 tests. Three mutations, each caught by exactly one test:

| mutation | test that fails |
|---|---|
| require the space after `data:` | `collects data lines without a space after the colon identically` |
| remove the stall guard | `resolves with partial content when the stream stalls` (times out) |
| restore the strict block lookup | `retains a delta for an unregistered block index` |

Full hermetic suite: 2182 pass, 0 fail.

Depends on nothing outstanding — #166's finalize teardown is already merged.
