### PR TITLE
fix(cli): find Bun on Windows, where `which` does not exist

### DIFF
--- a/packages/cli/bin/claudish.cjs
+++ b/packages/cli/bin/claudish.cjs
@@ -7,18 +7,51 @@
 const { execFileSync, execSync } = require("node:child_process");
 const { resolve } = require("node:path");
 
-function findBun() {
+/**
+ * The shell command that asks PATH where bun is.
+ *
+ * `which` does not exist in cmd or PowerShell — it throws "'which' is not
+ * recognized...", so Windows fell straight through to a list of POSIX-only
+ * paths and reported Bun missing even when it was sitting on PATH.
+ */
+function lookupCommand(platform) {
+  return platform === "win32" ? "where bun" : "which bun";
+}
+
+/**
+ * Fallback install locations, in probe order.
+ *
+ * HOME is usually unset on Windows, which would interpolate the literal string
+ * "undefined\.bun\..." — so the home directory is resolved per-platform rather
+ * than assumed to exist.
+ */
+function bunCandidates(platform, env) {
+  const home = env.HOME || env.USERPROFILE || "";
+  if (platform === "win32") {
+    return [`${home}\\.bun\\bin\\bun.exe`, `${env.LOCALAPPDATA || ""}\\bun\\bun.exe`];
+  }
+  return [`${home}/.bun/bin/bun`, "/usr/local/bin/bun", "/opt/homebrew/bin/bun"];
+}
+
+/** The install one-liner, in the shell the user is actually standing in. */
+function installHint(platform) {
+  return platform === "win32"
+    ? 'powershell -c "irm bun.sh/install.ps1 | iex"'
+    : "curl -fsSL https://bun.sh/install | bash";
+}
+
+function findBun(platform = process.platform, env = process.env) {
   try {
-    const path = execSync("which bun", { encoding: "utf-8" }).trim();
+    const out = execSync(lookupCommand(platform), {
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    // `where` prints EVERY match, one per line. Take the first.
+    const path = out.split(/\r?\n/)[0].trim();
     if (path) return path;
   } catch {}
-  // Common install locations
-  const candidates = [
-    `${process.env.HOME}/.bun/bin/bun`,
-    "/usr/local/bin/bun",
-    "/opt/homebrew/bin/bun",
-  ];
-  for (const c of candidates) {
+
+  for (const c of bunCandidates(platform, env)) {
     try {
       execFileSync(c, ["--version"], { stdio: "ignore" });
       return c;
@@ -27,29 +60,40 @@ function findBun() {
   return null;
 }
 
-const bun = findBun();
-if (!bun) {
-  console.error(`claudish requires the Bun runtime but it was not found.
+function main() {
+  const bun = findBun();
+  if (!bun) {
+    console.error(`claudish requires the Bun runtime but it was not found.
 
 Install Bun (one command):
-  curl -fsSL https://bun.sh/install | bash
+  ${installHint(process.platform)}
 
 Then retry:
   claudish --version
 
 Learn more: https://bun.sh`);
-  process.exit(1);
+    process.exit(1);
+  }
+
+  // Exec into bun with the real entry point
+  const entry = resolve(__dirname, "..", "dist", "index.js");
+  try {
+    const result = require("node:child_process").spawnSync(bun, [entry, ...process.argv.slice(2)], {
+      stdio: "inherit",
+      env: process.env,
+    });
+    process.exit(result.status ?? 1);
+  } catch (err) {
+    console.error("Failed to start claudish:", err.message);
+    process.exit(1);
+  }
 }
 
-// Exec into bun with the real entry point
-const entry = resolve(__dirname, "..", "dist", "index.js");
-try {
-  const result = require("node:child_process").spawnSync(bun, [entry, ...process.argv.slice(2)], {
-    stdio: "inherit",
-    env: process.env,
-  });
-  process.exit(result.status ?? 1);
-} catch (err) {
-  console.error("Failed to start claudish:", err.message);
-  process.exit(1);
+// Running it as a program launches. Requiring it exposes the helpers so the
+// platform branches can be tested from macOS, which is how the Windows bug
+// stayed alive: nothing here was reachable without actually being on Windows.
+if (require.main === module) {
+  main();
+} else {
+  module.exports = { findBun, lookupCommand, bunCandidates, installHint };
 }

--- a/packages/cli/src/launcher-bun-detect.test.ts
+++ b/packages/cli/src/launcher-bun-detect.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { createRequire } from "node:module";
+
+type LauncherHelpers = {
+  findBun: (platform?: string, env?: Record<string, string | undefined>) => string | null;
+  lookupCommand: (platform: string) => string;
+  bunCandidates: (platform: string, env: Record<string, string | undefined>) => string[];
+  installHint: (platform: string) => string;
+};
+
+const require = createRequire(import.meta.url);
+const { findBun, lookupCommand, bunCandidates, installHint } =
+  require("../bin/claudish.cjs") as LauncherHelpers;
+
+describe("npm launcher Bun detection helpers", () => {
+  test("requiring the launcher is side-effect free and exposes its helpers", () => {
+    expect(findBun).toBeFunction();
+    expect(lookupCommand).toBeFunction();
+    expect(bunCandidates).toBeFunction();
+    expect(installHint).toBeFunction();
+  });
+
+  test("lookupCommand uses the platform's command lookup tool", () => {
+    // `which` does not exist in cmd or PowerShell; using it was the original
+    // bug that made Windows fall through to POSIX-only Bun paths.
+    expect(lookupCommand("win32")).toBe("where bun");
+    expect(lookupCommand("darwin")).toBe("which bun");
+    expect(lookupCommand("linux")).toBe("which bun");
+  });
+
+  test("bunCandidates returns native Windows executable paths", () => {
+    const candidates = bunCandidates("win32", {
+      USERPROFILE: "C:\\Users\\jack",
+      LOCALAPPDATA: "C:\\Users\\jack\\AppData\\Local",
+    });
+
+    expect(candidates[0]).toBe("C:\\Users\\jack\\.bun\\bin\\bun.exe");
+    for (const candidate of candidates) {
+      expect(candidate.endsWith("bun.exe")).toBe(true);
+      expect(candidate).toContain("\\");
+      expect(candidate).not.toContain("/");
+    }
+  });
+
+  test("bunCandidates does not interpolate missing Windows home variables", () => {
+    // HOME is normally unset on Windows, so direct interpolation used to
+    // produce the literal path `undefined\\.bun\\bin\\bun.exe`.
+    const candidates = bunCandidates("win32", {});
+
+    for (const candidate of candidates) {
+      expect(candidate).not.toContain("undefined");
+    }
+  });
+
+  test("bunCandidates preserves POSIX paths on macOS", () => {
+    const candidates = bunCandidates("darwin", { HOME: "/Users/jack" });
+
+    expect(candidates[0]).toBe("/Users/jack/.bun/bin/bun");
+    expect(candidates).toContain("/usr/local/bin/bun");
+    expect(candidates).toContain("/opt/homebrew/bin/bun");
+    for (const candidate of candidates) {
+      expect(candidate).not.toContain("\\");
+      expect(candidate).not.toContain(".exe");
+    }
+  });
+
+  test("installHint uses a command suitable for each platform", () => {
+    const windowsHint = installHint("win32");
+    const macHint = installHint("darwin");
+
+    // Showing `curl ... | bash` in cmd would give Windows users a second dead
+    // end immediately after launcher detection failed.
+    expect(windowsHint).toContain("powershell");
+    expect(windowsHint).not.toContain("| bash");
+    expect(macHint).toContain("curl");
+    expect(macHint).toContain("bun.sh/install");
+  });
+});


### PR DESCRIPTION
Reimplemented from @Trypd's #131, which had gone conflicting.

## The bug

The npm launcher couldn't start claudish on Windows even with Bun installed and on PATH:

```
'which' is not recognized as an internal or external command,
operable program or batch file.
claudish requires the Bun runtime but it was not found.
```

`findBun()` was POSIX-only twice over. `execSync("which bun")` throws in cmd and PowerShell, and every fallback candidate was a Unix path — so the lookup failed, and then the fallbacks couldn't rescue it either.

## Four changes, same theme

- **`where bun` on win32.** It prints *every* match, one per line, so the first line is taken rather than the whole buffer.
- **Windows candidates**: `%USERPROFILE%\.bun\bin\bun.exe` and the LOCALAPPDATA install. `HOME` is normally unset on Windows, so the old interpolation produced the literal path `undefined\.bun\bin\bun.exe` — a string that can't match anything and reads like a bug in Bun rather than in us.
- **The install hint follows the shell you're standing in.** Showing `curl … | bash` inside cmd hands the user a second dead end immediately after the first.
- **The POSIX branch is unchanged** — same command, same three candidates, same order.

## Why it survived

The launcher had no tests, and nothing in it was reachable without actually being on Windows.

The platform decisions are now three pure helpers (`lookupCommand`, `bunCandidates`, `installHint`), and the file exports them when *required* instead of run — guarded by `require.main === module`, so running it still launches and requiring it starts no process.

Six hermetic tests, no spawning. The sharpest asserts `bunCandidates("win32", {})` contains no `"undefined"`, because the empty-env case is the one a Windows user actually hits.

| mutation | tests failing |
|---|---|
| `where` → `which` | 1 |
| drop the `USERPROFILE` fallback | 2 |

Verified the POSIX path still resolves on macOS: `node bin/claudish.cjs --version` finds bun and execs into it (it then reports an unbuilt `dist/`, which is this worktree, not the launcher).

I can't run Windows here, so the win32 branch is covered by unit tests over its pure helpers rather than an end-to-end run. @Trypd if you're able to try this branch on your machine that'd be worth a lot.
