### PR TITLE
fix(openai): give codex models a Responses body, not just a Responses endpoint

### DIFF
--- a/packages/cli/src/providers/provider-profiles.test.ts
+++ b/packages/cli/src/providers/provider-profiles.test.ts
@@ -95,3 +95,66 @@ describe("OpenCode Zen provider composition", () => {
     }
   }
 });
+
+describe("OpenAI Responses-API gate", () => {
+  const responsesComposition = {
+    transport: "openai",
+    streamFormat: "openai-responses-sse",
+    endpoint: "https://api.openai.com/v1/responses",
+  } as const;
+  const chatCompletionsComposition = {
+    transport: "openai",
+    streamFormat: "openai-sse",
+    endpoint: "https://api.openai.com/v1/chat/completions",
+  } as const;
+  const openAICompositionCases = [
+    { model: "gpt-5.3-codex", expected: responsesComposition },
+    { model: "gpt-5-codex", expected: responsesComposition },
+    { model: "gpt-5.1-codex-max", expected: responsesComposition },
+    { model: "gpt-5.1-codex-mini", expected: responsesComposition },
+    { model: "GPT-5.1-CODEX-MINI", expected: responsesComposition },
+    { model: "gpt-5.6-luna", expected: responsesComposition },
+    { model: "gpt-5.6-sol", expected: responsesComposition },
+    { model: "gpt-5.4", expected: chatCompletionsComposition },
+    { model: "gpt-5.5", expected: chatCompletionsComposition },
+    { model: "gpt-4o", expected: chatCompletionsComposition },
+    { model: "gpt-5", expected: chatCompletionsComposition },
+    { model: "gpt-5-mini", expected: chatCompletionsComposition },
+  ] as const;
+
+  for (const row of openAICompositionCases) {
+    test(`openai ${row.model} uses ${row.expected.streamFormat} at ${row.expected.endpoint}`, () => {
+      expect(describeHandler("openai", row.model)).toEqual(row.expected);
+    });
+  }
+
+  test("a codex id routes to Responses regardless of where 'codex' appears in the name", () => {
+    expect(describeHandler("openai", "codex-mini-latest")).toEqual(responsesComposition);
+  });
+
+  test("a codex id gets a Responses body AND a Responses endpoint (the two layers must agree)", () => {
+    for (const model of ["gpt-5.4-codex", "gpt-5.3-codex", "codex-mini-latest"]) {
+      const composition = describeHandler("openai", model);
+
+      // The endpoint already follows the codex rule in transport/openai.ts:31,37;
+      // streamFormat is what catches drift in the profile adapter choice.
+      expect(composition.streamFormat).toBe("openai-responses-sse");
+      expect(composition.endpoint.endsWith("/v1/responses")).toBe(true);
+    }
+  });
+
+  test("a non-codex model keeps both layers on Chat Completions", () => {
+    const composition = describeHandler("openai", "gpt-5.4");
+
+    expect(composition.streamFormat).toBe("openai-sse");
+    expect(composition.endpoint.endsWith("/v1/chat/completions")).toBe(true);
+  });
+
+  test("openai-codex remains Responses-only for codex and non-codex ids", () => {
+    const expected = { ...responsesComposition, transport: "openai-codex" };
+
+    // This provider composes to Responses by construction, so the `openai` gate is not what decides it.
+    expect(describeHandler("openai-codex", "gpt-5.3-codex")).toEqual(expected);
+    expect(describeHandler("openai-codex", "gpt-4o")).toEqual(expected);
+  });
+});

