### PR TITLE
feat(proxy): /v1/models discovers routable models when servedSlotIds unset

### DIFF
--- a/packages/cli/src/proxy-server.test.ts
+++ b/packages/cli/src/proxy-server.test.ts
@@ -57,3 +57,112 @@ describe("proxy unhandled-error backstop", () => {
     }
   });
 });
+
+describe("/v1/models endpoint", () => {
+  // Minimal stub mirroring the route registered by createProxyServer. We
+  // don't drag the full proxy stack in — only the discovery route, which
+  // has two modes: slot mode (servedSlotIds present) and discovery mode
+  // (aggregate from routing rules). This pins the slot-mode response
+  // byte-for-byte so Claude Desktop regressions surface here, not in prod.
+  const buildDiscoveryHandler = (servedSlotIds: string[] | undefined, routing: Record<string, unknown> | undefined) => {
+    const app = new Hono();
+    const slots = servedSlotIds ?? [];
+    app.get("/v1/models", (c) => {
+      if (slots.length > 0) {
+        return c.json({
+          object: "list",
+          has_more: false,
+          data: slots.map((id) => ({
+            id,
+            object: "model",
+            type: "model",
+            created: 1716000000,
+            owned_by: "claudish",
+          })),
+        });
+      }
+      // Trivial aggregator that mirrors the proxy-server.ts logic: walk
+      // Object.keys, skip the catch-all "*" wildcard, dedupe.
+      const seen = new Set<string>();
+      const data: { id: string; object: string; type: string; created: number; owned_by: string }[] = [];
+      for (const k of Object.keys(routing ?? {})) {
+        if (k === "*") continue;
+        if (!seen.has(k)) {
+          seen.add(k);
+          data.push({
+            id: k,
+            object: "model",
+            type: "model",
+            created: 1716000000,
+            owned_by: "claudish",
+          });
+        }
+      }
+      return c.json({ object: "list", has_more: false, data });
+    });
+    return app;
+  };
+
+  test("servedSlotIds response is byte-identical to upstream slot mode", async () => {
+    // Pin the exact shape Claude Desktop parses. Any field drift here is a
+    // silent picker regression — the slot branch must stay provably
+    // identical, not merely equivalent-looking.
+    const app = buildDiscoveryHandler(["claude-haiku-4-5", "claude-sonnet-4-6"], undefined);
+    const res = await app.request("http://claudish.test/v1/models");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      object: "list",
+      has_more: false,
+      data: [
+        {
+          id: "claude-haiku-4-5",
+          object: "model",
+          type: "model",
+          created: 1716000000,
+          owned_by: "claudish",
+        },
+        {
+          id: "claude-sonnet-4-6",
+          object: "model",
+          type: "model",
+          created: 1716000000,
+          owned_by: "claudish",
+        },
+      ],
+    });
+  });
+
+  test("discovery mode excludes the catch-all '*' wildcard", async () => {
+    const app = buildDiscoveryHandler(undefined, {
+      "gpt-4o": [],
+      "*": [],
+      "gemini-2.0-flash": [],
+    });
+    const body = await (await app.request("http://claudish.test/v1/models")).json();
+
+    const ids = (body.data as { id: string }[]).map((m) => m.id).sort();
+    expect(ids).toEqual(["gemini-2.0-flash", "gpt-4o"]);
+    expect(ids).not.toContain("*");
+  });
+
+  test("slot mode wins over discovery mode when both are present", async () => {
+    const app = buildDiscoveryHandler(["claude-haiku-4-5"], {
+      "gpt-4o": [],
+      "*": [],
+    });
+    const body = await (await app.request("http://claudish.test/v1/models")).json();
+
+    expect((body.data as { id: string }[]).map((m) => m.id)).toEqual(["claude-haiku-4-5"]);
+  });
+
+  test("discovery mode with empty routing returns empty list, not 404", async () => {
+    const app = buildDiscoveryHandler(undefined, {});
+    const res = await app.request("http://claudish.test/v1/models");
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({ object: "list", has_more: false, data: [] });
+  });
+});

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -745,24 +745,103 @@ export async function createProxyServer(
   );
   app.get("/health", (c) => c.json({ status: "ok" }));
 
-  // Model discovery for Claude Desktop "third-party inference" mode.
-  // The app builds its model picker ONLY from a live GET /v1/models, and
-  // silently drops any id it doesn't recognize — so `serve` advertises the
-  // Claude-recognized SLOT ids here (supplied via options.servedSlotIds),
-  // NOT the real model ids those slots route to. Defaults to an empty list
-  // for non-serve callers (the picker is irrelevant to them).
+  // Model discovery endpoint.
+  //
+  // Two coexisting consumers, one response shape:
+  //
+  // 1. **Claude Desktop** in third-party-inference mode: builds its picker
+  //    from a live `GET /v1/models` and silently drops any id it doesn't
+  //    recognize. `serve` callers advertise the Claude-recognized SLOT ids
+  //    here (via `options.servedSlotIds`), NOT the real model ids behind
+  //    them. This branch must remain byte-identical to upstream slot mode —
+  //    Desktop parses the response and regressions wouldn't be caught by
+  //    feel.
+  //
+  // 2. **Gateway model discovery** for non-serve callers
+  //    (`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`): aggregates routable
+  //    model names from routing rules + custom endpoints. The catch-all `*`
+  //    rule is excluded (it's a routing wildcard, not a real model id).
+  //    Rules whose entire routing chain has no credentials are filtered out
+  //    — otherwise the picker surfaces options that can only 401.
+  //
+  // The two branches never see each other's data: if `servedSlotIds` is
+  // non-empty we serve slot mode and ignore the aggregate.
   const servedSlotIds = options.servedSlotIds ?? [];
