### PR TITLE
fix(antigravity): stop reporting a transient 429 as terminal quota exhaustion

### DIFF
--- a/packages/cli/src/auth/antigravity-token.test.ts
+++ b/packages/cli/src/auth/antigravity-token.test.ts
@@ -4,6 +4,7 @@ import {
   type AntigravityTokenDeps,
   _resetAntigravityTokenState,
   deleteSharedAntigravityToken,
+  forceRefreshAntigravityToken,
   getValidAntigravityAccessToken,
   readSharedAntigravityToken,
   writeSharedAntigravityToken,
@@ -40,7 +41,10 @@ function decodeStore(raw: string): StoreRecord {
 
 function makeFakeDeps(
   initialStore: string | null,
-  onRefresh: (setStore: (raw: string | null) => void) => void = () => {}
+  onRefresh: (
+    setStore: (raw: string | null) => void,
+    getStore: () => string | null
+  ) => void = () => {}
 ) {
   let store = initialStore;
   let refreshCallCount = 0;
@@ -62,7 +66,7 @@ function makeFakeDeps(
     },
     runAgyRefresh: () => {
       refreshCallCount += 1;
-      onRefresh(setStore);
+      onRefresh(setStore, () => store);
     },
     now: () => NOW,
   };
@@ -218,6 +222,151 @@ describe("getValidAntigravityAccessToken", () => {
         "single-flight-access-token",
         "single-flight-access-token",
       ]);
+      expect(fake.getRefreshCallCount()).toBe(1);
+    }
+  );
+});
+
+describe("forceRefreshAntigravityToken", () => {
+  test.skipIf(process.platform !== "darwin")(
+    "forces agy to re-mint a locally valid token rejected upstream",
+    async () => {
+      const original = makeToken({
+        access_token: "server-rejected-token",
+        expiry: new Date(NOW + 30 * 60_000).toISOString(),
+      });
+      let agyCalls = 0;
+      const fake = makeFakeDeps(
+        encodeStore({ token: original, id_token: "preserved-id-token" }),
+        (setStore, getStore) => {
+          const raw = getStore();
+          if (!raw) return;
+          const rec = decodeStore(raw);
+          if (Date.parse(rec.token.expiry) > NOW) return;
+
+          setStore(
+            encodeStore({
+              ...rec,
+              token: {
+                ...rec.token,
+                access_token: "fresh-token",
+                expiry: new Date(NOW + 60 * 60_000).toISOString(),
+              },
+            })
+          );
+          agyCalls += 1;
+        }
+      );
+
+      await expect(forceRefreshAntigravityToken(fake.deps)).resolves.toBe("fresh-token");
+      expect(agyCalls).toBe(1);
+      expect(fake.getRefreshCallCount()).toBe(1);
+      expect(decodeStore(fake.getStore()!).token.access_token).toBe("fresh-token");
+    }
+  );
+
+  test.skipIf(process.platform !== "darwin")(
+    "restores the original store byte-for-byte when agy does not write",
+    async () => {
+      const originalStore = encodeStore({
+        token: makeToken({
+          access_token: "original-token",
+          expiry: new Date(NOW + 30 * 60_000).toISOString(),
+        }),
+        id_token: "original-id-token",
+        auth_method: "oauth",
+        preserved_field: "preserved-value",
+      });
+      const fake = makeFakeDeps(originalStore);
+
+      await expect(forceRefreshAntigravityToken(fake.deps)).rejects.toThrow(
+        /could not be re-minted/
+      );
+      expect(fake.getStore()).toBe(originalStore);
+      expect(fake.getRefreshCallCount()).toBe(1);
+    }
+  );
+
+  test.skipIf(process.platform !== "darwin")(
+    "keeps agy's unusable replacement instead of restoring the original",
+    async () => {
+      const agyToken = makeToken({
+        access_token: "agy-stale-token",
+        expiry: new Date(NOW + 60_000).toISOString(),
+      });
+      const fake = makeFakeDeps(
+        encodeStore({
+          token: makeToken({
+            access_token: "original-token",
+            expiry: new Date(NOW + 30 * 60_000).toISOString(),
+          }),
+        }),
+        (setStore) => setStore(encodeStore({ token: agyToken, id_token: "agy-id-token" }))
+      );
+
+      await expect(forceRefreshAntigravityToken(fake.deps)).rejects.toThrow(
+        /could not be re-minted/
+      );
+      expect(decodeStore(fake.getStore()!)).toEqual({
+        token: agyToken,
+        id_token: "agy-id-token",
+      });
+      expect(decodeStore(fake.getStore()!).token.access_token).not.toBe("original-token");
+    }
+  );
+
+  test.skipIf(process.platform !== "darwin")(
+    "rejects when no Antigravity session exists",
+    async () => {
+      const fake = makeFakeDeps(null);
+
+      await expect(forceRefreshAntigravityToken(fake.deps)).rejects.toThrow(
+        /No Antigravity session found/
+      );
+      expect(fake.getRefreshCallCount()).toBe(0);
+      expect(fake.writes).toHaveLength(0);
+    }
+  );
+
+  test.skipIf(process.platform !== "darwin")(
+    "makes the refreshed token visible to the next valid-token lookup",
+    async () => {
+      const fake = makeFakeDeps(
+        encodeStore({
+          token: makeToken({
+            access_token: "original-token",
+            expiry: new Date(NOW + 30 * 60_000).toISOString(),
+          }),
+        }),
+        (setStore, getStore) => {
+          const raw = getStore();
+          if (!raw) return;
+          const rec = decodeStore(raw);
+          if (Date.parse(rec.token.expiry) > NOW) return;
+          setStore(
+            encodeStore({
+              ...rec,
+              token: {
+                ...rec.token,
+                access_token: "fresh-token",
+                expiry: new Date(NOW + 60 * 60_000).toISOString(),
+              },
+            })
+          );
+        }
+      );
+
+      // Leave the original-token lookup pending in the single-flight slot, then
+      // force the refresh and ask again before any promise continuation runs.
+      // Without forceRefreshAntigravityToken() dropping cached state up front,
+      // the final lookup aliases the stale promise and returns original-token.
+      const staleLookup = getValidAntigravityAccessToken(fake.deps);
+      const forcedRefresh = forceRefreshAntigravityToken(fake.deps);
+      const postRefreshLookup = getValidAntigravityAccessToken(fake.deps);
+
+      await expect(staleLookup).resolves.toBe("original-token");
+      await expect(forcedRefresh).resolves.toBe("fresh-token");
+      await expect(postRefreshLookup).resolves.toBe("fresh-token");
       expect(fake.getRefreshCallCount()).toBe(1);
     }
   );

--- a/packages/cli/src/auth/antigravity-token.ts
+++ b/packages/cli/src/auth/antigravity-token.ts
@@ -404,6 +404,85 @@ export function getValidAntigravityAccessToken(
 }
 
 // ---------------------------------------------------------------------------
+// Public: forced refresh (the backend rejected the token we presented)
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-mint the shared Antigravity token even though it is not locally expired.
+ *
+ * `needsRefresh()` only ever asks the CLOCK. A token Google invalidated
+ * server-side — session revoked, signed in elsewhere, OAuth client rotated —
+ * still carries a future `expiry`, so claudish considers itself healthy and
+ * keeps presenting a dead credential until the clock catches up. This is the
+ * escape hatch for the one moment when we hold better evidence than the clock:
+ * the backend has just REJECTED the token.
+ *
+ * Stamping the stored expiry into the past before calling agy is LOAD-BEARING.
+ * `agy models` re-mints only when AGY believes the token is expired, so against
+ * a locally-valid record it would authenticate with the same dead token, exit 0,
+ * and the "refresh" would be a silent no-op — the caller then retries with the
+ * credential that just failed. Marking the record expired is honest (the backend
+ * already told us it is dead), and a failed re-mint restores exactly what we
+ * found, so an absent or broken agy cannot leave the store worse than it was.
+ *
+ * Throws rather than returning null: the caller is mid-retry, and a null would
+ * send it back upstream with the same rejected credential instead of surfacing
+ * an actionable message.
+ */
+export async function forceRefreshAntigravityToken(
+  deps: AntigravityTokenDeps = defaultDeps
+): Promise<string> {
+  if (process.platform !== "darwin") {
+    throw new Error(
+      "[Antigravity] The shared Antigravity token store is macOS-only for now. " +
+        "Use g@<model> with GEMINI_API_KEY on this platform."
+    );
+  }
+
+  // Drop the single-flight promise AND the read memo first, so nothing below can
+  // be handed back the very token the backend just rejected.
+  _resetAntigravityTokenState();
+
+  const rec = parseRecord(deps.readStore());
+  if (!rec) {
+    throw new Error(
+      "[Antigravity] No Antigravity session found. Sign in with `claudish login antigravity`, " +
+        "or use g@<model> with GEMINI_API_KEY " +
+        "(get one at https://aistudio.google.com/app/apikey)."
+    );
+  }
+
+  const original = rec.token;
+  log("[Antigravity] Upstream rejected the current token — asking the Antigravity CLI to re-mint.");
+  writeSharedAntigravityToken(
+    { ...original, expiry: new Date(deps.now() - 1000).toISOString() },
+    deps
+  );
+  deps.runAgyRefresh();
+
+  const refreshed = parseRecord(deps.readStore());
+  const token = refreshed?.token;
+  if (token && token.access_token !== original.access_token && !needsRefresh(token, deps.now())) {
+    log("[Antigravity] Shared token re-minted by the Antigravity CLI.");
+    return token.access_token;
+  }
+
+  // Restore ONLY when agy never wrote (the store still holds our own expiry
+  // stamp). If agy did write something — even something we can't use — that
+  // record is more current than ours, and clobbering it would undo a real
+  // sign-in. Our stamp was a means to provoke the re-mint, never a verdict to
+  // persist.
+  if (!refreshed || refreshed.token.access_token === original.access_token) {
+    writeSharedAntigravityToken(original, deps);
+  }
+  _resetAntigravityTokenState();
+  throw new Error(
+    "[Antigravity] The Antigravity session was rejected upstream and could not be re-minted. " +
+      "Run `claudish login antigravity` to sign in again."
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Test seam
 // ---------------------------------------------------------------------------
 

--- a/packages/cli/src/handlers/composed-handler-error.test.ts
+++ b/packages/cli/src/handlers/composed-handler-error.test.ts
@@ -231,3 +231,61 @@ describe("ComposedHandler.handle — error surfacing wiring", () => {
     expect(captured.status).toBeUndefined();
   });
 });
+
+type TerminalClassifier = NonNullable<ProviderTransport["classifyTerminalError"]>;
+
+function makeHandlerWithClassifier(classifyTerminalError: TerminalClassifier): ComposedHandler {
+  const transport: ProviderTransport = { ...makeTransport(), classifyTerminalError };
+  return new ComposedHandler(transport, "fugu-ultra", "fugu-ultra", 8080, {});
+}
+
+describe("ComposedHandler.handle — transport terminality override", () => {
+  test("transport-declared transient 429 overrides quota-wording heuristic", async () => {
+    const message = "Resource has been exhausted (e.g. check quota).";
+    stubUpstream(429, {
+      error: { code: 429, message, status: "RESOURCE_EXHAUSTED" },
+    });
+    let calls = 0;
+    const handler = makeHandlerWithClassifier((status, bodyText) => {
+      calls += 1;
+      expect(status).toBe(429);
+      expect(bodyText).toContain(message);
+      return false;
+    });
+    const { c, captured } = makeContext();
+
+    await handler.handle(c, PAYLOAD);
+
+    expect(calls).toBe(1);
+    expect(captured.status).toBe(429);
+    expect(captured.body?.error?.message).toContain(message);
+  });
+
+  test("transport-declared terminal 429 is surfaced as out of quota", async () => {
+    stubUpstream(429, { error: { message: "rate limit exceeded, slow down" } });
+    const { c, captured } = makeContext();
+
+    await makeHandlerWithClassifier(() => true).handle(c, PAYLOAD);
+
+    expect(captured.status).toBe(400);
+    expect(captured.body?.error?.type).toBe("invalid_request_error");
+    expect(captured.body?.error?.message).toContain("Out of quota");
+  });
+
+  test("an undefined transport verdict falls back to generic terminal-429 classification", async () => {
+    stubUpstream(429, {
+      error: {
+        message: "insufficient_quota",
+        type: "insufficient_quota",
+        code: "insufficient_quota",
+      },
+    });
+    const { c, captured } = makeContext();
+
+    await makeHandlerWithClassifier(() => undefined).handle(c, PAYLOAD);
+
+    expect(captured.status).toBe(400);
+    expect(captured.body?.error?.message).toContain("Out of quota");
+    expect(captured.body?.error?.message).toContain("insufficient_quota");
+  });
+});

--- a/packages/cli/src/handlers/composed-handler-error.test.ts
+++ b/packages/cli/src/handlers/composed-handler-error.test.ts
@@ -34,6 +34,19 @@ function makeTransport(): ProviderTransport {
   } as unknown as ProviderTransport;
 }
 
+function makeTransportWithRefresh(
+  onRefresh: () => void | Promise<void>,
+  getHeaders: () => Promise<Record<string, string>> = async () => ({})
+): ProviderTransport {
+  return {
+    ...makeTransport(),
+    getHeaders,
+    forceRefreshAuth: async () => {
+      await onRefresh();
+    },
+  };
+}
+
 /** Stub global fetch to return one canned upstream error response. */
 function stubUpstream(status: number, body: unknown) {
   const text = typeof body === "string" ? body : JSON.stringify(body);
@@ -42,6 +55,36 @@ function stubUpstream(status: number, body: unknown) {
       status,
       headers: { "Content-Type": "application/json" },
     })) as unknown as typeof fetch;
