### PR TITLE
feat(custom-endpoints): honor streamFormat config — let the wire win over the dialect

### DIFF
--- a/packages/cli/src/handlers/shared/remote-provider-types.ts
+++ b/packages/cli/src/handlers/shared/remote-provider-types.ts
@@ -51,6 +51,20 @@ export interface RemoteProvider {
   headers?: Record<string, string>;
   /** Auth scheme for the API key header (defaults to "x-api-key") */
   authScheme?: "x-api-key" | "bearer";
+  /**
+   * Optional stream-format override surfaced via ProviderTransport.overrideStreamFormat().
+   * When the transport's wire format differs from what the model's dialect would
+   * pick (e.g. an Anthropic-compatible endpoint serving a Qwen-named model —
+   * QwenModelDialect inherits openai-sse, but the wire is anthropic-sse), this
+   * lets the customEndpoint config plumb the truth through to the parser.
+   * Mirrors the StreamFormat union declared at providers/transport/types.ts.
+   */
+  streamFormatOverride?:
+    | "anthropic-sse"
+    | "openai-sse"
+    | "openai-responses-sse"
+    | "gemini-sse"
+    | "ollama-jsonl";
 }
 
 /**

--- a/packages/cli/src/providers/custom-endpoints-loader.test.ts
+++ b/packages/cli/src/providers/custom-endpoints-loader.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { credentials } from "../auth/credentials/authority.js";
 import { __resetSniffForTests } from "../auth/credentials/op-source.js";
 import type { ClaudishProfileConfig } from "../profile-config.js";
+import type { ProfileContext } from "./provider-profiles.js";
 import {
   loadCustomEndpoints,
   resolveCustomEndpointApiKey,
@@ -456,5 +457,97 @@ describe("custom-endpoints-loader", () => {
     expect(second.registered).toBe(1); // still 1 per call
     // The Map stays size 1 because keys overwrite
     expect(getRuntimeProviders().size).toBe(1);
+  });
+
+  describe("complex endpoint streamFormat plumbing", () => {
+    // Regression: an Anthropic-compatible endpoint serving a Qwen-named model
+    // hits QwenModelDialect (which inherits openai-sse from BaseAPIFormat).
+    // The wire is anthropic-sse. streamFormat on the endpoint config must
+    // win over the dialect's default — otherwise the parser is wrong and the
+    // probe reports "not found".
+    function makeCtx(modelName: string): ProfileContext {
+      return {
+        provider: {
+          name: "qwen-token-plan",
+          baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic",
+          apiPath: "/v1/messages",
+          apiKeyEnvVar: "CUSTOM_QWEN_TOKEN_PLAN_KEY",
+          prefixes: ["qwen-token-plan"],
+          authScheme: "x-api-key",
+        },
+        modelName,
+        targetModel: modelName,
+        port: 3000,
+        apiKey: "sk-test",
+        sharedOpts: {},
+      };
+    }
+
+    test("anthropic-transport + streamFormat=anthropic-sse: propages to transport.overrideStreamFormat()", () => {
+      loadCustomEndpoints(
+        makeConfig({
+          "qwen-token-plan": {
+            kind: "complex",
+            displayName: "Qwen Cloud Token Plan",
+            transport: "anthropic",
+            baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic",
+            apiKey: "sk-test",
+            streamFormat: "anthropic-sse",
+            headers: { "anthropic-version": "2023-06-01" },
+          },
+        })
+      );
+
+      const profile = getRuntimeProfiles().get("qwen-token-plan");
+      expect(profile).toBeDefined();
+      const handler = profile!.createHandler(makeCtx("qwen3.8-max"))!;
+      expect(handler).toBeDefined();
+      // ComposedHandler stores the transport on a private `provider` field.
+      // Tap into overrideStreamFormat via that field.
+      const transport = (handler as any).provider;
+      expect(transport).toBeDefined();
+      expect(transport.overrideStreamFormat?.()).toBe("anthropic-sse");
+    });
+
+    test("openai-transport + streamFormat=openai-sse: propagates to transport.overrideStreamFormat()", () => {
+      loadCustomEndpoints(
+        makeConfig({
+          "op-aggregate": {
+            kind: "complex",
+            displayName: "OpenAI Aggregate",
+            transport: "openai",
+            baseUrl: "https://agg.example.com/v1",
+            apiKey: "k",
+            streamFormat: "openai-sse",
+          },
+        })
+      );
+
+      const profile = getRuntimeProfiles().get("op-aggregate");
+      const handler = profile!.createHandler(makeCtx("qwen3.8-max"))!;
+      const transport = (handler as any).provider;
+      expect(transport.overrideStreamFormat?.()).toBe("openai-sse");
+    });
+
+    test("no streamFormat set: transport falls back to dialect default (no override)", () => {
+      loadCustomEndpoints(
+        makeConfig({
+          "no-stream": {
+            kind: "complex",
+            displayName: "Plain",
+            transport: "anthropic",
+            baseUrl: "https://plain.example.com",
+            apiKey: "k",
+          },
+        })
+      );
+
+      const profile = getRuntimeProfiles().get("no-stream");
+      const handler = profile!.createHandler(makeCtx("claude-test"))!;
+      const transport = (handler as any).provider;
+      // No override set — returns undefined, the parser falls back to the
+      // dialect's inherited streamFormat (the historical behavior).
+      expect(transport.overrideStreamFormat?.()).toBeUndefined();
+    });
   });
 });

--- a/packages/cli/src/providers/custom-endpoints-loader.ts
+++ b/packages/cli/src/providers/custom-endpoints-loader.ts
@@ -232,6 +232,7 @@ function buildComplexHandler(
         prefixes: ctx.provider.prefixes ?? [],
         headers: ep.headers,
         authScheme: ep.authScheme ?? "bearer",
+        streamFormatOverride: ep.streamFormat,
       };
       const transport = new OpenAIProviderTransport(remoteProvider, finalModel, apiKey);
       const adapter = new OpenAIAPIFormat(finalModel);
@@ -250,6 +251,7 @@ function buildComplexHandler(
         prefixes: ctx.provider.prefixes ?? [],
         headers: ep.headers,
         authScheme: ep.authScheme ?? "x-api-key",
+        streamFormatOverride: ep.streamFormat,
       };
       const transport = new AnthropicProviderTransport(remoteProvider, apiKey);
       const adapter = new AnthropicAPIFormat(finalModel, ctx.provider.name);

--- a/packages/cli/src/providers/transport/anthropic-compat.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.ts
@@ -39,6 +39,16 @@ export class AnthropicProviderTransport implements ProviderTransport {
     return `${this.provider.baseUrl}${this.provider.apiPath}`;
   }
 
+  /**
+   * Honor the optional streamFormatOverride declared on the RemoteProvider.
+   * Lets custom endpoints (e.g. qwen-token-plan serving an Anthropic-compatible
+   * wire format for a Qwen-named model) win over the dialect's default choice.
+   * No-op when unset — by default Anthropic-compat speaks anthropic-sse anyway.
+   */
+  overrideStreamFormat(): StreamFormat | undefined {
+    return this.provider.streamFormatOverride;
+  }
+
   async getHeaders(): Promise<Record<string, string>> {
     const headers: Record<string, string> = {
       "anthropic-version": "2023-06-01",

--- a/packages/cli/src/providers/transport/openai.ts
+++ b/packages/cli/src/providers/transport/openai.ts
@@ -40,6 +40,15 @@ export class OpenAIProviderTransport implements ProviderTransport {
     return `${this.provider.baseUrl}${this.provider.apiPath}`;
   }
 
+  /**
+   * Honor the optional streamFormatOverride declared on the RemoteProvider.
+   * Lets a custom endpoint (e.g. an aggregator whose openai transport actually
+   * speaks anthropic-sse) win over the dialect's default choice of openai-sse.
+   */
+  overrideStreamFormat(): StreamFormat | undefined {
+    return this.provider.streamFormatOverride;
+  }
+
   async getHeaders(): Promise<Record<string, string>> {
     const headers: Record<string, string> = {};
     if (this.apiKey) {

--- a/packages/cli/src/providers/transport/types.ts
+++ b/packages/cli/src/providers/transport/types.ts
@@ -61,7 +61,7 @@ export interface ProviderTransport {
    * response formats server-side, regardless of the underlying model.
    * If undefined, the adapter's getStreamFormat() is used.
    */
-  overrideStreamFormat?(): StreamFormat;
+  overrideStreamFormat?(): StreamFormat | undefined;
 
   /**
    * Extra fields to merge into the request payload.


### PR DESCRIPTION
@
## Context

A Qwen-named model served by an Anthropic-compatible endpoint (Alibaba MaaS) was hitting `QwenModelDialect` (which inherits `openai-sse` from `BaseAPIFormat`) while the wire was `anthropic-sse`. The probe returned `⊗ not found`. The customEndpoints schema already exposed `streamFormat`, but `buildComplexHandler()` ignored it — the Zod field was dead code.

## What this PR changes

- **`RemoteProvider`**: new optional `streamFormatOverride` field (`StreamFormat | undefined`)
- **`buildComplexHandler()`**: now plumbs `ep.streamFormat` through to the transport (both `openai` and `anthropic` branches)
- **`AnthropicProviderTransport` / `OpenAIProviderTransport`**: implement `overrideStreamFormat()` returning the configured value (mirrors `LiteLLMProviderTransport` / `OpenRouterProviderTransport`)
- **`ProviderTransport.overrideStreamFormat?()`**: signature relaxed to allow `| undefined` (consistent with optional semantics)
- **`custom-endpoints-loader.test.ts`**: 3 new regression tests (Qwen/Anthropic, OpenAI/Aggregate, no-override fallthrough)

## Required config co-fix

When `transport: "anthropic"`, customEndpoints must also set `apiPath: "/v1/messages"` — the default is `/v1/chat/completions` and upstream returns 404 otherwise. The Qwen endpoint config on the hub already has this fix applied.

## Validation (po-2023 standalone-proxy, port 3010)

```
qwen-token-plan@qwen3.8-max     → 200 SSE (thinking + content + stop)
qwen-token-plan@qwen3.7-plus   → 200 SSE
ds@deepseek-v4-flash           → 200 SSE
deepseek-v4-flash              → 200 SSE (chain ds→qwen)
deepseek-v4-pro                → 200 SSE (chain ds→qwen)
non-streaming /compact         → 200 JSON (shape preserved)
```

## Tests

```
packages/cli/src/providers/custom-endpoints-loader.test.ts: 12 pass (3 new)
packages/cli/src/providers/                            : 300 pass
packages/cli/src/providers/transport/                  :  13 pass
```

`bunx tsc --noEmit` clean for the 6 changed files (pre-existing TUI errors unrelated).

## Cluster impact

No behavioral change for any model currently routed through claudish — `streamFormat` is opt-in via config. The patch unblocks the Qwen Cloud Token Plan routes (`qwen3.8-max`, `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-flash`) and any future Anthropic-compatible endpoint serving a Qwen-named model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@