### PR TITLE
fix(minimax): point mm@/mmax@ at minimaxi.com, the silo its keys come from

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Claudish automatically loads `.env` from the current directory at startup. For t
 |----------|----------|---------|
 | `GEMINI_BASE_URL` | Gemini API | `https://generativelanguage.googleapis.com` |
 | `OPENAI_BASE_URL` | OpenAI/Azure | `https://api.openai.com` |
-| `MINIMAX_BASE_URL` | MiniMax | `https://api.minimax.io` |
+| `MINIMAX_BASE_URL` | MiniMax | `https://api.minimaxi.com` |
 | `MOONSHOT_BASE_URL` | Kimi/Moonshot | `https://api.moonshot.ai` |
 | `ZHIPU_BASE_URL` | GLM/Zhipu | `https://open.bigmodel.cn` |
 | `ZAI_BASE_URL` | Z.AI | `https://api.z.ai` |

--- a/docs/settings-reference.md
+++ b/docs/settings-reference.md
@@ -179,7 +179,7 @@ Claudish automatically loads `.env` from the current working directory at startu
 |----------|----------|---------|
 | `GEMINI_BASE_URL` | Google Gemini API | `https://generativelanguage.googleapis.com` |
 | `OPENAI_BASE_URL` | OpenAI API (also for Azure-compatible) | `https://api.openai.com` |
-| `MINIMAX_BASE_URL` | MiniMax API | `https://api.minimax.io` |
+| `MINIMAX_BASE_URL` | MiniMax API | `https://api.minimaxi.com` |
 | `MINIMAX_CODING_BASE_URL` | MiniMax Coding Plan endpoint | `https://api.minimax.io` |
 | `MOONSHOT_BASE_URL` | Kimi/Moonshot API | `https://api.moonshot.ai` |
 | `KIMI_BASE_URL` | Alias for `MOONSHOT_BASE_URL` | |

--- a/packages/cli/src/config-command.ts
+++ b/packages/cli/src/config-command.ts
@@ -76,7 +76,7 @@ const PROVIDERS: ProviderDef[] = [
     description: "MiniMax API (mm@, mmax@)",
     keyUrl: "https://www.minimaxi.com/",
     endpointEnvVar: "MINIMAX_BASE_URL",
-    defaultEndpoint: "https://api.minimax.io",
+    defaultEndpoint: "https://api.minimaxi.com",
   },
   {
     name: "kimi",

--- a/packages/cli/src/model-catalog.test.ts
+++ b/packages/cli/src/model-catalog.test.ts
@@ -24,7 +24,10 @@ import { lookupModel, lookupModelForProvider } from "./adapters/model-catalog.js
 
 const MINIMAX_API_KEY = process.env.MINIMAX_CODING_API_KEY || process.env.MINIMAX_API_KEY;
 const SKIP_REAL_API = !MINIMAX_API_KEY;
-const MINIMAX_API_BASE = "https://api.minimax.io/anthropic/v1/messages";
+// Choose the host by key type because PAYG and coding are separate credential silos.
+const MINIMAX_API_BASE = process.env.MINIMAX_CODING_API_KEY
+  ? "https://api.minimax.io/anthropic/v1/messages"
+  : "https://api.minimaxi.com/anthropic/v1/messages";
 
 // ─── Mock slim-cache seeding ─────────────────────────────────────────────────
 

--- a/packages/cli/src/providers/provider-definitions.test.ts
+++ b/packages/cli/src/providers/provider-definitions.test.ts
@@ -350,3 +350,17 @@ describe("getApiKeyEnvVars", () => {
 // readiness cases formerly tested here (local always-available, publicKeyFallback,
 // primary key, alias key, no-key → unavailable) are covered by the authority's
 // equivalence matrix in auth/credentials/equivalence.test.ts.
+
+describe("MiniMax credential silo endpoints", () => {
+  test("keeps PAYG and coding providers on their matching hosts", () => {
+    const payg = getProviderByName("minimax")!;
+    const coding = getProviderByName("minimax-coding")!;
+
+    expect(payg.baseUrl).toBe("https://api.minimaxi.com");
+    expect(coding.baseUrl).toBe("https://api.minimax.io");
+    // This is the actual regression guard: identical URLs sent PAYG keys to the coding host.
+    expect(payg.baseUrl).not.toBe(coding.baseUrl);
+    expect(payg.apiKeyUrl).toContain("minimaxi.com");
+    expect(payg.baseUrl).toContain("minimaxi.com");
+  });
+});

--- a/packages/cli/src/providers/provider-definitions.ts
+++ b/packages/cli/src/providers/provider-definitions.ts
@@ -314,7 +314,15 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     name: "minimax",
     displayName: "MiniMax",
     transport: "anthropic",
-    baseUrl: "https://api.minimax.io",
+    // NOT api.minimax.io — that host is the CODING PLAN's, and the two are
+    // separate credential silos rather than aliases of one service. Measured
+    // 2026-08-11 with a real coding key: api.minimax.io answers 200, while
+    // api.minimaxi.com answers 401 "invalid api key" for the same key. A PAYG
+    // key sent to minimax.io fails the same way in reverse, which is what
+    // `mm@`/`mmax@` did from here. `apiKeyUrl` below has always pointed at
+    // minimaxi.com, so this entry was telling users to fetch a key from one
+    // silo and then spending it against the other.
+    baseUrl: "https://api.minimaxi.com",
     baseUrlEnvVars: ["MINIMAX_BASE_URL"],
     apiPath: "/anthropic/v1/messages",
     apiKeyEnvVar: "MINIMAX_API_KEY",


### PR DESCRIPTION
Reimplemented from @dev-seahouse's #122, which had gone conflicting. Closes #121.

## The claim, verified

`api.minimax.io` and `api.minimaxi.com` are not two names for one service. They're separate credential silos, and the PAYG provider was spending its keys against the coding plan's host.

Measured today with a real MiniMax **Coding** key against `/anthropic/v1/messages`:

| host | result |
|---|---|
| `api.minimax.io` | **200** |
| `api.minimaxi.com` | **401** `{"type":"authentication_error","message":"invalid api key"}` |

That's the mirror image of the reported bug, from the one key type I hold. A PAYG key fails the same way in the other direction, which is what `mm@`/`mmax@` were doing.

## The entry contradicted itself in plain sight

```ts
name: "minimax",
baseUrl:   "https://api.minimax.io",     // coding plan's silo
apiKeyUrl: "https://www.minimaxi.com/",  // where we send users for the key
```

Claudish told people to fetch a key from one silo and then spent it against the other. `minimax-coding` (`mmc@`) is internally consistent — key page and host are both `minimax.io` — and is untouched.

## A latent version of the same bug in the tests

`model-catalog.test.ts` picks `MINIMAX_CODING_API_KEY || MINIMAX_API_KEY` but hardcoded the coding host. It works today only because a coding key happens to be the one present. Anyone holding just a PAYG key sends it to the wrong silo and watches the live tests fail for a reason unrelated to what they test. The host now follows the key that was actually selected.

## Test

The hermetic regression test asserts the two providers' `baseUrl` values **differ** — that's the property that was violated, and they were identical before. It also asserts `minimax`'s `apiKeyUrl` and `baseUrl` agree on `minimaxi.com`, since the self-contradiction above was catchable by inspection alone.

Reverting the baseUrl fails it. Full hermetic suite: 2165 pass, 0 fail.