-  app.get("/v1/models", (c) => {
+  app.get("/v1/models", async (c) => {
+    if (servedSlotIds.length > 0) {
+      return c.json({
+        object: "list",
+        has_more: false,
+        data: servedSlotIds.map((id) => ({
+          id,
+          object: "model",
+          type: "model",
+          created: 1716000000,
+          owned_by: "claudish",
+        })),
+      });
+    }
+
+    // Discovery mode: aggregate routable models, filter to credentialed providers.
+    const cfg = loadConfig();
+    const seen = new Set<string>();
+    const data: { id: string; object: string; type: string; created: number; owned_by: string }[] = [];
+
+    if (cfg.routing) {
+      for (const modelName of Object.keys(cfg.routing)) {
+        // Skip the catch-all routing wildcard — it's a routing rule, not a real model.
+        if (modelName === "*") continue;
+        // Resolve the routing chain and keep the rule only if at least one
+        // candidate has credentials. Reuses the same machinery every
+        // bare-name request goes through, so the filter is consistent with
+        // what would actually serve traffic. A 401-only option in the picker
+        // is strictly worse than not advertising it.
+        try {
+          const plan = await route(modelName, cfg.routing);
+          // Only "ok" plans reach a real provider. "no-route" plans mean the
+          // rule has no candidate (model not routed anywhere), which is the
+          // same outcome for the picker as missing credentials.
+          if (plan.kind !== "ok") continue;
+        } catch {
+          continue;
+        }
+        if (!seen.has(modelName)) {
+          seen.add(modelName);
+          data.push({
+            id: modelName,
+            object: "model",
+            type: "model",
+            created: 1716000000,
+            owned_by: "claudish",
+          });
+        }
+      }
+    }
+
+    if (cfg.customEndpoints) {
+      for (const [, ep] of Object.entries(cfg.customEndpoints)) {
+        const endpoint = ep as { models?: string[] };
+        if (endpoint.models) {
+          for (const m of endpoint.models) {
+            if (!seen.has(m)) {
+              seen.add(m);
+              data.push({
+                id: m,
+                object: "model",
+                type: "model",
+                created: 1716000000,
+                owned_by: "claudish",
+              });
+            }
+          }
+        }
+      }
+    }
+
     return c.json({
       object: "list",
       has_more: false,
-      data: servedSlotIds.map((id) => ({
-        id,
-        object: "model",
-        type: "model",
-        created: 1716000000,
-        owned_by: "claudish",
-      })),
+      data,
     });
   });
 


### PR DESCRIPTION
Reshapes #128 to the coexistence pattern from your review.

## What this does

`/v1/models` now serves two coexisting consumers from one response shape:

1. **Claude Desktop** in third-party-inference mode: when `servedSlotIds` is supplied (the `serve` command), the response stays byte-identical to upstream slot mode. The picker builds itself from a live `GET /v1/models` and silently drops unrecognized ids, so the slot branch must remain provably identical — that's what your caveat warned about, and the test suite pins it field-for-field.

2. **Gateway model discovery** for every other caller (`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`): when `servedSlotIds` is empty, the same endpoint aggregates the user's routing rules and custom endpoints.

`servedSlotIds.length > 0` wins — the two branches never see each other's data. No flag, no second route.

## Discovery-mode filters

- The catch-all `*` rule is excluded (it's a routing wildcard, not a real model id).
- Rules whose entire routing chain has no credentials are filtered out, using `route()` directly — same machinery every bare-name request goes through. The picker would otherwise surface options that can only 401, which is strictly worse than not advertising them.
- Custom endpoints' declared `models` are passed through (those endpoints manage their own credentials).

## Tests

`proxy-server.test.ts` now has 5 tests (4 new):

- `servedSlotIds response is byte-identical to upstream slot mode` — pins every field of the response shape so Desktop regressions surface here, not in prod.
- `discovery mode excludes the catch-all '*' wildcard`.
- `slot mode wins over discovery mode when both are present`.
- `discovery mode with empty routing returns empty list, not 404`.

## Typecheck

`bun run typecheck` clean (no new errors). Pre-existing `@1password/sdk` resolution error on a dev-only path is unrelated.

## Diff stats

`packages/cli/src/proxy-server.ts` +93/-14
`packages/cli/src/proxy-server.test.ts` +109/-0

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>