### PR TITLE
fix(test): drive magmux over its socket, not through a pty

### DIFF
--- a/packages/cli/src/team-grid.e2e-helpers.ts
+++ b/packages/cli/src/team-grid.e2e-helpers.ts
@@ -71,6 +71,58 @@ export interface PtyHandle {
   kill(signal?: NodeJS.Signals): void;
 }
 
+export type HeadlessHandle = Omit<PtyHandle, "send">;
+
+/**
+ * Spawn a command directly with non-TTY stdio.
+ *
+ * magmux 0.8.0 auto-enables headless mode when stdin is not a terminal and no
+ * longer survives the expect(1) wrapper used by runInPty(). Socket-protocol
+ * tests therefore launch it directly and use the socket as the whole interface.
+ */
+export function runHeadless(opts: PtyRunOptions): HeadlessHandle {
+  const command = opts.command[0];
+  if (!command) throw new Error("runHeadless requires a command");
+
+  const proc = spawn(command, opts.command.slice(1), {
+    cwd: opts.cwd,
+    env: opts.env ?? process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let rawStdout = "";
+  proc.stdout?.on("data", (chunk: Buffer) => {
+    const s = chunk.toString("utf-8");
+    rawStdout += s;
+    opts.onData?.(s);
+  });
+  proc.stderr?.on("data", (chunk: Buffer) => {
+    const s = chunk.toString("utf-8");
+    rawStdout += s;
+    opts.onData?.(s);
+  });
+
+  const exit = new Promise<{ code: number; stdout: string }>((resolve) => {
+    proc.once("exit", (code) => {
+      resolve({ code: code ?? -1, stdout: stripAnsi(rawStdout) });
+    });
+  });
+
+  return {
+    proc,
+    waitForExit() {
+      return exit;
+    },
+    kill(signal: NodeJS.Signals = "SIGTERM") {
+      try {
+        proc.kill(signal);
+      } catch {
+        /* already dead */
+      }
+    },
+  };
+}
+
 /**
  * Spawn a command under a real PTY using expect(1). Cleaned stdout excludes
  * ANSI escape sequences.

--- a/packages/cli/src/team-grid.e2e.test.ts
+++ b/packages/cli/src/team-grid.e2e.test.ts
@@ -21,10 +21,12 @@
 
 import { beforeAll, describe, expect, it } from "bun:test";
 import { spawn } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { join } from "node:path";
 import {
   type MagmuxSubscription,
   findMagmuxForTest,
+  runHeadless,
   runInPty,
   snapshotMagmuxSockets,
   stripAnsi,
@@ -122,16 +124,16 @@ describe("magmux socket protocol (shell commands)", () => {
     // before magmux starts emitting events. `-w` makes magmux auto-quit
     // as soon as the pane is "done".
     const grid = writeGridfile([`echo 'hello from test pane'; sleep 2`]);
-    const baseline = snapshotMagmuxSockets();
+    const id = `e2e-${randomUUID().slice(0, 8)}`;
 
-    const handle = runInPty({
-      command: [magmuxPath, "-g", grid.path, "-w"],
+    const handle = runHeadless({
+      command: [magmuxPath, "--id", id, "-g", grid.path, "-w"],
     });
 
     let sub: MagmuxSubscription | null = null;
     try {
       // Wait briefly for magmux to create its socket.
-      sub = await subscribeToMagmuxSocket({ baseline });
+      sub = await subscribeToMagmuxSocket(`/tmp/magmux-${id}.sock`);
 
       // The shutdown event is the canonical "we're about to close" signal.
       await sub.waitFor((events) => events.some((e) => e.type === "shutdown"), 15_000);
@@ -171,15 +173,15 @@ describe("magmux socket protocol (shell commands)", () => {
   it("marks a failed pane as failed in the results event", async () => {
     // Sleep first so the subscriber has time to attach, then fail.
     const grid = writeGridfile([`sleep 2; echo 'oops' >&2; exit 37`]);
-    const baseline = snapshotMagmuxSockets();
+    const id = `e2e-${randomUUID().slice(0, 8)}`;
 
-    const handle = runInPty({
-      command: [magmuxPath, "-g", grid.path, "-w"],
+    const handle = runHeadless({
+      command: [magmuxPath, "--id", id, "-g", grid.path, "-w"],
     });
 
     let sub: MagmuxSubscription | null = null;
     try {
-      sub = await subscribeToMagmuxSocket({ baseline });
+      sub = await subscribeToMagmuxSocket(`/tmp/magmux-${id}.sock`);
       await sub.waitFor((events) => events.some((e) => e.type === "results"), 15_000);
 
       const resultsEvent = sub.events.find((e) => e.type === "results")!;
@@ -196,15 +198,15 @@ describe("magmux socket protocol (shell commands)", () => {
 
   it("handles multiple panes and reports per-pane state", async () => {
     const grid = writeGridfile([`echo 'pane0 ok'; sleep 2`, `echo 'pane1 ok'; sleep 2`]);
-    const baseline = snapshotMagmuxSockets();
+    const id = `e2e-${randomUUID().slice(0, 8)}`;
 
-    const handle = runInPty({
-      command: [magmuxPath, "-g", grid.path, "-w"],
+    const handle = runHeadless({
+      command: [magmuxPath, "--id", id, "-g", grid.path, "-w"],
     });
 
     let sub: MagmuxSubscription | null = null;
     try {
-      sub = await subscribeToMagmuxSocket({ baseline });
+      sub = await subscribeToMagmuxSocket(`/tmp/magmux-${id}.sock`);
       await sub.waitFor((events) => events.some((e) => e.type === "results"), 15_000);
 
       const resultsEvent = sub.events.find((e) => e.type === "results")!;
@@ -227,15 +229,15 @@ describe("magmux socket protocol (shell commands)", () => {
     // pane1 is fast, pane0 is slow. Both sleep enough that subscribe
     // beats them to the punch.
     const grid = writeGridfile([`sleep 3; echo 'slow'`, `sleep 1; echo 'fast'`]);
-    const baseline = snapshotMagmuxSockets();
+    const id = `e2e-${randomUUID().slice(0, 8)}`;
 
-    const handle = runInPty({
-      command: [magmuxPath, "-g", grid.path, "-w"],
+    const handle = runHeadless({
+      command: [magmuxPath, "--id", id, "-g", grid.path, "-w"],
     });
 
     let sub: MagmuxSubscription | null = null;
     try {
-      sub = await subscribeToMagmuxSocket({ baseline });
+      sub = await subscribeToMagmuxSocket(`/tmp/magmux-${id}.sock`);
       await sub.waitFor((events) => events.filter((e) => e.type === "exit").length === 2, 15_000);
 
       const exits = sub.events.filter((e) => e.type === "exit");
@@ -256,15 +258,15 @@ describe("magmux crash fallback", () => {
   it("SIGKILL before results event → no results received", async () => {
     // A long-lived pane so we can kill before completion.
     const grid = writeGridfile(["sleep 30"]);
-    const baseline = snapshotMagmuxSockets();
+    const id = `e2e-${randomUUID().slice(0, 8)}`;
 
-    const handle = runInPty({
-      command: [magmuxPath, "-g", grid.path],
+    const handle = runHeadless({
+      command: [magmuxPath, "--id", id, "-g", grid.path],
     });
 
     let sub: MagmuxSubscription | null = null;
     try {
-      sub = await subscribeToMagmuxSocket({ baseline });
+      sub = await subscribeToMagmuxSocket(`/tmp/magmux-${id}.sock`);
 
       // Give magmux a moment to start rendering but not send results.
       await new Promise((r) => setTimeout(r, 500));


### PR DESCRIPTION
Fixes the red hermetic gate on `main`.

## Not flaky, and not the control-pane bug

magmux **0.8.0** shipped mid-release and turned the gate red with no claudish commit to blame. The discriminator was visible only in each run's Homebrew line:

| run | magmux | result |
|---|---|---|
| PR #194 @ 16:02 | **0.7.0** | 2468 pass |
| main @ 16:18 | **0.8.0** | `Received 0 events` |

CI installs it unpinned (`brew install MadAppGang/tap/magmux`) — the same *"an upstream release can turn the gate red with no commit to blame"* failure mode that `bun-version` in the same workflow is already pinned against.

Reproduced locally after upgrading. At 100 ms resolution, magmux 0.8.0 **exits within ~200 ms** under the tests' `expect` wrapper (`runInPty`), leaving a stale socket file, so every subscribe fails with `connect ENOENT` or a 15 s timeout. Distinct from the control-pane bug in 483cc83: that was a wrong *count*, this is *no events at all*.

## Users are unaffected

Checked rather than assumed. `runMagmuxGrid` spawns magmux with `stdio: "inherit"`, so an interactive `claudish team --grid` hands it a real tty; a non-interactive caller gets 0.8.0's headless mode, which auto-enables when stdin is not a terminal. Verified directly — headless delivers the complete protocol (`snapshot, exit, results, shutdown`), control pane included, which also re-confirms the `commandPanes()` filtering shipped in 7.52.0 is still correct.

The breakage was only ever in the harness.

## The fix

The harness stops pretending to be a terminal. `runHeadless()` spawns magmux with plain non-tty stdio — the mode 0.8.0 documents for exactly this case: *"The socket is the whole interface — read `results` for the outcome."* No expect, no pty, one less moving part between the test and the thing under test.

Each run also binds a **deterministic** socket via a unique `--id`, and tests subscribe to that exact path instead of guessing "newest socket created after baseline". That guess is a real race, not a hypothetical one — it latched onto a concurrent `claudish team` run's live socket on this machine earlier today and returned a pane count from someone else's session. The id is `e2e-<uuid8>`, deliberately not all-digits, because magmux's startup reaper treats an all-digit name as a pid socket and may remove it.

Requires magmux ≥ 0.8.0, which is what CI installs. Baseline discovery stays exported for other callers.

## Testing

`team-grid.e2e.test.ts`: **5 pass, 2 skip, 0 fail**. Full suite: **2507 pass, 25 skip, 0 fail**. Typecheck and lint clean.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)