### PR TITLE
fix(native): drop thinking blocks Anthropic cannot have signed

### DIFF
--- a/packages/cli/src/handlers/native-handler.ts
+++ b/packages/cli/src/handlers/native-handler.ts
@@ -15,6 +15,7 @@ import {
   swapAdvisorToolInBody,
 } from "./native-handler-advisor.js";
 import { wrapAnthropicError } from "./shared/anthropic-error.js";
+import { stripUnsignedThinkingBlocks } from "./shared/thinking-signature.js";
 import type { ModelHandler } from "./types.js";
 
 /**
@@ -79,6 +80,23 @@ export class NativeHandler implements ModelHandler {
   async handle(c: Context, payload: any): Promise<Response> {
     const originalHeaders = c.req.header();
     const target = payload.model;
+
+    // Drop thinking blocks Anthropic cannot have signed, before anything else
+    // reads the payload — so the advisor logging below dumps what actually goes
+    // on the wire rather than what arrived.
+    //
+    // Foreign reasoning reaches the client as `{type:"thinking", signature:""}`
+    // (openai-sse has no signature to give it), and a single mixed-provider
+    // session then 400s every subsequent native turn with
+    // "Invalid signature in thinking block". See thinking-signature.ts for why
+    // this belongs on the native path only, and which case it deliberately
+    // still misses.
+    const strippedThinking = stripUnsignedThinkingBlocks(payload.messages);
+    if (strippedThinking > 0) {
+      log(
+        `[Native] stripped ${strippedThinking} unsigned thinking block(s) from history for ${target} (foreign-provider origin)`
+      );
+    }
 
     // -------------------------------------------------------------------
     // Advisor-swap experiment (opt-in via CLAUDISH_SWAP_ADVISOR=1).

--- a/packages/cli/src/handlers/shared/thinking-signature.test.ts
+++ b/packages/cli/src/handlers/shared/thinking-signature.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from "bun:test";
+import { stripUnsignedThinkingBlocks } from "./thinking-signature.js";
+
+const ANTHROPIC_STYLE_SIGNATURE =
+  "EqQBCgIYAhIM1p3g5rRkW9Q2x0sEGiAq7mJ4v8N6cY1bT5uH3dF9kL2wP0zX" +
+  "nC8sV4aR7eU1qG6jM9hB3yD5fK0tW2pL8xZ4cN7vS1gQ6mJ9rH3bY5dF0kP" +
+  "2wT8uA4eR7iO1qG6jM9hB3yD5fK0tW2pL8xZ4cN7vS1gQ6mJ9rH3bY5d" +
+  "F0kP2wT8uA4eR7iO1qG6jM9hB3yD5fK0tW2pL8xZ4cN7vS1gQ6mJ9rH3";
+
+describe("stripUnsignedThinkingBlocks", () => {
+  test("removes an empty-signature thinking block without disturbing sibling text", () => {
+    const text = { type: "text", text: "The useful answer" };
+    const messages = [
+      {
+        role: "assistant",
+        content: [text, { type: "thinking", thinking: "Foreign reasoning", signature: "" }],
+      },
+    ];
+
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(1);
+    expect(messages[0].content).toEqual([text]);
+    expect(messages[0].content[0]).toBe(text);
+  });
+
+  test("removes a thinking block with no signature key", () => {
+    const messages = [{ role: "assistant", content: [{ type: "thinking", thinking: "Unsigned" }] }];
+
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(1);
+    expect(messages[0].content).toEqual([]);
+  });
+
+  test("removes a thinking block whose signature is null", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Unsigned", signature: null }],
+      },
+    ];
+
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(1);
+    expect(messages[0].content).toEqual([]);
+  });
+
+  test("preserves a realistic non-empty Anthropic-style signature", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          {
+            type: "thinking",
+            thinking: "Native extended thinking",
+            signature: ANTHROPIC_STYLE_SIGNATURE,
+          },
+        ],
+      },
+    ];
+    const expected = structuredClone(messages);
+
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(0);
+    expect(messages).toEqual(expected);
+  });
+
+  test("preserves the documented foreign 64-hex signature gap", () => {
+    const minimaxSignature = "7caa0d3cc2a449ac1cc68507504693f566245c7b5db3558f6041585e15a848f8";
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "MiniMax reasoning", signature: minimaxSignature }],
+      },
+    ];
+
+    // A non-empty signature is preserved: this removes only blocks known not to be Anthropic-signed.
+    // This 64-hex value is a real MiniMax signature retained as a realistic non-empty fixture. In practice,
+    // it never arrives here because Anthropic-wire emission strips thinking via shouldFilterThinking() →
+    // createAnthropicPassthroughStream(). If filtering were narrowed to a model list, foreign signatures
+    // would reach the client and this filter would be insufficient; the implicit coupling is the wire format.
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(0);
+    expect(messages[0].content[0].signature).toBe(minimaxSignature);
+  });
+
+  test("removes multiple unsigned blocks across several messages", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "First", signature: "" },
+          { type: "text", text: "First answer" },
+        ],
+      },
+      {
+        role: "user",
+        content: [{ type: "text", text: "Continue" }],
+      },
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Second" },
+          { type: "thinking", thinking: "Third", signature: null },
+          { type: "text", text: "Second answer" },
+        ],
+      },
+    ];
+
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(3);
+    expect(messages[0].content).toEqual([{ type: "text", text: "First answer" }]);
+    expect(messages[1].content).toEqual([{ type: "text", text: "Continue" }]);
+    expect(messages[2].content).toEqual([{ type: "text", text: "Second answer" }]);
+  });
+
+  test("never touches non-thinking block types, even when they carry an empty signature", () => {
+    const content = [
+      { type: "text", text: "Answer", signature: "" },
+      { type: "tool_use", id: "tool-1", name: "lookup", input: {}, signature: "" },
+      { type: "tool_result", tool_use_id: "tool-1", content: "Result", signature: "" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: "AA==" } },
+    ];
+    const messages = [{ role: "assistant", content }];
+
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(0);
+    expect(messages[0].content).toBe(content);
+    expect(messages[0].content).toEqual(content);
+  });
+
+  test("keeps a message when removing its only content block", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [{ type: "thinking", thinking: "Only block", signature: "" }],
+      },
+    ];
+
+    // Removing the message would renumber the conversation.
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(1);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toEqual([]);
+  });
+
+  test("mutates the original messages array in place", () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Remove me", signature: "" },
+          { type: "text", text: "Keep me" },
+        ],
+      },
+    ];
+    const payload = { messages };
+
+    expect(stripUnsignedThinkingBlocks(payload.messages)).toBe(1);
+    expect(payload.messages).toBe(messages);
+    expect(messages).toEqual([{ role: "assistant", content: [{ type: "text", text: "Keep me" }] }]);
+  });
+
+  test("returns zero without throwing for degenerate inputs", () => {
+    const inputs: unknown[] = [
+      undefined,
+      null,
+      "nope",
+      [],
+      [null],
+      [{}],
+      [{ content: "a string" }],
+      [{ content: null }],
+    ];
+
+    for (const input of inputs) {
+      let result: number | undefined;
+      expect(() => {
+        result = stripUnsignedThinkingBlocks(input);
+      }).not.toThrow();
+      expect(result).toBe(0);
+    }
+  });
+
+  test("does not rewrite a content array when there is nothing to remove", () => {
+    const content = [
+      { type: "text", text: "Already safe" },
+      {
+        type: "thinking",
+        thinking: "Native extended thinking",
+        signature: ANTHROPIC_STYLE_SIGNATURE,
+      },
+    ];
+    const messages = [{ role: "assistant", content }];
+
+    expect(stripUnsignedThinkingBlocks(messages)).toBe(0);
+    expect(messages[0].content).toBe(content);
+  });
+});

--- a/packages/cli/src/handlers/shared/thinking-signature.ts
+++ b/packages/cli/src/handlers/shared/thinking-signature.ts
@@ -1,0 +1,97 @@
+/**
+ * Unsigned thinking blocks, and why the native path has to drop them.
+ *
+ * A `thinking` block carries a cryptographic `signature` that Anthropic issued
+ * and later verifies. Send one back with a signature Anthropic did not produce
+ * and the whole request dies:
+ *
+ *   400 messages.19.content.0: Invalid signature in thinking block
+ *
+ * Claudish manufactures exactly that situation. Reasoning from foreign models is
+ * surfaced to the client as Anthropic-shaped `{ type: "thinking" }` blocks so
+ * Claude Code can render it — but `openai-sse` has no signature to give them
+ * (grep it: the word never appears), so the client stores `signature: ""`.
+ *
+ * While a session stays on a foreign provider that is harmless. Thinking is
+ * never echoed back with its signature intact: the OpenAI path folds the text
+ * into `reasoning_content` and discards everything else (openai-messages.ts:151).
+ * The blocks only become poison when a LATER turn in the same session routes to
+ * a real Anthropic model, because `NativeHandler` forwards the conversation
+ * verbatim — which is the entire point of a native passthrough.
+ *
+ * So the strip belongs here, on the way out to api.anthropic.com, and nowhere
+ * else. One mixed-provider session is enough to wedge every subsequent native
+ * turn until the user compacts.
+ *
+ * ─── Why absent-signature is the WHOLE problem, not part of it ─────────────
+ *
+ * The obvious worry is that this only catches an EMPTY signature, while an
+ * Anthropic-compatible provider could send a real-looking one that Anthropic
+ * still will not accept. MiniMax does exactly that — a 64-hex digest, visible
+ * as `7caa0d3cc2a449ac…` in `minimax-m25-turn1-thinking-text-tool.sse`.
+ *
+ * It never reaches the client. On the Anthropic wire, thinking is stripped at
+ * EMIT: `shouldFilterThinking()` is true for every dialect there
+ * (base-api-format.ts — it keys on the wire, deliberately, not on a model
+ * roster), and `createAnthropicPassthroughStream` drops the blocks and
+ * re-indexes what remains. Replaying that MiniMax fixture through the real
+ * composition yields 0 thinking blocks and 0 signature frames. Same answer for
+ * kimi-k2.5, glm-5.2 and deepseek-v4 — all `filterThinking: true`.
+ *
+ * So a foreign signature is never stored in the conversation and can never come
+ * back here. The only thinking blocks that survive to the client carry NO
+ * signature, because `openai-sse` has none to give and does not filter. Absent
+ * is not a subset of the problem; on the paths that can reach this function it
+ * IS the problem.
+ *
+ * The consequence worth remembering: if `shouldFilterThinking()` is ever
+ * narrowed — scoped to a model list, say — foreign signatures start reaching
+ * the client and this filter silently stops being sufficient. The two are
+ * coupled through the wire, not through anything either file says.
+ */
+
+/**
+ * True when this block is a thinking block Anthropic cannot have signed.
+ *
+ * Only an ABSENT or EMPTY signature counts. A non-empty signature is left alone
+ * even though it may be a foreign one — see the known gap above; guessing which
+ * non-empty signatures are genuine is how you delete real thinking.
+ */
+function isUnsignedThinking(block: unknown): boolean {
+  if (!block || typeof block !== "object") return false;
+  const b = block as { type?: unknown; signature?: unknown };
+  if (b.type !== "thinking") return false;
+  return typeof b.signature !== "string" || b.signature.length === 0;
+}
+
+/**
+ * Remove unsigned thinking blocks from a message array, IN PLACE.
+ *
+ * In place because the caller is about to serialize this exact payload, and a
+ * copy would have to be threaded back through every branch that touches
+ * `payload.messages` — more surface for the strip to be silently skipped on.
+ *
+ * Returns how many blocks were removed, so the caller can log the fact rather
+ * than the transformation being invisible.
+ *
+ * A message whose content becomes EMPTY is left with an empty array rather than
+ * deleted. Removing the message would renumber the conversation, and Anthropic
+ * rejects an empty `content` array — but it also rejects the message ordering
+ * breaking, and the empty case only arises for a turn that was pure unsigned
+ * thinking, which cannot have carried anything Anthropic needs.
+ */
+export function stripUnsignedThinkingBlocks(messages: unknown): number {
+  if (!Array.isArray(messages)) return 0;
+  let removed = 0;
+  for (const message of messages) {
+    if (!message || typeof message !== "object") continue;
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+    const kept = content.filter((block) => !isUnsignedThinking(block));
+    if (kept.length !== content.length) {
+      removed += content.length - kept.length;
+      (message as { content: unknown }).content = kept;
+    }
+  }
+  return removed;
+}


