### PR TITLE
chore: let .claudemem/ be ignored globally, where its convention says it lives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,8 +99,6 @@ gtd/sessions/
 .claude/.statusline-worktree-*
 # Claude cache contents are local generated data and can grow quickly.
 .claude/cache/
-# Local claudemem indexes are generated from the repo and should not be committed.
-.claudemem/
 
 # Added by claudeup
 # Team MCP configuration should be committed so shared tools are discoverable.


### PR DESCRIPTION
Reverts the two lines #170 added, because #170 was wrong about what it was fixing.

## What was actually happening

`.claudemem/` kept disappearing from `.gitignore` — three times in one session. I assumed something was corrupting the file and restored the line in #170. It kept coming back, so I went looking properly.

`code-analysis@magus` declares gitignore conventions in **two scopes**:

```json
"gitignore": {
  "project": [".mnemex/"],
  "global":  [".claudemem/", ".claude/.coaching/"]
}
```

`.claudemem/` is **global**-scope. So `conventions-manager.removeGitignoreEntries` strips it from the *project* `.gitignore` on every claudeup run — deliberately, because a per-developer local index doesn't belong in a shared repo file. It matches whole lines and leaves everything else alone, which is why the comment above it survived every time and the diff read as corruption rather than policy.

Worth noting what is *not* to blame: claudeup's `BUILTIN_DEFAULTS` lists `.claudemem/` under `ignore` and would never touch it. I blamed those first and they're innocent — the removal comes from the plugin convention layer sitting on top of them.

## What was genuinely broken

The convention was **half-installed**. The entry was being removed from the project file but had never been added to `~/.gitignore_global`, so between claudeup runs `.claudemem/` had no rule covering it at all. That's the real defect, and restoring the project line only masked it — while guaranteeing the churn continued.

Adding the global entries (done locally, outside this repo) makes the project line redundant. With it gone, claudeup has nothing left to strip and the phantom diff stops.

## Verified

With the line removed from this repo:

```
$ git check-ignore -v --no-index .claudemem/
/Users/jack/.gitignore_global:10:.claudemem/	.claudemem/
```

Still ignored, now by the file the convention intends.

## Trade-off

A contributor who runs claudemem before ever running claudeup would see `.claudemem/` as untracked. That's the intended shape though — claudeup installs the same global convention on their machine, and `.mnemex/` is already project-scoped in the same manifest, so the plugin author is drawing this distinction on purpose.
