### PR TITLE
fix(team-grid): ignore magmux's control panel when reading pane results

### DIFF
--- a/packages/cli/src/team-grid.e2e.test.ts
+++ b/packages/cli/src/team-grid.e2e.test.ts
@@ -113,6 +113,9 @@ beforeAll(() => {
 // ─── Fast tier: socket protocol ──────────────────────────────────────────────
 
 describe("magmux socket protocol (shell commands)", () => {
+  const commandPanes = (event: Record<string, unknown>) =>
+    (event.panes as Array<Record<string, unknown>>).filter((pane) => pane.control !== true);
+
   it("broadcasts snapshot, exit, results, shutdown for a short-lived pane", async () => {
     // A pane that prints one line then exits. We sleep for 2s before
     // exiting to give the test's socket subscriber enough time to connect
@@ -149,7 +152,10 @@ describe("magmux socket protocol (shell commands)", () => {
       // The results event should contain one pane marked completed.
       const resultsEvent = sub.events.find((e) => e.type === "results")!;
       expect(Array.isArray(resultsEvent.panes)).toBe(true);
-      const panes = resultsEvent.panes as Array<Record<string, unknown>>;
+      const rawPanes = resultsEvent.panes as Array<Record<string, unknown>>;
+      // magmux always reports a control panel; claudish filters it in withoutControlPanes().
+      expect(rawPanes.filter((pane) => pane.control === true)).toHaveLength(1);
+      const panes = commandPanes(resultsEvent);
       expect(panes).toHaveLength(1);
       expect(panes[0].pane).toBe(0);
       expect(panes[0].state).toBe("completed");
@@ -177,7 +183,7 @@ describe("magmux socket protocol (shell commands)", () => {
       await sub.waitFor((events) => events.some((e) => e.type === "results"), 15_000);
 
       const resultsEvent = sub.events.find((e) => e.type === "results")!;
-      const panes = resultsEvent.panes as Array<Record<string, unknown>>;
+      const panes = commandPanes(resultsEvent);
       expect(panes).toHaveLength(1);
       expect(panes[0].state).toBe("failed");
       expect(panes[0].exitCode).toBe(37);
@@ -202,7 +208,7 @@ describe("magmux socket protocol (shell commands)", () => {
       await sub.waitFor((events) => events.some((e) => e.type === "results"), 15_000);
 
       const resultsEvent = sub.events.find((e) => e.type === "results")!;
-      const panes = (resultsEvent.panes as Array<Record<string, unknown>>).sort(
+      const panes = commandPanes(resultsEvent).sort(
         (a, b) => (a.pane as number) - (b.pane as number)
       );
       expect(panes).toHaveLength(2);
@@ -289,6 +295,9 @@ function devClaudishCommand(model: string, prompt: string): string {
 }
 
 describe("claudish team with real models and Claude Code", () => {
+  const commandPanes = (event: Record<string, unknown>) =>
+    (event.panes as Array<Record<string, unknown>>).filter((pane) => pane.control !== true);
+
   it.skipIf(!glmCapable)(
     "default mode: pane runs a real model, magmux emits completed results",
     async () => {
@@ -337,7 +346,7 @@ describe("claudish team with real models and Claude Code", () => {
         }
 
         const resultsEvent = sub.events.find((e) => e.type === "results")!;
-        const panes = resultsEvent.panes as Array<Record<string, unknown>>;
+        const panes = commandPanes(resultsEvent);
         expect(panes).toHaveLength(1);
         expect(panes[0].state).toBe("completed");
         expect(panes[0].exitCode).toBe(0);
@@ -405,7 +414,7 @@ describe("claudish team with real models and Claude Code", () => {
         // Claude Code session, via its JSONL transcript, all the way to
         // awaiting_input.
         const resultsEvent = sub.events.find((e) => e.type === "results")!;
-        const panes = resultsEvent.panes as Array<Record<string, unknown>>;
+        const panes = commandPanes(resultsEvent);
         expect(panes).toHaveLength(1);
         expect(panes[0].controller).toBe("claude-code");
         expect(panes[0].state).toBe("awaiting_input");

--- a/packages/cli/src/team-grid.ts
+++ b/packages/cli/src/team-grid.ts
@@ -239,6 +239,13 @@ interface PaneResult {
   state: string; // "completed" | "failed" | "awaiting_input" | "running"
   exitCode: number;
   dead: boolean;
+  /**
+   * magmux's own control panel, not a model. It ALWAYS exists (hidden without
+   * `-c`) and since magmux 0.7.0 it is reported in `results` like any other
+   * pane, as `{control: true, hidden: true, state: "panel"}`.
+   */
+  control?: boolean;
+  hidden?: boolean;
   controller?: string;
   model?: string;
   project?: string;
@@ -253,6 +260,25 @@ interface MagmuxResultsEvent {
   type: "results";
   panes: PaneResult[];
   endedAt: string;
+}
+
+/**
+ * Drop magmux's control panel from a results event, so `panes` means "the
+ * models this run launched" and nothing else.
+ *
+ * magmux 0.7.0 reports the always-present control panel alongside the command
+ * panes (`{control: true, hidden: true, state: "panel"}`). Today it lands at
+ * index N — one past the last model — so `buildTeamStatus`, which looks up
+ * panes 0..N-1 by index, happens to miss it. That is arithmetic luck, not a
+ * contract: a magmux release that ordered the panel first would silently map a
+ * `state: "panel"` entry onto a real model and record it TIMEOUT.
+ *
+ * Filtering here, at the single point where the event enters claudish, makes
+ * that impossible and keeps the rest of the file talking about models only.
+ */
+function withoutControlPanes(evt: MagmuxResultsEvent): MagmuxResultsEvent {
+  if (!Array.isArray(evt.panes)) return evt;
+  return { ...evt, panes: evt.panes.filter((p) => p?.control !== true) };
 }
 
 /**
@@ -305,7 +331,7 @@ async function subscribeToMagmux(
           const evt = JSON.parse(line) as Record<string, unknown>;
           onEvent?.(evt);
           if (evt.type === "results") {
-            finalResults = evt as unknown as MagmuxResultsEvent;
+            finalResults = withoutControlPanes(evt as unknown as MagmuxResultsEvent);
           }
         } catch {
           /* ignore malformed events */


### PR DESCRIPTION
Turns the CI gate green. It has been red on `main` itself for weeks, and the cause was **not** environmental as previously assumed — including by me, twice, when I merged past it with `--admin`.

## The actual cause

magmux 0.7.0 reports its always-present **control panel** in the `results` socket event alongside the command panes. A one-command gridfile yields two panes:

```json
[ {"pane":0,"cmd":"…echo hello…","state":"completed","exitCode":0,"dead":true},
  {"pane":1,"control":true,"hidden":true,"state":"panel"} ]
```

So every `toHaveLength(N)` assertion is off by one — the exact "expected 1, got 2 / expected 2, got 3" signature the old diagnosis observed and then misattributed to pane leakage.

## Why the environmental theory survived so long

It was consistent with the evidence. A PR touching only version strings failed the same three tests, which looks like proof of an environment problem — but it is equally consistent with a payload bug, since neither PR changed the payload. That control could not discriminate between the two hypotheses.

The experiment that actually settled it: re-run against a **dedicated** socket (`magmux --id <unique>`, binding `/tmp/magmux-NAME.sock`) to rule out cross-talk from a concurrent `claudish team` run in another worktree. Still two panes → not cross-talk → the payload.

## Production was correct only by arithmetic luck

`buildTeamStatus` looks up panes `0..N-1` by index, and the control panel currently lands at index `N` — one past the last model, so it was never read. That is luck, not a contract. **A magmux release that ordered the panel first would map `state: "panel"` onto a real model and silently record it TIMEOUT.**

`withoutControlPanes()` now filters at the single point the event enters claudish, and `PaneResult` gained the `control`/`hidden` fields it was already receiving untyped.

The tests assert magmux's raw wire format, so they filter explicitly via `commandPanes()` rather than going through the production path — and one asserts the raw event still carries exactly **one** control pane, so a future magmux release that adds, removes or reorders it fails loudly instead of shifting indices underneath us.

## Verification

Local: `team-grid.e2e.test.ts` → **6 pass, 1 skip, 0 fail**. The skip is the interactive-mode test, which needs a headless-usable `claude` login.

CI on this PR is the real proof: a green gate on the runner is what finally rules out the environment.

Original work is commit `483cc83`, cherry-picked here onto main on its own so the PR covers one thing.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)