### PR TITLE
fix(anthropic): hoist inline system messages out of messages[]

### DIFF
--- a/packages/cli/src/adapters/anthropic-api-format.ts
+++ b/packages/cli/src/adapters/anthropic-api-format.ts
@@ -9,6 +9,61 @@
 import type { StreamFormat } from "../providers/transport/types.js";
 import { type AdapterResult, BaseAPIFormat } from "./base-api-format.js";
 
+/** Text of one inline system message, whatever content shape it arrived in. */
+function systemText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((block: any) => (typeof block?.text === "string" ? block.text : ""))
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * Split `role: "system"` entries out of the messages array.
+ *
+ * Returns the ORIGINAL array reference when there is nothing to hoist, so the
+ * overwhelmingly common case allocates nothing and the payload is byte-identical
+ * to what it was before this existed.
+ */
+export function hoistInlineSystem(messages: any[]): { messages: any[]; hoisted: string[] } {
+  if (!Array.isArray(messages) || !messages.some((m) => m?.role === "system")) {
+    return { messages, hoisted: [] };
+  }
+  const kept: any[] = [];
+  const hoisted: string[] = [];
+  for (const msg of messages) {
+    if (msg?.role === "system") {
+      const text = systemText(msg.content);
+      // A system message with no extractable text is dropped rather than
+      // hoisted as "": it would add a blank paragraph to the system prompt and
+      // change the cached prefix for nothing.
+      if (text) hoisted.push(text);
+      continue;
+    }
+    kept.push(msg);
+  }
+  return { messages: kept, hoisted };
+}
+
+/**
+ * Append hoisted text to whatever `system` already was.
+ *
+ * The array form is PRESERVED as an array. Claude Code sends system as blocks
+ * carrying `cache_control`, and flattening them to one string would discard the
+ * cache breakpoints — turning a fix for a 400 into a silent cost regression.
+ */
+export function mergeSystem(existing: unknown, hoisted: string[]): unknown {
+  if (hoisted.length === 0) return existing;
+  const merged = hoisted.join("\n\n");
+  if (existing === undefined || existing === null || existing === "") return merged;
+  if (Array.isArray(existing)) return [...existing, { type: "text", text: merged }];
+  if (typeof existing === "string") return `${existing}\n\n${merged}`;
+  return existing;
+}
+
 export class AnthropicAPIFormat extends BaseAPIFormat {
   constructor(modelId: string, _providerName?: string) {
     super(modelId);
@@ -75,15 +130,36 @@ export class AnthropicAPIFormat extends BaseAPIFormat {
    * with the model name replaced to match the target provider's model.
    */
   override buildPayload(claudeRequest: any, messages: any[], tools: any[]): any {
+    // Claude Code injects `role: "system"` entries INLINE in messages[] (system
+    // reminders between turns). The Messages API takes `system` as a top-level
+    // field and accepts only user/assistant in messages, so every
+    // Anthropic-compatible provider — Z.AI, GLM, MiniMax, Kimi — answers 400.
+    //
+    // This belongs here rather than in ComposedHandler because it is a
+    // wire-format legality rule, and this class IS the Anthropic wire format.
+    // Put behind a provider check upstream and it would have to name every
+    // anthropic-transport provider and stay current with the list.
+    //
+    // The OpenAI path never needed it: convertMessagesToOpenAI already hoists
+    // system entries (openai-messages.ts:24), and Chat Completions accepts the
+    // role anyway. `transformMessages()` in transform.ts does the same hoisting
+    // and is EXPORTED BUT NEVER CALLED — dead since before this file existed.
+    const { messages: cleanMessages, hoisted } = hoistInlineSystem(messages);
+
     const payload: any = {
       model: this.modelId,
-      messages,
+      messages: cleanMessages,
       max_tokens: claudeRequest.max_tokens || 4096,
       stream: true,
     };
 
-    if (claudeRequest.system) {
-      payload.system = claudeRequest.system;
+    // APPEND, never replace. The reminders are additional context, and the real
+    // system prompt is the expensive cached prefix — overwriting it would both
+    // lose the user's instructions and blow the provider's prefix cache every
+    // turn a reminder appears.
+    const system = mergeSystem(claudeRequest.system, hoisted);
+    if (system !== undefined) {
+      payload.system = system;
     }
     if (tools.length > 0) {
       payload.tools = tools;

--- a/packages/cli/src/adapters/anthropic-inline-system.test.ts
+++ b/packages/cli/src/adapters/anthropic-inline-system.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, test } from "bun:test";
+import { AnthropicAPIFormat, hoistInlineSystem, mergeSystem } from "./anthropic-api-format.js";
+
+describe("hoistInlineSystem", () => {
+  test("returns the original array when there are no system entries", () => {
+    const messages = [
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi" },
+    ];
+
+    const result = hoistInlineSystem(messages);
+
+    expect(result.messages).toBe(messages);
+    expect(result.hoisted).toEqual([]);
+  });
+
+  test("removes one string system entry and preserves surviving message order", () => {
+    const user = { role: "user", content: "Before" };
+    const assistant = { role: "assistant", content: "After" };
+    const messages = [user, { role: "system", content: "Remember this" }, assistant];
+
+    const result = hoistInlineSystem(messages);
+
+    expect(result.messages).toEqual([user, assistant]);
+    expect(result.hoisted).toEqual(["Remember this"]);
+  });
+
+  test("joins text from an array-content system entry with newlines", () => {
+    const result = hoistInlineSystem([
+      {
+        role: "system",
+        content: [
+          { type: "text", text: "A" },
+          { type: "text", text: "B" },
+        ],
+      },
+    ]);
+
+    expect(result.messages).toEqual([]);
+    expect(result.hoisted).toEqual(["A\nB"]);
+  });
+
+  test("removes and hoists several system entries in order", () => {
+    const user = { role: "user", content: "Question" };
+    const assistant = { role: "assistant", content: "Answer" };
+    const result = hoistInlineSystem([
+      { role: "system", content: "First" },
+      user,
+      { role: "system", content: [{ type: "text", text: "Second" }] },
+      assistant,
+      { role: "system", content: "Third" },
+    ]);
+
+    expect(result.messages).toEqual([user, assistant]);
+    expect(result.hoisted).toEqual(["First", "Second", "Third"]);
+  });
+
+  test("drops a textless system entry without adding it to hoisted", () => {
+    const user = { role: "user", content: "Keep me" };
+    const result = hoistInlineSystem([user, { role: "system", content: [{ type: "image" }] }]);
+
+    expect(result.messages).toEqual([user]);
+    // Hoisting "" would append a blank paragraph and change the cached system
+    // prefix even though no usable context was added.
+    expect(result.hoisted).toEqual([]);
+  });
+
+  test("handles non-array input without throwing", () => {
+    const call = () => hoistInlineSystem(undefined as any);
+
+    expect(call).not.toThrow();
+    expect(call().hoisted).toEqual([]);
+  });
+});
+
+describe("mergeSystem", () => {
+  test("returns an existing array by identity when hoisted is empty", () => {
+    const existing = [{ type: "text", text: "System" }];
+
+    expect(mergeSystem(existing, [])).toBe(existing);
+  });
+
+  test("returns hoisted text when existing is undefined", () => {
+    expect(mergeSystem(undefined, ["Reminder"])).toBe("Reminder");
+  });
+
+  test("appends hoisted text to an existing string", () => {
+    expect(mergeSystem("Existing", ["Hoisted"])).toBe("Existing\n\nHoisted");
+  });
+
+  test("appends one text block without mutating an existing array", () => {
+    const first = { type: "text", text: "First" };
+    const second = { type: "text", text: "Second" };
+    const existing = [first, second];
+
+    const merged = mergeSystem(existing, ["Reminder"]) as any[];
+
+    expect(Array.isArray(merged)).toBe(true);
+    expect(existing).toHaveLength(2);
+    expect(merged).toHaveLength(3);
+    expect(merged[0]).toBe(first);
+    expect(merged[1]).toBe(second);
+    expect(merged[2]).toEqual({ type: "text", text: "Reminder" });
+  });
+
+  test("preserves cache_control on existing system blocks", () => {
+    const existing = [
+      {
+        type: "text",
+        text: "sys",
+        cache_control: { type: "ephemeral" },
+      },
+    ];
+
+    const merged = mergeSystem(existing, ["Reminder"]) as any[];
+
+    // Claude Code puts cache breakpoints on system blocks. Flattening the array
+    // to a string would silently turn the HTTP 400 fix into a prefix-cache cost
+    // regression by discarding those breakpoints.
+    expect(merged[0].cache_control).toEqual({ type: "ephemeral" });
+  });
+
+  test("joins multiple hoisted strings with blank lines", () => {
+    expect(mergeSystem(undefined, ["First", "Second", "Third"])).toBe("First\n\nSecond\n\nThird");
+  });
+});
+
+describe("AnthropicAPIFormat.buildPayload end-to-end", () => {
+  const format = new AnthropicAPIFormat("glm-5.2", "zai");
+
+  test("hoists inline system text while preserving cached system blocks", () => {
+    const system = [
+      {
+        type: "text",
+        text: "You are helpful.",
+        cache_control: { type: "ephemeral" },
+      },
+    ];
+    const messages = [
+      { role: "user", content: "Question" },
+      { role: "system", content: "Use the latest context." },
+      { role: "assistant", content: "Answer" },
+    ];
+
+    const payload = format.buildPayload({ system }, messages, []);
+
+    expect(payload.messages.map((message: any) => message.role)).toEqual(["user", "assistant"]);
+    expect(payload.system).toHaveLength(2);
+    expect(payload.system[0].cache_control).toEqual({ type: "ephemeral" });
+    expect(payload.system[1]).toEqual({ type: "text", text: "Use the latest context." });
+  });
+
+  test("keeps system and message count unchanged when no inline system is present", () => {
+    const system = [{ type: "text", text: "You are helpful." }];
+    const messages = [
+      { role: "user", content: "Question" },
+      { role: "assistant", content: "Answer" },
+    ];
+
+    const payload = format.buildPayload({ system }, messages, []);
+
+    expect(payload.system).toEqual(system);
+    expect(payload.messages).toHaveLength(messages.length);
+  });
+
+  test("uses the hoisted string when the request has no top-level system", () => {
+    const payload = format.buildPayload(
+      {},
+      [
+        { role: "user", content: "Question" },
+        { role: "system", content: "Inline reminder" },
+      ],
+      []
+    );
+
+    expect(payload.system).toBe("Inline reminder");
+  });
+
+  test("omits system when neither top-level nor inline system is present", () => {
+    const payload = format.buildPayload({}, [{ role: "user", content: "Question" }], []);
+
+    expect("system" in payload).toBe(false);
+  });
+});


### PR DESCRIPTION
Reimplemented from @jsboige's #134.

## The bug

Claude Code injects `role: "system"` entries **inline in the messages array** (system reminders between turns). The Messages API takes `system` as a top-level field and accepts only `user`/`assistant` in messages, so every Anthropic-compatible provider — Z.AI, GLM, MiniMax, Kimi — answers HTTP 400 on any turn carrying one.

Confirmed the entry reaches the wire on main:

```
transformOpenAIToClaude({ messages: [user, system, assistant] })
→ roles left in messages: user, system, assistant
```

## The fix already half-existed, unreachable

`transform.ts`'s `transformMessages()` hoists exactly these entries into `req.system`, assigns the cleaned array back — and is **exported and called from nowhere**. Dead code predating this file.

It also *overwrites* `req.system` instead of appending, so wiring it up as-is would have dropped the user's real system prompt. Worth knowing before someone finds it and reaches for it.

## Placement

`AnthropicAPIFormat.buildPayload`, not `ComposedHandler`. This is a wire-format legality rule and that class **is** the Anthropic wire format. A check in the handler would have to enumerate every anthropic-transport provider and stay current with the list.

The OpenAI path needs nothing — `convertMessagesToOpenAI` already hoists system entries, and Chat Completions accepts the role anyway.

## Two properties it's built around

**Append, never replace.** The reminders are extra context; the real system prompt is the expensive cached prefix. Overwriting loses the user's instructions *and* blows the provider's prefix cache every turn a reminder appears.

**The array form stays an array.** Claude Code sends system as blocks carrying `cache_control`. Flattening them to one string discards the cache breakpoints, turning a 400 fix into a silent cost regression. Pinned by a test asserting `cache_control` survives on block 0:

```
system: [
  {"type":"text","text":"You are helpful.","cache_control":{"type":"ephemeral"}},
  {"type":"text","text":"<system-reminder>R1</system-reminder>"}
]
```

`hoistInlineSystem` returns the **original array reference** when there's nothing to hoist, so the common case allocates nothing and the payload is byte-identical to before. A system message with no extractable text is dropped rather than hoisted as `""`, which would append a blank paragraph and change the cached prefix for nothing.

## Tests

16 tests, hermetic. Disabling the hoist fails 2. Full suite: 2214 pass, 0 fail.