--- a/packages/cli/src/providers/provider-profiles.ts
+++ b/packages/cli/src/providers/provider-profiles.ts
@@ -137,14 +137,58 @@ const devinProfile: ProviderProfile = {
 };
 
 /**
- * Models that reject function tools + reasoning_effort on /v1/chat/completions
- * (OpenAI 400: "use /v1/responses or set reasoning_effort to 'none'"). This is
- * a PER-MODEL constraint, not family-wide. TEMPORARY name gate — replaced by
+ * Models OpenAI will not serve over /v1/chat/completions.
+ *
+ * Two different reasons, one remedy. `gpt-5.6` rejects function tools together
+ * with reasoning_effort ("use /v1/responses or set reasoning_effort to 'none'").
+ * A `*codex*` model rejects the endpoint outright, and says so in as many words
+ * — measured 2026-08-10 straight against api.openai.com with `gpt-5.3-codex`:
+ *
+ *   POST /v1/chat/completions → 404 "This model is not supported in the
+ *                                    v1/chat/completions endpoint. Use the
+ *                                    v1/responses endpoint instead."
+ *   POST /v1/responses        → 200
+ *
+ * So this is not the tools-plus-reasoning constraint wearing a second face; it
+ * is a flatly Responses-only model. Claude Code sends tools on essentially every
+ * request, which made every codex id unusable through `oai@` rather than merely
+ * degraded.
+ *
+ * THE SUBSTRING TEST IS LOAD-BEARING, and it is not a style choice.
+ * `OpenAIProviderTransport` has carried the same rule since long before this —
+ * `modelName.toLowerCase().includes("codex")` decides both its stream format
+ * (openai.ts:31) and its endpoint (openai.ts:37) — so Layer 3 was ALREADY
+ * sending every codex id to /v1/responses. Only Layer 1 disagreed: this gate
+ * matched `gpt-5.6` alone, so `openaiProfile` built an OpenAIAPIFormat and put
+ * a Chat Completions body on a Responses endpoint. That mismatch is the whole
+ * failure, and it is exactly what OpenAI reported back:
+ *
+ *   400 unsupported_parameter — "Unsupported parameter: 'messages'. In the
+ *   Responses API, this parameter has moved to 'input'."
+ *
+ * Right endpoint, wrong body. Any narrowing of this test (a `/^gpt-.*codex/`
+ * prefix, an explicit id list) silently re-opens the split, because the
+ * transport will keep routing ids this function no longer claims. The two tests
+ * must stay identical; a test pins their agreement.
+ *
+ * Only OpenAI-served ids reach this gate — it lives inside `openaiProfile`, so
+ * `cx@` (Responses-only by construction) and every other provider are untouched.
+ *
+ * Pick the verification model carefully. /v1/models is a CATALOGUE, not a served
+ * set: of those six ids, only `gpt-5.3-codex` actually answers 200 on
+ * /v1/responses for the developer's account — the rest return 404 "Model not
+ * found" there, and `gpt-5-codex` is additionally reported DEPRECATED on
+ * /v1/chat/completions. Testing against any of them looks exactly like "the
+ * routing fix did not work" when the model is simply not being served. Same
+ * catalogue-vs-served-set trap the Antigravity and Devin providers document.
+ *
+ * Still a PER-MODEL constraint and still a TEMPORARY name gate — replaced by
  * the catalog capability record (endpoints.openai.toolsWithReasoning ===
  * "requires-responses") once route-time capability fetch lands.
  */
 function requiresResponsesApi(modelName: string): boolean {
-  return /^gpt-5\.6/.test(modelName.toLowerCase());
+  const name = modelName.toLowerCase();
+  return /^gpt-5\.6/.test(name) || name.includes("codex");
 }
 
 const openaiProfile: ProviderProfile = {


### PR DESCRIPTION
Every `oai@*codex*` model returned 400 on its first request:

```
Unsupported parameter: 'messages'. In the Responses API, this parameter has moved to 'input'.
```

## The endpoint was already right

`OpenAIProviderTransport` has tested `modelName.toLowerCase().includes("codex")` since long before this — it picks the endpoint (`transport/openai.ts:37`) and the stream format (`:31`). So Layer 3 was already sending every codex id to `/v1/responses`.

Layer 1 disagreed. `requiresResponsesApi` matched `^gpt-5.6` only, so `openaiProfile` built an `OpenAIAPIFormat` and put a **Chat Completions body on a Responses endpoint**. Right endpoint, wrong body — and two layers had quietly drifted apart on a rule they both implement.

Widening the gate to the *same substring test the transport already uses* brings them back into agreement. That's why it's a substring and not a prefix or an id list: any narrowing re-opens the split, because the transport keeps routing ids this function would no longer claim. A test now pins that agreement.

## Evidence

Straight against `api.openai.com` with `gpt-5.3-codex`, no claudish in the picture:

| endpoint | result |
|---|---|
| `POST /v1/chat/completions` | **404** — *"This model is not supported in the v1/chat/completions endpoint. Use the v1/responses endpoint instead."* |
| `POST /v1/responses` | **200** |

So this isn't the `gpt-5.6` tools-plus-reasoning constraint wearing a second face. Codex models are flatly Responses-only, and Claude Code sends tools on essentially every request — so they were **unusable** through `oai@`, not degraded.

Through claudish, same model, A/B on the gate alone:

| gate | result |
|---|---|
| with the `codex` clause | **200** `text/event-stream` |
| without it | **400** `unsupported_parameter` |

## A trap worth knowing about

`/v1/models` is a **catalogue, not a served set**. It lists six codex ids; only `gpt-5.3-codex` answers 200 on `/v1/responses` for my account:

| id | `/v1/responses` |
|---|---|
| gpt-5.3-codex | **200** |
| gpt-5.2-codex | 404 Model not found |
| gpt-5.1-codex | 404 Model not found |
| gpt-5.1-codex-max | 404 Model not found |
| gpt-5.1-codex-mini | 404 Model not found |
| gpt-5-codex | 404 — also **deprecated** on chat/completions |

Testing against any of the others looks exactly like "the routing fix didn't work" when the model is simply not being served. `gpt-5-codex` is what I was originally going to verify against, which would have been a dead end. Same catalogue-vs-served-set trap the Antigravity and Devin providers already document — it's in the source comment so the next person doesn't spend the afternoon on it.

## Tests

16 tests on the existing hermetic `describeHandler()` seam — no keys, no network. Reverting the clause fails **7** of them.

One replaced a false positive I nearly shipped: *"gpt-5.4 and gpt-5.4-codex get different compositions"* passes **with or without** the fix, because the transport already gives the codex id a different endpoint. The assertion was satisfied for the wrong reason. It's now a layer-agreement test asserting stream format **and** endpoint together — which is what actually catches the split — plus a non-codex negative control.

Full hermetic suite: 2180 pass, 0 fail.

Still a temporary name gate, still slated for replacement by the catalog capability record once route-time capability fetch lands.