+}
+
+interface StubbedUpstreamResponse {
+  status: number;
+  body: unknown;
+  headers?: Record<string, string>;
+}
+
+interface SequencedFetchCall {
+  input: string | URL | Request;
+  init?: RequestInit;
+}
+
+/** Stub global fetch with one response per call and retain each request for assertions. */
+function stubUpstreamSequence(...responses: StubbedUpstreamResponse[]): SequencedFetchCall[] {
+  const calls: SequencedFetchCall[] = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const response = responses[calls.length];
+    calls.push({ input, init });
+    if (!response) {
+      throw new Error(`Unexpected fetch call ${calls.length}`);
+    }
+
+    const text = typeof response.body === "string" ? response.body : JSON.stringify(response.body);
+    return new Response(text, {
+      status: response.status,
+      headers: { "Content-Type": "application/json", ...response.headers },
+    });
+  }) as unknown as typeof fetch;
+  return calls;
 }
 
 /** Stub global fetch to throw before any upstream response is received. */
@@ -70,6 +113,7 @@ function makeContext(): { c: Context; captured: CapturedResponse } {
   const c = {
     req: { header: () => ({}) },
     header: () => {},
+    body: (body: BodyInit | null, init?: ResponseInit) => new Response(body, init),
     json: (body: unknown, status?: number) => {
       captured.body = body as CapturedErrorBody;
       captured.status = status;
@@ -287,5 +331,113 @@ describe("ComposedHandler.handle — transport terminality override", () => {
     expect(captured.status).toBe(400);
     expect(captured.body?.error?.message).toContain("Out of quota");
     expect(captured.body?.error?.message).toContain("insufficient_quota");
+  });
+});
+
+const RETRIED_SUCCESS_SSE = [
+  `data: ${JSON.stringify({
+    id: "chatcmpl-after-refresh",
+    object: "chat.completion.chunk",
+    created: 1,
+    model: "fugu-ultra",
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant", content: "response from refreshed request" },
+        finish_reason: "stop",
+      },
+    ],
+  })}`,
+  "data: [DONE]",
+  "",
+].join("\n\n");
+
+describe("ComposedHandler.handle — 401 auth refresh retry", () => {
+  test("calls forceRefreshAuth exactly once, retries once, and returns the retried 200 response", async () => {
+    let refreshCalls = 0;
+    const calls = stubUpstreamSequence(
+      { status: 401, body: { error: { message: "stale token" } } },
+      {
+        status: 200,
+        body: RETRIED_SUCCESS_SSE,
+        headers: { "Content-Type": "text/event-stream" },
+      }
+    );
+    const transport = makeTransportWithRefresh(() => {
+      refreshCalls += 1;
+    });
+    const handler = new ComposedHandler(transport, "fugu-ultra", "fugu-ultra", 8080, {});
+    const { c } = makeContext();
+
+    const response = await handler.handle(c, PAYLOAD);
+    const body = (await response.json()) as { content?: Array<{ text?: string }> };
+
+    expect(refreshCalls).toBe(1);
+    expect(calls).toHaveLength(2);
+    expect(response.status).toBe(200);
+    expect(body.content?.[0]?.text).toBe("response from refreshed request");
+  });
+
+  test("retries with headers minted after forceRefreshAuth", async () => {
+    let refreshed = false;
+    const calls = stubUpstreamSequence(
+      { status: 401, body: { error: { message: "stale token" } } },
+      {
+        status: 200,
+        body: RETRIED_SUCCESS_SSE,
+        headers: { "Content-Type": "text/event-stream" },
+      }
+    );
+    const transport = makeTransportWithRefresh(
+      () => {
+        refreshed = true;
+      },
+      async () => ({ Authorization: refreshed ? "Bearer fresh" : "Bearer stale" })
+    );
+    const handler = new ComposedHandler(transport, "fugu-ultra", "fugu-ultra", 8080, {});
+    const { c } = makeContext();
+
+    const response = await handler.handle(c, PAYLOAD);
+    await response.arrayBuffer();
+
+    expect(calls).toHaveLength(2);
+    expect(new Headers(calls[0]?.init?.headers).get("Authorization")).toBe("Bearer stale");
+    expect(new Headers(calls[1]?.init?.headers).get("Authorization")).toBe("Bearer fresh");
+  });
+
+  test("refreshes only once when the retried request also returns 401", async () => {
+    let refreshCalls = 0;
+    const calls = stubUpstreamSequence(
+      { status: 401, body: { error: { message: "stale token" } } },
+      { status: 401, body: { error: { message: "fresh token rejected too" } } }
+    );
+    const transport = makeTransportWithRefresh(() => {
+      refreshCalls += 1;
+    });
+    const handler = new ComposedHandler(transport, "fugu-ultra", "fugu-ultra", 8080, {});
+    const { c, captured } = makeContext();
+
+    const response = await handler.handle(c, PAYLOAD);
+
+    expect(refreshCalls).toBe(1);
+    expect(calls).toHaveLength(2);
+    expect(response.ok).toBe(false);
+    expect(captured.status).toBe(401);
+  });
+
+  test("a transport without forceRefreshAuth surfaces a 401 through the generic error path", async () => {
+    const calls = stubUpstreamSequence({
+      status: 401,
+      body: { error: { message: "invalid api key" } },
+    });
+    const handler = new ComposedHandler(makeTransport(), "fugu-ultra", "fugu-ultra", 8080, {});
+    const { c, captured } = makeContext();
+
+    const response = await handler.handle(c, PAYLOAD);
+
+    expect(calls).toHaveLength(1);
+    expect(response.ok).toBe(false);
+    expect(captured.status).toBe(400);
+    expect(captured.body?.error?.message).toContain("Sakana Fugu error (HTTP 401)");
   });
 });

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -771,7 +771,18 @@ export class ComposedHandler implements ModelHandler {
       } else {
         const errorText = await response.text();
         log(`[${this.provider.displayName}] Error: ${errorText}`);
-        const hint = getRecoveryHint(response.status, errorText, this.provider.displayName);
+        // A transport that parses its provider's structured errors outranks the
+        // shared substring heuristics — computed ONCE here so the user-facing
+        // hint and the terminal/retryable remap below cannot disagree about what
+        // happened. `undefined` (the default for every transport without the
+        // hook) leaves the generic rules exactly as they were.
+        const transportTerminal = this.provider.classifyTerminalError?.(response.status, errorText);
+        const hint = getRecoveryHint(
+          response.status,
+          errorText,
+          this.provider.displayName,
+          transportTerminal
+        );
         let parsedErrorBody: any;
         try {
           parsedErrorBody = JSON.parse(errorText);
@@ -853,7 +864,9 @@ export class ComposedHandler implements ModelHandler {
         // (invalid_request_error) — a status Claude Code surfaces verbatim — and
         // attach a rich message (provider + status + hint + upstream message) so
         // the user sees WHY it failed, right in the chat.
-        if (isTerminalError(response.status, errorText, isTerminal429(errorText))) {
+        if (
+          isTerminalError(response.status, errorText, transportTerminal ?? isTerminal429(errorText))
+        ) {
           const surfaced = buildSurfacedErrorMessage({
             providerDisplayName: this.provider.displayName,
             status: response.status,
@@ -1548,15 +1561,36 @@ export class ComposedHandler implements ModelHandler {
 
 /**
  * Return a human-readable recovery hint based on HTTP status and error body.
+ *
+ * `transportTerminal429` is the transport's own verdict on a 429 when it can
+ * read its provider's structured errors (see
+ * `ProviderTransport.classifyTerminalError`). It OVERRIDES the wording
+ * heuristics below, which are pattern-matching prose and cannot tell a spent
+ * plan from a per-minute throttle when the provider phrases both identically.
+ * `undefined` — every transport without the hook — keeps the original behaviour.
  */
-function getRecoveryHint(status: number, errorText: string, providerName: string): string {
+function getRecoveryHint(
+  status: number,
+  errorText: string,
+  providerName: string,
+  transportTerminal429?: boolean
+): string {
   const lower = errorText.toLowerCase();
 
   if (status === 503 || lower.includes("overloaded")) {
     return "Provider overloaded. Retry or use a different model.";
   }
-  if (status === 429 && isTerminal429(errorText)) {
+  if (status === 429 && (transportTerminal429 ?? isTerminal429(errorText))) {
     return "Out of quota — check your plan & billing details. This won't recover on retry.";
+  }
+  // The transport has positively identified this 429 as transient. Return the
+  // throttling advice here rather than falling through, because the
+  // exhaustion-wording branch below would otherwise claim it: Google stamps
+  // "Resource has been exhausted (e.g. check quota)." on every RESOURCE_EXHAUSTED
+  // reply, so a per-minute rate limit matches "quota" and gets described as a
+  // spent subscription allowance that "refills on the provider's own schedule".
+  if (status === 429 && transportTerminal429 === false) {
+    return "Rate limited. Wait, reduce concurrency, or check plan limits.";
   }
   // A spent SUBSCRIPTION allowance also arrives as 429, and the generic
   // rate-limit advice below is actively wrong for it: "reduce concurrency" does

--- a/packages/cli/src/providers/transport/antigravity-terminality.test.ts
+++ b/packages/cli/src/providers/transport/antigravity-terminality.test.ts
@@ -116,3 +116,14 @@ describe("AntigravityProviderTransport.classifyTerminalError", () => {
     expect(wrappedVerdict).toBe(unwrappedVerdict);
   });
 });
+
+describe("AntigravityProviderTransport auth recovery contract", () => {
+  test("opts into ComposedHandler's 401 recovery hook", () => {
+    // This provider silently omitted the hook, so a server-invalidated session with
+    // a future local expiry had no recovery path even though every other layer was correct.
+    // Deleting the method must therefore fail a test instead of becoming unchecked behavior.
+    const transport = new AntigravityProviderTransport("gemini-3.6-flash");
+
+    expect(typeof transport.forceRefreshAuth).toBe("function");
+  });
+});

--- a/packages/cli/src/providers/transport/antigravity-terminality.test.ts
+++ b/packages/cli/src/providers/transport/antigravity-terminality.test.ts
@@ -1,0 +1,118 @@
+// These bodies are CANONICAL google.rpc shapes constructed from Google's published error model, NOT captured from a live Antigravity 429—no such capture exists in this repo.
+
+import { describe, expect, test } from "bun:test";
+import { AntigravityProviderTransport } from "./antigravity.js";
+
+const RESOURCE_EXHAUSTED_MESSAGE = "Resource has been exhausted (e.g. check quota).";
+const ERROR_INFO_TYPE = "type.googleapis.com/google.rpc.ErrorInfo";
+const RETRY_INFO_TYPE = "type.googleapis.com/google.rpc.RetryInfo";
+const QUOTA_FAILURE_TYPE = "type.googleapis.com/google.rpc.QuotaFailure";
+
+type GoogleRpcDetail = Record<string, unknown>;
+
+function errorInfo(reason: string): GoogleRpcDetail {
+  return {
+    "@type": ERROR_INFO_TYPE,
+    reason,
+  };
+}
+
+function retryInfo(retryDelay: string): GoogleRpcDetail {
+  return {
+    "@type": RETRY_INFO_TYPE,
+    retryDelay,
+  };
+}
+
+function quotaFailure(quotaId: string, description: string): GoogleRpcDetail {
+  return {
+    "@type": QUOTA_FAILURE_TYPE,
+    violations: [{ quotaId, description }],
+  };
+}
+
+function googleRpcBody(details?: GoogleRpcDetail[], arrayWrapped = false): string {
+  const payload = {
+    error: {
+      code: 429,
+      message: RESOURCE_EXHAUSTED_MESSAGE,
+      status: "RESOURCE_EXHAUSTED",
+      ...(details === undefined ? {} : { details }),
+    },
+  };
+
+  return JSON.stringify(arrayWrapped ? [payload] : payload);
+}
+
+describe("AntigravityProviderTransport.classifyTerminalError", () => {
+  const transport = new AntigravityProviderTransport("gemini-3.6-flash");
+
+  test("returns undefined for status 500 even when the body says quota", () => {
+    const body = googleRpcBody([errorInfo("QUOTA_EXHAUSTED")]);
+
+    expect(transport.classifyTerminalError(500, body)).toBeUndefined();
+  });
+
+  test("returns undefined for an unparseable 429 body", () => {
+    expect(transport.classifyTerminalError(429, RESOURCE_EXHAUSTED_MESSAGE)).toBeUndefined();
+  });
+
+  test("treats ErrorInfo QUOTA_EXHAUSTED as terminal", () => {
+    const body = googleRpcBody([errorInfo("QUOTA_EXHAUSTED")]);
+
+    expect(transport.classifyTerminalError(429, body)).toBe(true);
+  });
+
+  test("treats ErrorInfo RATE_LIMIT_EXCEEDED as retryable", () => {
+    const body = googleRpcBody([errorInfo("RATE_LIMIT_EXCEEDED"), retryInfo("2s")]);
+
+    expect(transport.classifyTerminalError(429, body)).toBe(false);
+  });
+
+  test("treats ErrorInfo MODEL_CAPACITY_EXHAUSTED as retryable at the handler boundary", () => {
+    const body = googleRpcBody([errorInfo("MODEL_CAPACITY_EXHAUSTED"), retryInfo("1.5s")]);
+
+    expect(transport.classifyTerminalError(429, body)).toBe(false);
+  });
+
+  test("treats per-day and daily QuotaFailure violations as terminal", () => {
+    const perDayBody = googleRpcBody([
+      quotaFailure(
+        "GenerateRequestsPerDayPerProjectPerModel",
+        "Requests per day per project per model"
+      ),
+    ]);
+    const dailyBody = googleRpcBody([
+      quotaFailure("GenerateRequestsPerProject", "Daily request allowance exhausted"),
+    ]);
+
+    expect(transport.classifyTerminalError(429, perDayBody)).toBe(true);
+    expect(transport.classifyTerminalError(429, dailyBody)).toBe(true);
+  });
+
+  test("treats per-minute QuotaFailure violations as retryable", () => {
+    const body = googleRpcBody([
+      quotaFailure(
+        "GenerateRequestsPerMinutePerProjectPerModel",
+        "Requests per minute per project per model"
+      ),
+    ]);
+
+    expect(transport.classifyTerminalError(429, body)).toBe(false);
+  });
+
+  test("treats a bare RESOURCE_EXHAUSTED body with no details as retryable", () => {
+    const body = googleRpcBody();
+
+    expect(transport.classifyTerminalError(429, body)).toBe(false);
+  });
+
+  test("classifies an array-wrapped streaming body the same as the unwrapped body", () => {
+    const details = [errorInfo("RATE_LIMIT_EXCEEDED"), retryInfo("2s")];
+    const unwrappedVerdict = transport.classifyTerminalError(429, googleRpcBody(details));
+    const wrappedVerdict = transport.classifyTerminalError(429, googleRpcBody(details, true));
+
+    expect(unwrappedVerdict).toBe(false);
+    expect(wrappedVerdict).toBe(unwrappedVerdict);
+  });
+});

--- a/packages/cli/src/providers/transport/antigravity.ts
+++ b/packages/cli/src/providers/transport/antigravity.ts
@@ -27,11 +27,15 @@
 
 import { randomUUID } from "node:crypto";
 import { lookupFamilyDefaultVariant } from "../../adapters/model-catalog.js";
-import { getValidAntigravityAccessToken } from "../../auth/antigravity-token.js";
+import {
+  forceRefreshAntigravityToken,
+  getValidAntigravityAccessToken,
+} from "../../auth/antigravity-token.js";
 import {
   buildAntigravityUserAgent,
   getAntigravityTierDisplayName,
   getServedAntigravityModels,
+  resetAntigravityUserCache,
   retrieveUserQuota,
   setupAntigravityUser,
 } from "../../auth/antigravity-user.js";
@@ -51,6 +55,14 @@ const ANTIGRAVITY_ENDPOINT = `${ANTIGRAVITY_BASE}/v1internal:streamGenerateConte
 const MAX_RETRY_ATTEMPTS = 3;
 /** Default retry delay when server doesn't specify one */
 const DEFAULT_RATE_LIMIT_DELAY_MS = 10_000;
+/**
+ * Budget for the quota reading that fact-checks an "out of quota" verdict.
+ * `retrieveUserQuota` carries no timeout of its own, and this call sits on a
+ * path that is ALREADY failing — a hung connection must not hold the user's
+ * error response open. Timing out degrades to the honest "couldn't confirm"
+ * wording, never to a wrong claim.
+ */
+const QUOTA_CHECK_TIMEOUT_MS = 3000;
 
 // ---------------------------------------------------------------------------
 // Model-id resolution (live served set — NO hardcoded model ids)
@@ -363,6 +375,68 @@ export class AntigravityProviderTransport implements ProviderTransport {
   }
 
   /**
+   * Re-mint the shared token after the backend REJECTED the one we presented,
+   * then rebuild every piece of per-account state derived from it.
+   *
+   * ComposedHandler already owns the "401 → forceRefreshAuth() → retry once"
+   * loop for any transport that implements this hook (the same one Vertex uses).
+   * Antigravity simply never opted in, which is why a stale session had no
+   * recovery path at all: `getValidAntigravityAccessToken()` refreshes on the
+   * LOCAL clock only, so a server-invalidated token with a future `expiry` was
+   * re-presented on every attempt, forever.
+   *
+   * `resetAntigravityUserCache()` is not incidental. `setupAntigravityUser()`
+   * memoizes project + tier for the life of the PROCESS with no expiry, and
+   * `getServedAntigravityModels()` caches the served set for 10 minutes — both
+   * keyed to the identity that was just invalidated. A re-established session
+   * can land on a different project, so keeping them would pin the fresh token
+   * to the dead session's project. (Until now that reset function had no callers
+   * at all.)
+   */
+  async forceRefreshAuth(): Promise<void> {
+    await forceRefreshAntigravityToken();
+    resetAntigravityUserCache();
+    // Drop the delegated artifact too — its headers carry the rejected bearer
+    // token, and getHeaders() prefers it over the locally-built set.
+    this.cachedAuth = null;
+    await this.refreshAuth();
+  }
+
+  /**
+   * This transport's own verdict on 429 terminality, overriding the shared
+   * substring heuristics (see `ProviderTransport.classifyTerminalError`).
+   *
+   * `classify429` reads `google.rpc.ErrorInfo` / `QuotaFailure` and already
+   * distinguishes a spent daily allowance from a per-minute throttle. The
+   * generic classifier cannot: Google stamps "Resource has been exhausted (e.g.
+   * check quota)." on EVERY RESOURCE_EXHAUSTED reply, the shared exhaustion list
+   * matches the bare word "quota", and so a transient throttle reached the user
+   * as "Out of quota — ... This won't recover on retry." — sending them to a
+   * billing dashboard that shows nothing wrong, for a fault that clears on its
+   * own.
+   *
+   * MODEL_CAPACITY_EXHAUSTED is reported as NON-terminal here on purpose, and
+   * that is a deliberate behaviour change. It is terminal for ONE MODEL — which
+   * is why `enqueueRequest` answers it with the served-set fallback chain rather
+   * than a retry — but it says nothing about the account. Google has no capacity
+   * right now; capacity returns on the order of seconds, so retrying is the
+   * actual remedy rather than theatre, and a bare name whose chain continues
+   * (antigravity → google → openrouter) gets served instead of hard-failing.
+   * Reporting it terminal also handed it the quota message, which is how a
+   * capacity fault ended up telling users to check their billing.
+   *
+   * Pure: derived from `bodyText` alone, never from per-request instance state.
+   */
+  classifyTerminalError(status: number, bodyText: string): boolean | undefined {
+    if (status !== 429) return undefined;
+    const classification = classify429(bodyText);
+    // Unparseable body → no opinion; the generic rules are as good a guess.
+    if (!classification) return undefined;
+    if (classification.reason === "MODEL_CAPACITY_EXHAUSTED") return false;
+    return classification.terminal;
+  }
+
+  /**
    * Wrap the standard Gemini payload in the CodeAssist envelope.
    *
    * Stores the envelope for potential fallback retries in enqueueRequest.
@@ -438,10 +512,7 @@ export class AntigravityProviderTransport implements ProviderTransport {
       }
 
       if (classification.terminal) {
-        logStderr(
-          `[Antigravity] Quota exhausted (${classification.reason || "daily limit"}). Check plan limits.`
-        );
-        return response;
+        return await this.explainTerminalQuota(response, bodyText, classification.reason);
       }
 
       if (attempt < MAX_RETRY_ATTEMPTS) {
@@ -595,6 +666,97 @@ export class AntigravityProviderTransport implements ProviderTransport {
     }
     return new Response(body, {
       status: 404,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  /**
+   * Remaining allowance fraction for the model that just 429'd, or `undefined`
+   * when the reading could not be taken (no token/project, endpoint down, or —
+   * tellingly — the credential itself is no longer accepted).
+   */
+  private async quotaRemainingForServedModel(): Promise<number | undefined> {
+    if (!this.accessToken || !this.projectId) return undefined;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const data = await Promise.race([
+      retrieveUserQuota(this.accessToken, this.projectId).catch(() => null),
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), QUOTA_CHECK_TIMEOUT_MS);
+      }),
+    ]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+    const buckets = data?.buckets;
+    if (!buckets?.length) return undefined;
+    const bucket =
+      buckets.find((b) => b.modelId === this.servedModelName) ??
+      buckets.find((b) => b.modelId === this.modelName);
+    return typeof bucket?.remainingFraction === "number" ? bucket.remainingFraction : undefined;
+  }
+
+  /**
+   * Answer a terminal-quota 429 with a claim claudish has actually CHECKED.
+   *
+   * "Out of quota — check your plan & billing details" is an assertion about the
+   * ACCOUNT, and it was being made purely from the shape of an error body. When
+   * it is wrong it is expensively wrong: it sends the user to a billing
+   * dashboard showing nothing amiss, while the bare-name chain
+   * (antigravity → google → openrouter) quietly moves them onto a METERED hop
+   * for a model their subscription already covers. The reported case was exactly
+   * this — a plan with allowance left, restored by re-running `agy`.
+   *
+   * `retrieveUserQuota` is the same per-model bucket endpoint the status line
+   * reads, so the claim can be tested against the account itself. Three
+   * outcomes, and the middle one is why this exists at all:
+   *   - allowance remains  → the 429 is not what it says; name the stale session.
+   *   - reading failed     → say we could not confirm, rather than asserting.
+   *   - allowance is zero  → the message was right; keep it, drop the hedging.
+   *
+   * The response is REBUILT rather than replaced: `details` (and therefore
+   * `ErrorInfo.reason`) are preserved verbatim, because `classifyTerminalError`
+   * re-parses this body upstream and must reach the same verdict. Only
+   * `error.message` gains text. An unparseable body is passed through untouched.
+   */
+  private async explainTerminalQuota(
+    response: Response,
+    bodyText: string,
+    reason: string | undefined
+  ): Promise<Response> {
+    const remaining = await this.quotaRemainingForServedModel();
+    const model = this.servedModelName;
+
+    let advice: string;
+    if (remaining !== undefined && remaining > 0) {
+      advice =
+        `your Antigravity plan still reports ${(remaining * 100).toFixed(1)}% of the ${model} ` +
+        "allowance available, so this is probably NOT an exhausted plan. The usual cause is an " +
+        "Antigravity session Google invalidated server-side; run `claudish login antigravity`.";
+    } else if (remaining === undefined) {
+      advice =
+        "claudish could not read your Antigravity quota to confirm this. If your plan is not " +
+        "actually spent, the session may be stale — run `claudish login antigravity`.";
+    } else {
+      advice = `your Antigravity plan reports no remaining ${model} allowance; it refills on Google's own schedule.`;
+    }
+
+    logStderr(`[Antigravity] Terminal 429 (${reason || "daily limit"}) — ${advice}`);
+
+    let parsed: any;
+    try {
+      parsed = JSON.parse(bodyText);
+    } catch {
+      return response;
+    }
+    const target = Array.isArray(parsed) ? parsed[0]?.error : parsed?.error;
+    if (!target || typeof target !== "object") return response;
+    const upstream =
+      typeof target.message === "string" && target.message.length > 0
+        ? target.message
+        : "Resource has been exhausted";
+    target.message = `${upstream} — ${advice}`;
+
+    return new Response(JSON.stringify(parsed), {
+      status: 429,
       headers: { "Content-Type": "application/json" },
     });
   }

--- a/packages/cli/src/providers/transport/types.ts
+++ b/packages/cli/src/providers/transport/types.ts
@@ -90,6 +90,33 @@ export interface ProviderTransport {
   forceRefreshAuth?(): Promise<void>;
 
   /**
+   * Optional per-provider verdict on whether an error response is TERMINAL
+   * (won't recover on retry) — the transport's own reading of its provider's
+   * error dialect.
+   *
+   * `true` / `false` are authoritative and override the shared substring
+   * heuristics in `isTerminal429` / `getRecoveryHint`; `undefined` means "no
+   * opinion, use the generic rules", which is also what every transport that
+   * omits this hook gets.
+   *
+   * It exists because a substring heuristic cannot read a structured error.
+   * Google answers EVERY `RESOURCE_EXHAUSTED` — including a plain per-minute
+   * rate limit — with the boilerplate "Resource has been exhausted (e.g. check
+   * quota).", and the shared exhaustion-wording list matches on the bare word
+   * "quota". So a transient throttle was surfaced to the user as "Out of quota
+   * — check your plan & billing details. This won't recover on retry.", a
+   * confident false statement in two directions, while the SAME transport had
+   * already parsed `google.rpc.ErrorInfo.reason: RATE_LIMIT_EXCEEDED` and
+   * correctly called it retryable. The layer that understands the dialect gets
+   * the final say.
+   *
+   * MUST be a pure function of (status, bodyText) — the handler calls it on a
+   * body it already holds, and a handler instance can serve overlapping
+   * requests, so per-request state on the transport would race.
+   */
+  classifyTerminalError?(status: number, bodyText: string): boolean | undefined;
+
+  /**
    * Optional payload transformation before sending.
    * Used by providers that wrap the payload in an envelope (e.g., CodeAssist).
    * Called after adapter.buildPayload() + adapter.prepareRequest().


### PR DESCRIPTION
## The bug

`ag@` requests failed with:

```
antigravity   ag@gemini-3.7-flash   state=out-of-credit  http=429
   msg: Antigravity Ultra error (HTTP 429): Out of quota — check your plan &
        billing details. This won't recover on retry. — Resource has been exhausted
```

The account was not out of quota. The message is a confident false statement in two directions: it blames billing (sending users to a dashboard showing nothing wrong) and asserts the failure "won't recover on retry" — while the chain `antigravity → google → openrouter` silently moves them onto a **metered** hop for a model their subscription already covers.

## Root cause — a layering violation

Google stamps `"Resource has been exhausted (e.g. check quota)."` on **every** `RESOURCE_EXHAUSTED` reply, including a plain per-minute throttle. claudish's shared classifier (`isTerminal429` → `hasQuotaExhaustionWording`) matches the **bare substring `"quota"`**, so every Google 429 was marked terminal billing exhaustion.

The Antigravity transport had *already* parsed `google.rpc.ErrorInfo.reason` and correctly called those 429s retryable. Two classifiers answered one question and the less-informed one won.

Measured — same bodies, transport verdict vs shipped generic verdict:

| body | transport | generic (shipped) |
|---|---|---|
| `QUOTA_EXHAUSTED` | terminal | terminal |
| `RATE_LIMIT_EXCEEDED` | **retryable** | terminal ❌ |
| `MODEL_CAPACITY_EXHAUSTED` | **retryable** | terminal ❌ |
| `QuotaFailure` per-minute | **retryable** | terminal ❌ |
| bare `RESOURCE_EXHAUSTED` | **retryable** | terminal ❌ |
| same body, word `quota` removed | — | retryable ✅ |

That last row is the control: the sole discriminator was the substring.

## The fix

- **`types.ts`** — optional `ProviderTransport.classifyTerminalError(status, body)`. `undefined` = no opinion, so the other ~15 transports are unchanged.
- **`antigravity.ts`** — implements it from `classify429`. `MODEL_CAPACITY_EXHAUSTED` becomes non-terminal: capacity returns in seconds, so retrying is the remedy, and calling it terminal is how a capacity fault claimed the quota message.
- **`composed-handler.ts`** — computes the verdict **once** and threads it into both `isTerminalError` and `getRecoveryHint`, so the hint and the remap cannot disagree.

### The stale session the false message was hiding

- **`antigravity-token.ts`** — new `forceRefreshAntigravityToken()`. `needsRefresh()` consults only the **clock**, so a server-invalidated token with a future `expiry` was re-presented forever. Stamping the stored expiry into the past before calling agy is load-bearing: `agy models` re-mints only when *agy* believes the token expired, so without it the refresh is a silent no-op on exactly this failure. A failed re-mint restores the original record verbatim.
- **`antigravity.ts`** — implements `forceRefreshAuth()`, wiring into the **pre-existing** generic `401 → forceRefreshAuth → retry once` loop in ComposedHandler that Vertex uses and Antigravity had simply never opted into. It also calls `resetAntigravityUserCache()`, which until now had **zero callers**.
- **`antigravity.ts`** — a terminal-quota 429 is now **fact-checked** against `retrieveUserQuota` (3s race, degrading to an honest "couldn't confirm") instead of asserting exhaustion from the shape of an error body.

## Live validation

Reproduced the exact reported wire condition against the real Antigravity backend:

| | before | now |
|---|---|---|
| probe state | `out-of-credit` | **`rate-limited`** |
| message | "Out of quota … won't recover on retry." | **"Resource has been exhausted (e.g. check quota)."** |
| HTTP | remapped to 400 | **429 preserved** → client retries, chain advances |

## Tests

Authored via Codex. **Five mutation proofs, each independently re-run:**

| Mutation | Reintroduces | Result |
|---|---|---|
| Remove the expiry stamp | force-refresh silently no-ops | 2 red |
| Neuter `classifyTerminalError` | substring heuristic wins again | 7 red |
| Revert handler wiring | 429 remapped to the billing claim | 2 red |
| Disable the 401 guard | no recovery from a rejected token | 3 red |
| Rename Antigravity's hook | **the original bug, exactly** | 1 red |

The 401 loop had no test anywhere in the repo before this — the mechanism the whole fix depends on was unverified.

## Not covered

- The report's "429 with no `ErrorInfo.reason` → force refresh" was **declined**: `agy models` is a subprocess with a 40s timeout, and firing it on ordinary rate limits would add that to the commonest failure path.
- **403 is not treated as refreshable** — per `CLAUDE.md`, cloudcode-pa's 403 `PERMISSION_DENIED` is the wrong-OAuth-client signal, which a refresh cannot fix.
- The original reporter's repro was never reproduced by them or me, and no captured Antigravity 429 exists in this repo, so the test bodies are canonical `google.rpc` shapes and the 401 path is fixed on structural grounds.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