### PR DESCRIPTION
Reimplemented from @jsboige's #140.

## The bug

A mixed-provider session wedges every native turn after the first foreign one:

```
400 messages.19.content.0: Invalid signature in thinking block
```

Foreign reasoning is surfaced to the client as Anthropic-shaped `{type:"thinking"}` blocks so Claude Code can render it — but `openai-sse` has no signature to give them (the word never appears in that parser), so the client stores `signature: ""`.

Harmless while the session stays foreign: thinking is never echoed back with its signature, because the OpenAI path folds the text into `reasoning_content` and discards the rest (`openai-messages.ts:151`). The blocks become poison the moment a later turn routes to a real Anthropic model, because `NativeHandler` forwards the conversation verbatim — which is the entire point of a native passthrough. So the strip belongs there and nowhere else.

Placed at the **top** of `handle()`, before the advisor block, so the advisor's request-body dump shows what actually goes on the wire rather than what arrived. Mutates in place, because the caller serializes this exact payload and returning a copy would have to be threaded through every branch touching `payload.messages` — more surface for the strip to be silently skipped on. Returns a count so it's logged rather than invisible.

## Absent-signature is the whole problem, and that took measuring

The obvious worry is that an Anthropic-compatible provider could send a real-looking signature Anthropic still rejects. MiniMax does exactly that — a 64-hex digest, `7caa0d3cc2a449ac…` in our own fixture. Non-empty, so it would survive this filter.

**It never reaches the client.** On the Anthropic wire, thinking is stripped at *emit*: `shouldFilterThinking()` is true for every dialect there (it keys on the wire, deliberately, not on a model roster) and `createAnthropicPassthroughStream` drops the blocks and re-indexes what remains. Replaying that MiniMax fixture through the **real adapter composition**:

```
adapter: MiniMaxModelDialect   shouldFilterThinking: true
thinking blocks in output: 0
signature frames in output: 0
```

Same for `kimi-k2.5`, `glm-5.2`, `deepseek-v4` — all `filterThinking: true`.

So a foreign signature is never stored in the conversation and can never come back here. The only thinking that survives to the client carries no signature.

**An earlier draft of this commit documented the opposite as a known gap.** That was measured with a probe built *without* an adapter, so the filter was off and thinking survived — a composition that doesn't exist in production. Corrected before shipping. The module header now records the real coupling: narrowing `shouldFilterThinking()` to a model list would silently make this filter insufficient, and the two files are linked through the wire format rather than through anything either one says.

## Tests

11 tests, hermetic. Making `isUnsignedThinking` always-false fails 6.
