### PR TITLE
feat(mcp): preflight tool; fix swe-* routing, explicit chains, SUB pricing, and 401 misclassification

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -944,11 +944,26 @@ Uses the low-level `Server` class (not `McpServer`) from `@modelcontextprotocol/
 - **SignalWatcher** — per-session state machine (starting→running→tool_executing→waiting_for_input→completed/failed/cancelled)
 - **ScrollbackBuffer** — in-memory ring buffer (2000 lines) for session output
 
-### MCP Tools (11 total)
+### MCP Tools (12 total)
 
 - **Low-level** (4): `run_prompt`, `list_models`, `search_models`, `compare_models`
-- **Agentic** (2): `team`, `report_error`
+- **Agentic** (3): `preflight`, `team`, `report_error`
 - **Channel** (5): `create_session`, `send_input`, `get_output`, `cancel_session`, `list_sessions`
+
+`preflight` exists because `--probe` is CLI-ONLY. An MCP consumer had no way to
+check a roster before committing to it, so it either shelled out to the CLI or
+discovered provisioning failures minutes in with the slots already spent — a real
+`team` run lost 3 of 10 slots that way. It reports, per model, WHICH provider
+would serve it (via `route()`, the same rules and credential filter a real run
+uses), whether that hop is flat-rate or METERED, and whether it is reachable now.
+The billing column is the non-obvious half: subscription-vs-metered is a property
+of the PROVIDER, not the model, so the same bare name can be free through a plan
+or billed per token depending on which credential is present — which is precisely
+what a caller cannot see from the model id.
+
+The roster is pinned by an EXACT frozen array in `channel/e2e-channel.test.ts`, so
+adding or removing a tool without updating that test fails CI. That is deliberate:
+it is a wire contract, and an accidental change to the tool surface should be loud.
 
 Tool gating via `CLAUDISH_MCP_TOOLS` env var: `all` (default), `low-level`, `agentic`, `channel`.
 

--- a/ai-docs/reports/models-index-recommended-catalog-subscription-gap.md
+++ b/ai-docs/reports/models-index-recommended-catalog-subscription-gap.md
@@ -1,0 +1,120 @@
+# models-index gap: `subscriptionPlans` does not reach the recommended catalog
+
+**For:** the `models-index` repo (MadAppGang/models-index)
+**Filed from:** claudish, 2026-08-18
+**Status:** open — claudish side is fixed and shipped; the remaining half is backend data
+
+---
+
+## One-line ask
+
+`?catalog=recommended` should emit the `subscription` object for every model whose full
+document carries `subscriptionPlans`. Today it does so for some models and not others, and
+claudish cannot tell the difference from the outside.
+
+---
+
+## Why this matters
+
+Claudish renders a model's price in `--models-top` and in the MCP `list_models` tool. When a
+model has no per-token rate it used to print a bare `N/A`, which reads as *"unknown / never
+provisioned"*. That is not a cosmetic problem: it caused a real mis-triage. A reporter looked
+at `swe-1.7` showing `N/A`, concluded the model was not provisioned, and filed it as
+unroutable — while `dv@swe-1.7` was serving 509-token replies the whole time.
+
+**`N/A` is usually the truthful answer for these models.** They are subscription-only and the
+vendor publishes no standalone per-token rate — and the catalog says so, per model, in
+`pricingSummary`. The problem was never the missing number; it was that claudish had no way to
+say *why* it was missing.
+
+Claudish now renders `SUB` (its existing flat-rate label) whenever a model has no rate **and**
+the recommended catalog names a subscription that includes it. That fix is live. It works for
+exactly the models the backend supplies `subscription` for.
+
+---
+
+## The measured gap
+
+Both models below are subscription-only with no published per-token rate. Both should render
+`SUB`. Only one does, because only one carries `subscription` on the recommended catalog.
+
+### `swe-1.7` — correct today
+
+```jsonc
+// GET ?search=swe-1.7
+{ "modelId": "swe-1.7",
+  "subscriptionPlans": ["cognition-devin"],
+  "pricingSummary": "SWE-1.7 is available in Devin (Web, Desktop, and CLI) via Cerebras at
+                     1000 TPS. Cognition does not publish standalone token pricing, context
+                     window, or max output token limits for this model row." }
+
+// GET ?catalog=recommended
+{ "id": "swe-1.7",
+  "pricing": { "input": "N/A", "output": "N/A", "average": "N/A" },
+  "subscription": { "prefix": "dv", "plan": "Devin", "command": "dv@swe-1.7" } }   // ✅ present
+```
+
+claudish renders: **`SUB`** (and `SUB (Devin)` on markdown surfaces).
+
+### `glm-5.3` — the gap
+
+```jsonc
+// GET ?search=glm-5.3
+{ "modelId": "glm-5.3",
+  "subscriptionPlans": ["z-ai-glm-coding-plan"],                                    // ← known here
+  "pricingSummary": "Available to all GLM Coding Plan users; Z.ai says the standalone API is
+                     coming soon, so it does not yet publish a per-token API rate for this
+                     model.",
+  "contextWindow": 1000000, "maxOutputTokens": 128000 }
+
+// GET ?catalog=recommended
+{ "id": "glm-5.3",
+  "pricing": { "input": "N/A", "output": "N/A", "average": "N/A" },
+  /* no "subscription" key */ }                                                     // ❌ absent
+```
+
+claudish renders: **`N/A`** — indistinguishable from a model nobody can reach.
+
+Counts at time of filing: the recommended catalog returns **30** models, **10** of which carry
+`subscription`. `glm-5.3` is not one of them despite having `subscriptionPlans` upstream.
+
+---
+
+## Suggested fix
+
+In whatever projection builds `?catalog=recommended`, derive `subscription` from the model
+document's `subscriptionPlans` rather than from a separate source, so the two endpoints cannot
+disagree. `z-ai-glm-coding-plan` maps to claudish's `gc@` GLM Coding Plan provider, so the
+entry would be roughly:
+
+```jsonc
+"subscription": { "prefix": "gc", "plan": "GLM Coding Plan", "command": "gc@glm-5.3" }
+```
+
+If a plan id has no claudish prefix, emitting `{ "plan": "<name>" }` alone is still a strict
+improvement — claudish only needs `plan` to render `SUB`, and `prefix`/`command` are used for
+the `via:` line.
+
+---
+
+## Two smaller notes, same area
+
+1. **Field name.** Claudish's `ModelDoc` declared `availableInPlans` and read it nowhere,
+   while the API sends `subscriptionPlans`. Fixed on the claudish side — flagged only in case
+   `availableInPlans` is a name the backend once used and something else still reads it.
+
+2. **`pricingSummary` is not on the recommended catalog.** It is the single most useful
+   sentence for explaining an absent price, and it exists per model on `?search=`. If it were
+   included in the recommended projection, claudish could show the vendor's own reason instead
+   of a two-letter label. Not required for the fix above — `subscription` alone resolves the
+   mis-triage — but it would make the answer self-explaining.
+
+---
+
+## What claudish will NOT do
+
+Per the repo boundary rule, claudish does not paper over catalog gaps in the CLI: no per-model
+cloud lookup to fill in missing fields (`catalog-client.ts` is explicit that re-querying the
+cloud one model at a time is not how this works), and no hardcoded model→plan table. Until the
+recommended catalog carries `subscription` for `glm-5.3`, claudish will keep rendering `N/A`
+for it — correctly, because from claudish's side that is genuinely unknown.

--- a/packages/cli/src/channel/e2e-channel.test.ts
+++ b/packages/cli/src/channel/e2e-channel.test.ts
@@ -81,7 +81,7 @@ describe("Group 1: MCP Protocol — channel capability", () => {
     expect(instructions).toContain("completed");
   });
 
-  test("lists all 11 tools (6 existing + 5 channel)", async () => {
+  test("lists the exact public tool roster", async () => {
     const result = await client.listTools();
     const names = result.tools.map((t) => t.name).sort();
     expect(names).toEqual([
@@ -91,6 +91,7 @@ describe("Group 1: MCP Protocol — channel capability", () => {
       "get_output",
       "list_models",
       "list_sessions",
+      "preflight",
       "report_error",
       "run_prompt",
       "search_models",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -25,6 +25,7 @@ import {
   getTop100Models,
   groupRecommendedModels,
   loadModelInfo,
+  formatListingPrice,
   normalizePricingDisplay,
   searchModels,
 } from "./model-loader.js";
@@ -1027,7 +1028,7 @@ async function printRecommendedModels(jsonOutput: boolean, forceUpdate: boolean)
     const modelId = rawId.length > 28 ? `${rawId.substring(0, 25)}...` : rawId;
     const modelIdPadded = modelId.padEnd(28);
 
-    const pricing = normalizePricingDisplay(m.pricing?.average);
+    const pricing = formatListingPrice(m, { compact: true });
     const pricingPadded = pricing.padEnd(10);
 
     const context = m.context || "N/A";
@@ -1332,6 +1333,66 @@ async function probeModelRouting(
   }
 
   /**
+   * The ONE chain entry an explicit `provider@model` address resolves to.
+   *
+   * `buildModelChain` returns `routes: []` for an explicit spec because there is
+   * no fallback chain to walk — it is pinned to a single provider. Emitting that
+   * raw made `--probe --json` report `chain: []` for a perfectly healthy model,
+   * with the real outcome hidden in `directProbe`. Anyone reading `chain` to
+   * decide routability concluded "dead route": `dv@swe-1.7` was filed as
+   * unroutable twice while it was serving 509-token replies.
+   *
+   * So an explicit address now yields a ONE-ITEM chain, and `[]` is reserved for
+   * its literal meaning — no provider can serve this, whether because the
+   * provider name resolves to nothing or because no fallback exists. Empty now
+   * says "no route" in both the bare and explicit cases instead of doubling as
+   * "not applicable here".
+   *
+   * Shared with `buildResultLinks` on purpose: the TUI row and the JSON chain
+   * disagreeing about the same address is the defect, not a rendering detail.
+   */
+  function buildDirectChainEntry(
+    parsed: ReturnType<typeof parseModelSpec>,
+    directProbe: ProbeResult | undefined
+  ): ReturnType<typeof buildModelChain>["chainDetails"] {
+    const providerDef = getProviderByName(parsed.provider);
+    const keyInfo = API_KEY_MAP[parsed.provider];
+    // Nothing known by this name — genuinely unroutable, so the chain stays
+    // empty and now MEANS empty.
+    if (!providerDef && !keyInfo) return [];
+
+    let hasCredentials: boolean;
+    let provenance: KeyProvenance | undefined;
+    if (providerDef?.isLocal) {
+      hasCredentials = isLocalProviderEnabled(parsed.provider);
+    } else if (!keyInfo?.envVar) {
+      hasCredentials = true;
+    } else {
+      provenance = resolveApiKeyProvenance(keyInfo.envVar, keyInfo.aliases);
+      hasCredentials =
+        provenance.hasValue || (keyInfo.aliases?.some((a) => !!process.env[a]) ?? false);
+    }
+
+    return [
+      {
+        provider: parsed.provider,
+        displayName: providerDef?.displayName ?? parsed.provider,
+        // The RESOLVED bare id, never the raw provider@-prefixed input, so the
+        // row never reads `provider@provider@model`.
+        modelSpec: parsed.model,
+        hasCredentials,
+        credentialHint: !hasCredentials
+          ? providerDef?.isLocal
+            ? "enable local provider in global config"
+            : keyInfo?.envVar
+          : undefined,
+        provenance,
+        probe: directProbe,
+      },
+    ];
+  }
+
+  /**
    * Build the provider-comparison links the Details tab renders. For EXPLICIT /
    * direct models buildModelChain returns an empty chain (the probe lives in
    * directProbe), so we synthesize a single link carrying that probe — the model
@@ -1568,7 +1629,13 @@ async function probeModelRouting(
           isExplicit: parsed.isExplicitProvider,
           routingSource: chain.source,
           matchedPattern: chain.matchedPattern,
-          chain: chainDetails,
+          // An explicit address resolves to exactly ONE route, so report it as a
+          // one-item chain rather than `[]`. `directProbe` stays for
+          // backwards-compatible readers.
+          chain:
+            chainDetails.length > 0
+              ? chainDetails
+              : buildDirectChainEntry(parsed, directProbeResult),
           directProbe: directProbeResult,
           wiring,
         });

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -50,6 +50,7 @@ import {
 import { API_KEY_MAP } from "./providers/api-key-map.js";
 import { type KeyProvenance, resolveApiKeyProvenance } from "./providers/api-key-provenance.js";
 import type { FallbackRoute } from "./providers/auto-route.js";
+import { latestOpusModelId } from "./providers/catalog-client.js";
 import { ensureEndpointsRegistered } from "./providers/endpoint-registration.js";
 import { parseModelChain, parseModelSpec } from "./providers/model-parser.js";
 import { fetchOllamaModels } from "./providers/ollama-discovery.js";
@@ -1197,14 +1198,24 @@ async function probeModelRouting(
       // may fold this into a shared helper.
       if (parsed.provider === "native-anthropic") {
         // The probe hits the Anthropic API directly, so this must be a real
-        // API-valid model id — NOT Claude Code's internal alias (`claude-opus-4-8`
-        // is the CLI's tier name and the API rejects it with "not a valid model
-        // ID"). `claude-opus-4-1` is the current Opus alias the API accepts
-        // (verified against api.anthropic.com). Honor an explicit override.
+        // API-valid model id. It used to be the literal `claude-opus-4-1`, under
+        // a comment asserting that was "the current Opus alias the API accepts
+        // (verified against api.anthropic.com)" and that `claude-opus-4-8` was
+        // rejected. Measured 2026-08-18 against the real API, BOTH claims are
+        // now false: `claude-opus-4-1` returns 404 not_found_error, and
+        // `claude-opus-4-8` returns 200. A verification note carries no expiry,
+        // so it stayed confident long after the fact changed — which is exactly
+        // the failure mode the no-hardcoded-model-data rule exists to prevent.
+        //
+        // Resolved by RULE instead: newest released `claude-opus-*` in the
+        // catalog. The literal below is a cold-catalog last resort only (no
+        // cache on a first run), and is deliberately the newest id verified 200
+        // today rather than a stable-looking alias.
         const opusModel =
           process.env[ENV.CLAUDISH_MODEL_OPUS] ||
           process.env[ENV.ANTHROPIC_DEFAULT_OPUS_MODEL] ||
-          "claude-opus-4-1";
+          latestOpusModelId() ||
+          "claude-opus-5";
         // IMPORTANT: pin a BARE model name (no `provider@`). The proxy resolves
         // the native passthrough via `isNative` = no "/" AND no "@" — pinning
         // `native-anthropic@...` would set hasExplicitProvider=true and DEFEAT

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,6 +18,7 @@ import {
   type RecommendedModelGroup,
   collectRoutingPrefixes,
   computeQuickPicks,
+  formatListingPrice,
   getAvailableModels,
   getModelsByProvider,
   getProviderList,
@@ -25,7 +26,6 @@ import {
   getTop100Models,
   groupRecommendedModels,
   loadModelInfo,
-  formatListingPrice,
   normalizePricingDisplay,
   searchModels,
 } from "./model-loader.js";

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -50,7 +50,8 @@ import {
 import { API_KEY_MAP } from "./providers/api-key-map.js";
 import { type KeyProvenance, resolveApiKeyProvenance } from "./providers/api-key-provenance.js";
 import type { FallbackRoute } from "./providers/auto-route.js";
-import { latestOpusModelId } from "./providers/catalog-client.js";
+import { latestAnthropicTierModelId } from "./providers/catalog-client.js";
+import { claudeCodeTierAlias } from "./providers/claude-code-aliases.js";
 import { ensureEndpointsRegistered } from "./providers/endpoint-registration.js";
 import { parseModelChain, parseModelSpec } from "./providers/model-parser.js";
 import { fetchOllamaModels } from "./providers/ollama-discovery.js";
@@ -1197,25 +1198,42 @@ async function probeModelRouting(
       // NOTE: mirrors the upstream proxy precedence; a later routing worktree
       // may fold this into a shared helper.
       if (parsed.provider === "native-anthropic") {
-        // The probe hits the Anthropic API directly, so this must be a real
-        // API-valid model id. It used to be the literal `claude-opus-4-1`, under
-        // a comment asserting that was "the current Opus alias the API accepts
-        // (verified against api.anthropic.com)" and that `claude-opus-4-8` was
-        // rejected. Measured 2026-08-18 against the real API, BOTH claims are
-        // now false: `claude-opus-4-1` returns 404 not_found_error, and
-        // `claude-opus-4-8` returns 200. A verification note carries no expiry,
-        // so it stayed confident long after the fact changed — which is exactly
-        // the failure mode the no-hardcoded-model-data rule exists to prevent.
+        // Substitute a concrete id ONLY for a Claude Code TIER ALIAS.
         //
-        // Resolved by RULE instead: newest released `claude-opus-*` in the
-        // catalog. The literal below is a cold-catalog last resort only (no
-        // cache on a first run), and is deliberately the newest id verified 200
-        // today rather than a stable-looking alias.
-        const opusModel =
-          process.env[ENV.CLAUDISH_MODEL_OPUS] ||
-          process.env[ENV.ANTHROPIC_DEFAULT_OPUS_MODEL] ||
-          latestOpusModelId() ||
-          "claude-opus-5";
+        // `parseModelSpec` sends every unrecognised bare name here, so this
+        // branch receives two different things. `opus` / `sonnet` / `internal`
+        // are Claude Code's own selectors: the API rejects them as model ids
+        // while the ROUTE is healthy, so they must be resolved to something real
+        // or the probe reports a failure that does not exist. A concrete name
+        // like `swe-1.7` or a typo is the opposite case — `native-handler.ts`
+        // forwards `payload.model` VERBATIM at runtime and Anthropic answers 404,
+        // so substituting here made `--probe` report `live` for a model that
+        // could not serve one request.
+        //
+        // That substitution is why `swe-1.7` "probed byte-identically to a
+        // nonsense string": both were rewritten to the same working id before
+        // the request went out, erasing the difference the probe exists to show.
+        // Unknown names now go through untouched and the API answers for itself.
+        const tier = claudeCodeTierAlias(parsed.model);
+        // The literal is a cold-catalog last resort (first run, no cache, no env
+        // override). It replaced `claude-opus-4-1`, which sat here under a
+        // comment asserting it was "the current Opus alias the API accepts
+        // (verified against api.anthropic.com)" and that `claude-opus-4-8` was
+        // rejected — measured 2026-08-18, that id returns 404 and 4-8 returns
+        // 200, so both halves had rotted. A verification note carries no expiry
+        // date, which is the failure the no-hardcoded-model-data rule prevents.
+        const tierEnv: Record<string, string | undefined> = {
+          opus:
+            process.env[ENV.CLAUDISH_MODEL_OPUS] || process.env[ENV.ANTHROPIC_DEFAULT_OPUS_MODEL],
+          sonnet:
+            process.env[ENV.CLAUDISH_MODEL_SONNET] ||
+            process.env[ENV.ANTHROPIC_DEFAULT_SONNET_MODEL],
+          haiku:
+            process.env[ENV.CLAUDISH_MODEL_HAIKU] || process.env[ENV.ANTHROPIC_DEFAULT_HAIKU_MODEL],
+        };
+        const opusModel = tier
+          ? tierEnv[tier] || latestAnthropicTierModelId(tier) || "claude-opus-5"
+          : parsed.model;
         // IMPORTANT: pin a BARE model name (no `provider@`). The proxy resolves
         // the native passthrough via `isNative` = no "/" AND no "@" — pinning
         // `native-anthropic@...` would set hasExplicitProvider=true and DEFEAT
@@ -1227,7 +1245,7 @@ async function probeModelRouting(
             {
               provider: "native-anthropic",
               modelSpec: opusModel,
-              displayName: "Claude Code (Opus)",
+              displayName: tier ? `Claude Code (${tier})` : "Claude Code",
             },
           ] as FallbackRoute[],
           source: "auto-chain" as const,

--- a/packages/cli/src/handlers/composed-handler-error.test.ts
+++ b/packages/cli/src/handlers/composed-handler-error.test.ts
@@ -166,6 +166,28 @@ describe("ComposedHandler.handle — error surfacing wiring", () => {
     expect(captured.body?.error?.message).toContain("invalid api key");
   });
 
+  test("a model-unsupported 401 surfaces the model hint instead of an API-key hint", async () => {
+    stubUpstream(401, {
+      error: { message: "Model deepseek-v4-pro-0813 is not supported" },
+    });
+    const { c, captured } = makeContext();
+
+    await makeHandler().handle(c, PAYLOAD);
+
+    expect(captured.body?.error?.message).toContain("Model not supported by this provider");
+    expect(captured.body?.error?.message).not.toContain("Check API key");
+  });
+
+  test("an invalid-key 401 surfaces the credential recovery hint", async () => {
+    stubUpstream(401, { error: { message: "Invalid API key." } });
+    const { c, captured } = makeContext();
+
+    await makeHandler().handle(c, PAYLOAD);
+
+    expect(captured.body?.error?.message).toContain("Check API key / OAuth credentials");
+    expect(captured.body?.error?.message).not.toContain("Model not supported by this provider");
+  });
+
   test("transient 503 keeps its retryable status (Claude Code SHOULD retry)", async () => {
     stubUpstream(503, { error: { message: "temporary overload", type: "server_error" } });
     const { c, captured } = makeContext();

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -54,6 +54,7 @@ import {
 import { sseResponseToJson } from "./shared/collect-sse-message.js";
 import { buildConnectionErrorMessage, classifyConnectionError } from "./shared/connection-error.js";
 import { sniffDevinStreamHead } from "./shared/devin-stream-head-sniffer.js";
+import { hasModelUnsupportedWording } from "./shared/model-unsupported.js";
 import { filterIdentity } from "./shared/openai-compat.js";
 import { isQuotaExhaustionError } from "./shared/quota-exhaustion.js";
 import { sniffResponsesStreamHead } from "./shared/stream-head-sniffer.js";
@@ -1604,12 +1605,12 @@ function getRecoveryHint(
     return "Rate limited. Wait, reduce concurrency, or check plan limits.";
   }
   if (status === 401 || status === 403) {
-    // Some providers (e.g. OpenCode Zen) return 401 for unsupported models, not auth failures
-    if (
-      lower.includes("not supported") ||
-      lower.includes("unsupported model") ||
-      lower.includes("model not found")
-    ) {
+    // Some providers (e.g. OpenCode Zen Go) return 401 for a model they do not
+    // carry, not for a bad credential. Shared with probe-live's state
+    // classifier — see shared/model-unsupported.ts for why one predicate rather
+    // than two: this hint said "model not supported" while the probe state said
+    // `auth-failed`, so the two surfaces disagreed about the same response.
+    if (hasModelUnsupportedWording(errorText)) {
       return "Model not supported by this provider. Verify model name.";
     }
     // A plan that has run out is not an auth failure, but some providers report

--- a/packages/cli/src/handlers/shared/model-unsupported.test.ts
+++ b/packages/cli/src/handlers/shared/model-unsupported.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { hasModelUnsupportedWording } from "./model-unsupported.js";
+
+const UNSUPPORTED_PHRASES = [
+  "not supported",
+  "unsupported model",
+  "unsupported_model",
+  "model not found",
+  "model_not_found",
+  "unknown model",
+  "no such model",
+] as const;
+
+function anthropicErrorBody(type: string, message: string): string {
+  return JSON.stringify({ type: "error", error: { type, message } });
+}
+
+describe("hasModelUnsupportedWording", () => {
+  test("matches every supported phrase case-insensitively inside a realistic error body", () => {
+    for (const phrase of UNSUPPORTED_PHRASES) {
+      const body = anthropicErrorBody(
+        "invalid_request_error",
+        `OpenCode Zen Go rejected deepseek-v4-pro-0813: ${phrase.toUpperCase()}.`
+      );
+
+      expect(hasModelUnsupportedWording(body)).toBe(true);
+    }
+  });
+
+  test("does not mistake authentication-failure wording for an unsupported model", () => {
+    const authFailures = [
+      "Invalid API key.",
+      "invalid",
+      "unauthorized",
+      "permission denied",
+      "forbidden",
+      "authentication failed",
+      "invalid token",
+    ] as const;
+
+    // A false positive here sends a user with genuinely broken credentials to
+    // check their model name instead of fixing the credential that actually failed.
+    for (const message of authFailures) {
+      const body = anthropicErrorBody("authentication_error", message);
+      expect({ message, matched: hasModelUnsupportedWording(body) }).toEqual({
+        message,
+        matched: false,
+      });
+    }
+  });
+
+  test("returns false without throwing for empty and undefined-ish input", () => {
+    const inputs = ["", undefined, null] as const;
+
+    for (const input of inputs) {
+      const invoke = () => hasModelUnsupportedWording(input as unknown as string);
+      expect(invoke).not.toThrow();
+      expect(invoke()).toBe(false);
+    }
+  });
+});

--- a/packages/cli/src/handlers/shared/model-unsupported.ts
+++ b/packages/cli/src/handlers/shared/model-unsupported.ts
@@ -1,0 +1,67 @@
+/**
+ * Detecting "this provider does not carry that model" from an error response.
+ *
+ * ## Why this needs its own module
+ *
+ * Providers do not agree on how to report an unknown model, and some report it
+ * under a status reserved for something else entirely. OpenCode Zen Go answers
+ * **HTTP 401** with `"Model deepseek-v4-pro-0813 is not supported"` — a status
+ * that otherwise means "your credential is bad". Measured 2026-08-18 against a
+ * real `OPENCODE_GO_API_KEY`: `zgo@deepseek-v4-pro-0813` returns 401 while
+ * `zgo@kimi-k3` on the SAME key returns 200. The credential is provably fine and
+ * the status is provably misleading.
+ *
+ * That matters because Zen Go sits early in a bare-name chain
+ * (`deepseek-*` → opencode-zen-go → deepseek → openrouter). The chain still
+ * advances — `isRetryableError` treats 401 as retryable, and OpenRouter probes
+ * `live` — so no service is lost. What IS lost is the diagnosis: the probe
+ * reported `auth-failed`, sending the user to check credentials that are
+ * working, and burying the fact that a live hop exists further down.
+ *
+ * Two places must tell these apart, and they must not drift:
+ *
+ * 1. `composed-handler.ts` picks the user-facing hint. It already had this test
+ *    inline and got it right — "Model not supported by this provider."
+ * 2. `probe-live.ts` classifies the probe STATE, and did not — it returned
+ *    `auth-failed` on the status alone, before any body inspection.
+ *
+ * One predicate, so the explanation and the state cannot disagree about what
+ * happened. Same reasoning as `quota-exhaustion.ts`, which exists because a
+ * spent plan also arrives under an auth-shaped status.
+ *
+ * Deliberately import-free: `probe-live.ts` has no dependencies at all, and a
+ * pure string test keeps it that way with no risk of an import cycle.
+ */
+
+/**
+ * Phrases that name the MODEL as the problem rather than the credential.
+ *
+ * Deliberately narrow, and the narrowness is load-bearing in the dangerous
+ * direction: a false positive here tells a user with genuinely broken
+ * credentials to go and check their model name instead. So every phrase names a
+ * model or says "not supported" — never bare "invalid", "denied" or
+ * "unauthorized", which are the vocabulary of real auth failures.
+ */
+const UNSUPPORTED_PHRASES = [
+  "not supported",
+  "unsupported model",
+  "unsupported_model",
+  "model not found",
+  "model_not_found",
+  "unknown model",
+  "no such model",
+] as const;
+
+/**
+ * True when this error body says the provider does not carry the requested
+ * model, whatever status it arrived under.
+ *
+ * Status-agnostic ON PURPOSE: the whole point is that the status lies. Callers
+ * that care about the status combine this with their own check — `probe-live`
+ * consults it only for 401/403, because a 404 already means model-not-found and
+ * needs no wording test.
+ */
+export function hasModelUnsupportedWording(errorBody: string): boolean {
+  const lower = (errorBody || "").toLowerCase();
+  return UNSUPPORTED_PHRASES.some((phrase) => lower.includes(phrase));
+}

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -22,6 +22,7 @@ import { config } from "dotenv";
 import { prehydrateCredentialsForSpawn } from "./auth/credentials/prehydrate.js";
 import { installWireTap, watchNotificationResult, wrapStateChange } from "./channel/diagnostics.js";
 import { SessionManager } from "./channel/index.js";
+import { isSubscriptionProvider } from "./handlers/shared/remote-provider-types.js";
 import {
   type HeartbeatHandle,
   NOOP_HEARTBEAT,
@@ -34,19 +35,18 @@ import {
   type RecommendedModelsDoc,
   collectRoutingPrefixes,
   computeQuickPicks,
+  formatListingPrice,
   getRecommendedModels,
   groupRecommendedModels,
-  formatListingPrice,
   normalizePricingDisplay,
 } from "./model-loader.js";
 import { findAvailablePort } from "./port-manager.js";
-import { isSubscriptionProvider } from "./handlers/shared/remote-provider-types.js";
-import { isLocalProviderName } from "./providers/model-parser.js";
-import { isReadyState, probeLink } from "./providers/probe-live.js";
-import { route } from "./providers/routing-rules.js";
 import { compareByReleaseDateDesc } from "./providers/model-ordering.js";
+import { isLocalProviderName } from "./providers/model-parser.js";
 import { renderOpFailureBlock } from "./providers/onepassword.js";
+import { isReadyState, probeLink } from "./providers/probe-live.js";
 import { BUILTIN_PROVIDERS } from "./providers/provider-definitions.js";
+import { route } from "./providers/routing-rules.js";
 import { createProxyServer } from "./proxy-server.js";
 import { sanitizeForReport } from "./redact.js";
 import {

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -36,6 +36,7 @@ import {
   computeQuickPicks,
   getRecommendedModels,
   groupRecommendedModels,
+  formatListingPrice,
   normalizePricingDisplay,
 } from "./model-loader.js";
 import { findAvailablePort } from "./port-manager.js";
@@ -606,7 +607,7 @@ function defineTools(
 
       const renderGroup = (group: RecommendedModelGroup): string => {
         const m = group.primary;
-        const pricing = normalizePricingDisplay(m.pricing?.average);
+        const pricing = formatListingPrice(m);
         const ctx = m.context || "N/A";
         const caps: string[] = [];
         if (m.supportsTools) caps.push("tools");

--- a/packages/cli/src/mcp-server.ts
+++ b/packages/cli/src/mcp-server.ts
@@ -40,6 +40,10 @@ import {
   normalizePricingDisplay,
 } from "./model-loader.js";
 import { findAvailablePort } from "./port-manager.js";
+import { isSubscriptionProvider } from "./handlers/shared/remote-provider-types.js";
+import { isLocalProviderName } from "./providers/model-parser.js";
+import { isReadyState, probeLink } from "./providers/probe-live.js";
+import { route } from "./providers/routing-rules.js";
 import { compareByReleaseDateDesc } from "./providers/model-ordering.js";
 import { renderOpFailureBlock } from "./providers/onepassword.js";
 import { BUILTIN_PROVIDERS } from "./providers/provider-definitions.js";
@@ -823,6 +827,168 @@ function defineTools(
   });
 
   // ── Agentic Tools ────────────────────────────────────────────────────
+
+  tools.push({
+    name: "preflight",
+    description:
+      "Check a roster of models BEFORE spending a run on it. For each model: which provider " +
+      "will actually serve it, whether that hop is covered by a SUBSCRIPTION or billed per " +
+      "token, and whether it is reachable right now. Call this before `team` or a batch of " +
+      "`create_session` calls — a dead or unexpectedly-metered model is then caught while " +
+      "the roster can still be adjusted, instead of costing a slot minutes into the run.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        models: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Model ids to check — bare (`glm-5.2`) or explicit (`dv@swe-1.7`). Bare names go " +
+            "through the SAME routing rules and credential filter a real run would use, so " +
+            "the provider reported here is the provider that would serve it.",
+        },
+        probe: {
+          type: "boolean",
+          description:
+            "Send a real short request to each resolved route (default true). Set false for " +
+            "a routing/billing answer only — far faster, but it cannot tell you the provider " +
+            "is actually reachable, which is the failure this tool exists to catch.",
+        },
+        timeout_ms: {
+          type: "number",
+          description: "Per-model probe timeout in ms (default 20000).",
+        },
+      },
+      required: ["models"],
+    },
+    group: "agentic",
+    // N models each waiting on a live provider can sit well past the client's MCP
+    // idle window, and this tool is specifically meant to be called with a big
+    // roster — exactly the shape that gets aborted without a keepalive.
+    heartbeat: true,
+    handler: async (args, ctx) => {
+      const models = Array.isArray(args.models) ? (args.models as string[]) : [];
+      if (models.length === 0) {
+        return {
+          content: [{ type: "text" as const, text: "preflight: no models given." }],
+          isError: true,
+        };
+      }
+
+      const doProbe = args.probe !== false;
+      const timeoutMs = typeof args.timeout_ms === "number" ? args.timeout_ms : 20_000;
+      const proxy = doProbe ? await getProxy() : null;
+
+      const rows: string[] = [];
+      const readyModels: string[] = [];
+      const failedModels: string[] = [];
+      let subCount = 0;
+      let meteredCount = 0;
+
+      for (const model of models) {
+        ctx.reportProgress(`preflight: ${model}`);
+
+        let plan: Awaited<ReturnType<typeof route>>;
+        try {
+          plan = await route(model);
+        } catch (err) {
+          failedModels.push(model);
+          rows.push(
+            `| \`${model}\` | — | — | ❌ route error | ${err instanceof Error ? err.message : String(err)} |`
+          );
+          continue;
+        }
+
+        if (plan.kind === "no-route") {
+          // No credentialed provider can serve this at all. Reported as a FAILURE
+          // rather than omitted, because "this model is not in your roster" is the
+          // single most useful thing to learn before the run rather than during it.
+          failedModels.push(model);
+          rows.push(`| \`${model}\` | — | — | ❌ no route | ${plan.reason} |`);
+          continue;
+        }
+
+        const primary = plan.primary;
+        // Billing mode is a property of the PROVIDER, not the model — the same
+        // model can be flat-rate through a plan and metered through a vendor API,
+        // and which one a bare name lands on is exactly what a caller cannot see.
+        const billing = isLocalProviderName(primary.provider)
+          ? "local"
+          : isSubscriptionProvider(primary.provider)
+            ? "SUB"
+            : "metered";
+        if (billing === "SUB") subCount++;
+        else if (billing === "metered") meteredCount++;
+
+        let status = "not probed";
+        let ok = true;
+        if (proxy) {
+          try {
+            const result = await probeLink(
+              proxy.url,
+              {
+                provider: primary.provider,
+                // route() already credential-filtered, so a miss here would be a
+                // routing bug, not a missing key.
+                modelSpec: primary.modelSpec,
+                hasCredentials: true,
+              },
+              timeoutMs
+            );
+            ok = isReadyState(result.state);
+            status = ok
+              ? `✅ ${result.state}`
+              : `❌ ${result.state}${result.errorMessage ? ` — ${result.errorMessage}` : ""}`;
+          } catch (err) {
+            ok = false;
+            status = `❌ probe error — ${err instanceof Error ? err.message : String(err)}`;
+          }
+        }
+
+        if (ok) readyModels.push(model);
+        else failedModels.push(model);
+
+        const fallbacks = plan.fallbacks.length > 0 ? ` (+${plan.fallbacks.length} fallback)` : "";
+        rows.push(
+          `| \`${model}\` | ${primary.displayName}${fallbacks} | ${billing} | ${status} | \`${primary.modelSpec}\` |`
+        );
+      }
+
+      const lines = [
+        `# Preflight — ${models.length} model${models.length === 1 ? "" : "s"}`,
+        "",
+        `**Ready: ${readyModels.length}** · **Failed: ${failedModels.length}** · ` +
+          `subscription: ${subCount} · metered: ${meteredCount}`,
+        "",
+        "| Model | Provider | Billing | Status | Wire id |",
+        "|---|---|---|---|---|",
+        ...rows,
+      ];
+
+      if (failedModels.length > 0) {
+        lines.push(
+          "",
+          `⚠️ Drop or replace before running: ${failedModels.map((m) => `\`${m}\``).join(", ")}`
+        );
+      }
+      if (meteredCount > 0) {
+        lines.push(
+          "",
+          `💸 ${meteredCount} model${meteredCount === 1 ? "" : "s"} will be billed PER TOKEN. ` +
+            "A bare name can land on a metered provider when the subscription that covers it " +
+            "has no credential configured — name the provider explicitly to pin it."
+        );
+      }
+      if (!doProbe) {
+        lines.push(
+          "",
+          "ℹ️ `probe: false` — routing and billing only. Reachability was NOT checked."
+        );
+      }
+
+      return { content: [{ type: "text" as const, text: lines.join("\n") }] };
+    },
+  });
 
   tools.push({
     name: "team",

--- a/packages/cli/src/model-loader.test.ts
+++ b/packages/cli/src/model-loader.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { formatListingPrice } from "./model-loader.js";
+
+const swe17Entry = {
+  pricing: { input: "N/A", output: "N/A", average: "N/A" },
+  subscription: { prefix: "dv", plan: "Devin", command: "dv@swe-1.7" },
+};
+
+const glm53Entry = {
+  pricing: { input: "N/A", output: "N/A", average: "N/A" },
+};
+
+const claudeCodeSubscription = {
+  plan: "Claude Code",
+  command: "claude-fable-5",
+};
+
+describe("formatListingPrice", () => {
+  it("passes through a real rate and preserves FREE and varies normalization", () => {
+    expect(formatListingPrice({ pricing: { average: "$1.32/1M" } })).toBe("$1.32/1M");
+    expect(formatListingPrice({ pricing: { average: "$0.00/1M" } })).toBe("FREE");
+    expect(formatListingPrice({ pricing: { average: "-1000000" } })).toBe("varies");
+  });
+
+  it("renders swe-1.7's subscription plan when its rate is unavailable", () => {
+    expect(formatListingPrice(swe17Entry)).toBe("SUB (Devin)");
+  });
+
+  it("renders compact swe-1.7 pricing as SUB", () => {
+    expect(formatListingPrice(swe17Entry, { compact: true })).toBe("SUB");
+  });
+
+  it("keeps glm-5.3's unknown price as N/A in both display modes", () => {
+    expect(formatListingPrice(glm53Entry)).toBe("N/A");
+    expect(formatListingPrice(glm53Entry, { compact: true })).toBe("N/A");
+  });
+
+  it("prefers a real rate over a subscription plan", () => {
+    expect(
+      formatListingPrice({
+        pricing: { average: "$1.32/1M" },
+        subscription: claudeCodeSubscription,
+      })
+    ).toBe("$1.32/1M");
+  });
+});

--- a/packages/cli/src/model-loader.ts
+++ b/packages/cli/src/model-loader.ts
@@ -155,8 +155,25 @@ export interface ModelDoc {
   };
   contextWindow?: number;
   maxOutputTokens?: number;
-  /** IDs of subscription plans (e.g. "openai-codex", "kimi-coding") that include this model. */
-  availableInPlans?: string[];
+  /**
+   * IDs of subscription plans (e.g. "cognition-devin", "z-ai-glm-coding-plan")
+   * that include this model.
+   *
+   * NAME MATTERS: the backend sends `subscriptionPlans`. This field was declared
+   * as `availableInPlans` and read by nothing, so claudish was blind to it —
+   * which is how a subscription-only model with no published per-token rate came
+   * out as a bare "N/A" that reads as "unknown / not provisioned".
+   */
+  subscriptionPlans?: string[];
+  /**
+   * Vendor's own prose explaining an ABSENT `pricing` — e.g. "Cognition does not
+   * publish standalone token pricing" / "Z.ai says the standalone API is coming
+   * soon". Missing pricing is usually a deliberate vendor fact, not a data gap,
+   * and this is the sentence that says which.
+   */
+  pricingSummary?: string;
+  /** Upstream owner slug (e.g. "cognition", "z-ai"). Distinct from `provider`. */
+  owner?: string;
   capabilities?: {
     vision?: boolean;
     thinking?: boolean;
@@ -378,6 +395,48 @@ export function normalizePricingDisplay(raw?: string): string {
   if (pricing.includes("-1000000")) return "varies";
   if (pricing === "$0.00/1M" || pricing === "FREE") return "FREE";
   return pricing;
+}
+
+/**
+ * Render a model's price for a LISTING, using the model's access route to
+ * explain an absent rate instead of printing a bare "N/A".
+ *
+ * "N/A" is not a data gap for these models — it is the truthful answer, and the
+ * catalog says why per model ("Cognition does not publish standalone token
+ * pricing…", "Z.ai says the standalone API is coming soon…"). Both are
+ * subscription-only models with no published per-token rate. Printing the raw
+ * sentinel loses that entirely and reads as "unknown / never provisioned",
+ * which is exactly how `swe-1.7` was triaged as unroutable while `dv@swe-1.7`
+ * was serving 509-token replies.
+ *
+ * So when there is no rate AND the catalog names a subscription that includes
+ * the model, say `SUB` — the same label the picker already uses for a flat-rate
+ * provider (see `SUBSCRIPTION_PROVIDERS`) — qualified by the plan name. A model
+ * with neither a rate nor a subscription keeps "N/A", which now genuinely means
+ * "we don't know" rather than doubling as "subscription-only".
+ *
+ * Deliberately NOT a per-model cloud lookup: `subscription` already rides along
+ * on the recommended catalog. `catalog-client.ts` is explicit that re-querying
+ * the cloud one model at a time to fill gaps is not how this works.
+ */
+export function formatListingPrice(
+  entry: {
+    pricing?: { average?: string };
+    subscription?: { plan?: string };
+  },
+  opts?: { compact?: boolean }
+): string {
+  const rate = normalizePricingDisplay(entry.pricing?.average);
+  if (rate !== "N/A") return rate;
+  const plan = entry.subscription?.plan;
+  if (!plan) return "N/A";
+  // `compact` exists for FIXED-WIDTH tables. Plan names are unbounded in
+  // practice — "Devin" is 5, "Claude Code" is 11, so `SUB (Claude Code)` is 17
+  // against a 10-wide column — and a price cell that overflows shoves every
+  // column after it out of alignment for that ONE row, which looks like a
+  // rendering bug rather than a longer name. Markdown surfaces have no column
+  // to break, so they get the plan.
+  return opts?.compact ? "SUB" : `SUB (${plan})`;
 }
 
 /**

--- a/packages/cli/src/providers/catalog-client.ts
+++ b/packages/cli/src/providers/catalog-client.ts
@@ -80,6 +80,9 @@ export interface ModelResolutionResult {
 /** Module-level memory cache of slim catalog entries. */
 let _memCache: SlimModelEntry[] | null = null;
 
+/** Explicit tri-state catalog override for hermetic tests. */
+let _catalogEntriesForTest: SlimModelEntry[] | null | undefined;
+
 /** In-flight warm, so concurrent callers await one fetch rather than N. */
 let _warmPromise: Promise<void> | null = null;
 
@@ -94,6 +97,7 @@ let _warmPromise: Promise<void> | null = null;
  * passthrough rather than concluding a model does not exist.
  */
 export function getCatalogEntries(): SlimModelEntry[] | null {
+  if (_catalogEntriesForTest !== undefined) return _catalogEntriesForTest;
   if (_memCache) return _memCache;
 
   const cache = readAllModelsCache();
@@ -117,13 +121,53 @@ export function getCatalogEntries(): SlimModelEntry[] | null {
   return null;
 }
 
+/**
+ * The newest Anthropic Opus id the catalog knows, or null when the catalog is
+ * cold. For the `--probe` native-Claude-Code link, which must send a REAL
+ * API-valid model id because it hits api.anthropic.com directly.
+ *
+ * Derived rather than pinned, because a pinned id here rots into a hard failure
+ * and did: `claude-opus-4-1` sat in `cli.ts` under a comment asserting it was
+ * "the current Opus alias the API accepts (verified against api.anthropic.com)".
+ * Measured 2026-08-18, that id returns **404 not_found_error**, while the same
+ * comment's claim that the API rejects `claude-opus-4-8` is also false — it
+ * returns 200. A verification note has no expiry date, so the comment stayed
+ * confident long after the fact changed.
+ *
+ * The rule is "newest released `claude-opus-*` the catalog lists", so a new Opus
+ * is picked up by the next catalog refresh with no code change. `-fast` variants
+ * are deprioritised only as a tiebreak within the same release date: either
+ * serves a probe, and preferring the base id keeps the choice deterministic.
+ */
+export function latestOpusModelId(): string | null {
+  const entries = getCatalogEntries();
+  if (!entries) return null;
+  const opus = entries.filter((e) => /^claude-opus-/i.test(e.modelId));
+  if (opus.length === 0) return null;
+  opus.sort((a, b) => {
+    const byDate = (b.releaseDate ?? "").localeCompare(a.releaseDate ?? "");
+    if (byDate !== 0) return byDate;
+    const aFast = /-fast$/i.test(a.modelId) ? 1 : 0;
+    const bFast = /-fast$/i.test(b.modelId) ? 1 : 0;
+    if (aFast !== bFast) return aFast - bFast;
+    return b.modelId.localeCompare(a.modelId);
+  });
+  return opus[0].modelId;
+}
+
 /** Whether the in-memory catalog is populated. */
 export function isCatalogWarm(): boolean {
   return _memCache !== null && _memCache.length > 0;
 }
 
+/** Test seam: override catalog entries without reading disk or fetching. @internal */
+export function _setCatalogEntriesForTest(entries: SlimModelEntry[] | null): void {
+  _catalogEntriesForTest = entries;
+}
+
 /** Test seam: drop the in-memory catalog and any in-flight warm. @internal */
 export function _resetCatalogClient(): void {
+  _catalogEntriesForTest = undefined;
   _memCache = null;
   _warmPromise = null;
 }

--- a/packages/cli/src/providers/catalog-client.ts
+++ b/packages/cli/src/providers/catalog-client.ts
@@ -140,9 +140,21 @@ export function getCatalogEntries(): SlimModelEntry[] | null {
  * serves a probe, and preferring the base id keeps the choice deterministic.
  */
 export function latestOpusModelId(): string | null {
+  return latestAnthropicTierModelId("opus");
+}
+
+/**
+ * The newest Anthropic model id for a Claude Code tier, or null when the catalog
+ * is cold or lists none. Same rule as `latestOpusModelId` (which delegates here),
+ * generalised because `--probe sonnet` and `--probe haiku` need the same answer
+ * for their own tiers — substituting an Opus id for `sonnet` would report a
+ * different model than the one asked about.
+ */
+export function latestAnthropicTierModelId(tier: "opus" | "sonnet" | "haiku"): string | null {
   const entries = getCatalogEntries();
   if (!entries) return null;
-  const opus = entries.filter((e) => /^claude-opus-/i.test(e.modelId));
+  const family = new RegExp(`^claude-${tier}-`, "i");
+  const opus = entries.filter((e) => family.test(e.modelId));
   if (opus.length === 0) return null;
   opus.sort((a, b) => {
     const byDate = (b.releaseDate ?? "").localeCompare(a.releaseDate ?? "");

--- a/packages/cli/src/providers/claude-code-aliases.test.ts
+++ b/packages/cli/src/providers/claude-code-aliases.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test";
+import { claudeCodeTierAlias } from "./claude-code-aliases.js";
+
+describe("claudeCodeTierAlias", () => {
+  test("maps every Claude Code alias to its tier", () => {
+    const aliases = [
+      ["opus", "opus"],
+      ["sonnet", "sonnet"],
+      ["haiku", "haiku"],
+      ["internal", "opus"],
+      ["default", "opus"],
+    ] as const;
+
+    for (const [alias, tier] of aliases) {
+      expect(claudeCodeTierAlias(alias)).toBe(tier);
+    }
+  });
+
+  test("ignores case and surrounding whitespace", () => {
+    expect(claudeCodeTierAlias(" OPUS ")).toBe("opus");
+  });
+
+  test("does not classify concrete model ids as aliases", () => {
+    const concreteModelIds = [
+      "swe-1.7",
+      "some-nonexistent-model-zzz",
+      "claude-opus-5",
+      "claude-sonnet-5",
+      "gpt-5.6-luna",
+      "",
+    ];
+
+    // A non-null result here would make `--probe` substitute a DIFFERENT
+    // working model and report `live` for a name that 404s when runtime sends it
+    // verbatim. In particular, a real id that merely contains a tier word, such
+    // as `claude-opus-5`, is still a concrete model id, not an alias.
+    for (const modelId of concreteModelIds) {
+      expect(claudeCodeTierAlias(modelId)).toBeNull();
+    }
+  });
+});

--- a/packages/cli/src/providers/claude-code-aliases.ts
+++ b/packages/cli/src/providers/claude-code-aliases.ts
@@ -1,0 +1,62 @@
+/**
+ * Claude Code's TIER ALIASES — names that route to native Claude Code but are
+ * not model ids the Anthropic API will accept.
+ *
+ * ## Why this distinction has to exist
+ *
+ * `parseModelSpec` sends every unrecognised bare name to `native-anthropic`
+ * ("No '/' - treat as native Anthropic model"), so two very different things
+ * arrive at that route:
+ *
+ *   - `opus`, `sonnet`, `haiku`, `internal`, `default` — Claude Code's own tier
+ *     selectors. The API rejects them ("not a valid model ID"), but the ROUTE is
+ *     healthy, so probing them verbatim would report a failure that does not
+ *     exist. These need a concrete id substituted.
+ *   - `swe-1.7`, `some-typo-model` — names nothing serves. At runtime
+ *     `native-handler.ts` forwards `payload.model` VERBATIM and Anthropic answers
+ *     404, so substituting a working id here makes `--probe` report `live` for a
+ *     model that cannot serve a single request.
+ *
+ * The probe used to substitute for BOTH, which is how `swe-1.7` came to "probe
+ * byte-identically to a nonsense string": the substitution erased the difference
+ * between them before the request was ever sent.
+ *
+ * So the rule is: substitute for a KNOWN alias, pass everything else through and
+ * let the API answer honestly.
+ *
+ * Kept import-free and separate from `team-orchestrator.ts`'s `SENTINEL_MODELS`
+ * on purpose. That set answers a different question — "may this be spawned as a
+ * claudish child process?" — and happens to list the same names today. Sharing
+ * one set would couple two unrelated decisions; what matters is that neither
+ * silently grows a name the other should have known about.
+ */
+
+/** The Claude Code tier a request maps onto. */
+export type ClaudeTier = "opus" | "sonnet" | "haiku";
+
+/**
+ * The tier alias table.
+ *
+ * `internal` and `default` mean "whatever Claude Code is configured with" rather
+ * than a specific tier. They map to `opus` because that is the tier Claude Code
+ * runs by default, and because the probe only needs SOME valid id to prove the
+ * passthrough works — it is testing the route and the credential, not a model.
+ */
+const TIER_ALIASES: Record<string, ClaudeTier> = {
+  opus: "opus",
+  sonnet: "sonnet",
+  haiku: "haiku",
+  internal: "opus",
+  default: "opus",
+};
+
+/**
+ * The tier this name selects, or null when it is an ordinary model id.
+ *
+ * Null is the answer that must NOT be substituted: it means the caller named
+ * something concrete, and the honest probe is to send it and report what the API
+ * says.
+ */
+export function claudeCodeTierAlias(model: string): ClaudeTier | null {
+  return TIER_ALIASES[model.trim().toLowerCase()] ?? null;
+}

--- a/packages/cli/src/providers/default-routing-rules.ts
+++ b/packages/cli/src/providers/default-routing-rules.ts
@@ -126,6 +126,26 @@ export const DEFAULT_ROUTING_RULES: RoutingRules = {
   // a fallback would claim a reachability that does not exist.
   "labs-*": ["mistralai"],
 
+  // Cognition SWE: Devin only, NO fallback — same shape as `labs-*` above, and
+  // for the same reason: no other provider in the catalog serves it, so naming
+  // a fallback would claim a reachability that does not exist.
+  //
+  // This is a DELIBERATE, NARROW amendment to the "no bare name ever routes to
+  // Devin" rule. That rule exists because Devin re-serves other vendors' models
+  // under uids that collide head-on with their namespaces — `claude-opus-5-high`
+  // matches native-anthropic's `/^claude-/i`, `gpt-5-6-luna-medium` matches
+  // OpenAI's, `glm-5-2` GLM's — so a bare name reaching Devin would answer as
+  // the wrong vendor. `swe-*` is the one family that is COGNITION'S OWN: it
+  // collides with nothing, no other provider in the catalog carries it, and the
+  // hosted catalog attributes it to `cognition-devin`. Without this rule the
+  // bare id matched nothing, fell through to native-anthropic, and was silently
+  // rewritten to `claude-opus-4-1` — a healthy backend made unreachable through
+  // the catalog's own identifier, answered by another vendor's model.
+  //
+  // The invariant still holds everywhere it was aimed: no COLLIDING bare name
+  // reaches Devin. Do not generalise this entry to Devin's re-served families.
+  "swe-*": ["devin"],
+
   // Sakana Fugu: subscription first, then token API. NO hardcoded openrouter —
   // we don't claim OpenRouter carries the model; it's reachable explicitly via
   // or@sakana/fugu (catalog-resolved). The bare "fugu" id needs its own exact

--- a/packages/cli/src/providers/latest-opus.test.ts
+++ b/packages/cli/src/providers/latest-opus.test.ts
@@ -4,6 +4,7 @@ import {
   _resetCatalogClient,
   _setCatalogEntriesForTest,
   getCatalogEntries,
+  latestAnthropicTierModelId,
   latestOpusModelId,
 } from "./catalog-client.js";
 
@@ -92,5 +93,54 @@ describe("latestOpusModelId", () => {
     const selected = latestOpusModelId();
     expect(selected).toBe("claude-opus-5");
     expect(selected).not.toBe("claude-opus-4-1");
+  });
+});
+
+describe("latestAnthropicTierModelId", () => {
+  test("sonnet returns the newest Sonnet model and never an Opus model", () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-opus-5", "2027-01-01"),
+      catalogEntry("claude-sonnet-4-5", "2025-09-29"),
+      catalogEntry("claude-sonnet-5", "2026-08-01"),
+    ]);
+
+    const selected = latestAnthropicTierModelId("sonnet");
+    expect(selected).toBe("claude-sonnet-5");
+    expect(selected).not.toMatch(/^claude-opus-/i);
+  });
+
+  test("haiku returns the newest Haiku model and never an Opus model", () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-opus-5", "2027-01-01"),
+      catalogEntry("claude-haiku-4-5", "2025-10-15"),
+      catalogEntry("claude-haiku-5", "2026-08-01"),
+    ]);
+
+    const selected = latestAnthropicTierModelId("haiku");
+    expect(selected).toBe("claude-haiku-5");
+    expect(selected).not.toMatch(/^claude-opus-/i);
+  });
+
+  test("latestOpusModelId agrees with the generic Opus selector", () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-sonnet-5", "2027-01-01"),
+      catalogEntry("claude-opus-4-8", "2025-11-24"),
+      catalogEntry("claude-opus-5", "2026-08-01"),
+    ]);
+
+    expect(latestOpusModelId()).toBe("claude-opus-5");
+    expect(latestOpusModelId()).toBe(latestAnthropicTierModelId("opus"));
+  });
+
+  test("returns null when the requested tier has no rows", () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-opus-5", "2026-08-01"),
+      catalogEntry("claude-sonnet-5", "2026-08-01"),
+    ]);
+
+    expect(latestAnthropicTierModelId("haiku")).toBeNull();
+    expect(latestAnthropicTierModelId("haiku") ?? "claude-haiku-fallback").toBe(
+      "claude-haiku-fallback"
+    );
   });
 });

--- a/packages/cli/src/providers/latest-opus.test.ts
+++ b/packages/cli/src/providers/latest-opus.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { SlimModelEntry } from "./all-models-cache.js";
+import {
+  _resetCatalogClient,
+  _setCatalogEntriesForTest,
+  getCatalogEntries,
+  latestOpusModelId,
+} from "./catalog-client.js";
+
+function catalogEntry(modelId: string, releaseDate?: string): SlimModelEntry {
+  return {
+    modelId,
+    aliases: [],
+    sources: { test: { externalId: modelId } },
+    ...(releaseDate === undefined ? {} : { releaseDate }),
+  };
+}
+
+beforeEach(() => {
+  _resetCatalogClient();
+});
+
+afterEach(() => {
+  _resetCatalogClient();
+});
+
+describe("latestOpusModelId", () => {
+  test("newest releaseDate wins regardless of catalog order", () => {
+    const older = catalogEntry("claude-opus-4-8", "2025-11-24");
+    const newest = catalogEntry("claude-opus-5", "2026-08-01");
+
+    for (const entries of [
+      [older, newest],
+      [newest, older],
+    ]) {
+      _setCatalogEntriesForTest(entries);
+      expect(latestOpusModelId()).toBe("claude-opus-5");
+    }
+  });
+
+  test("same releaseDate prefers the id without the -fast suffix", () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-opus-5-fast", "2026-08-01"),
+      catalogEntry("claude-opus-5", "2026-08-01"),
+    ]);
+
+    expect(latestOpusModelId()).toBe("claude-opus-5");
+  });
+
+  test("ignores non-Opus entries", () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-sonnet-5", "2027-01-01"),
+      catalogEntry("gpt-5.6-luna", "2027-01-02"),
+      catalogEntry("claude-opus-4-8", "2025-11-24"),
+    ]);
+
+    expect(latestOpusModelId()).toBe("claude-opus-4-8");
+
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-sonnet-5", "2027-01-01"),
+      catalogEntry("gpt-5.6-luna", "2027-01-02"),
+    ]);
+    expect(latestOpusModelId()).toBeNull();
+  });
+
+  test("undated entries do not crash or outrank a dated entry", () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-opus-99"),
+      catalogEntry("claude-opus-5", "2026-08-01"),
+    ]);
+
+    expect(latestOpusModelId()).toBe("claude-opus-5");
+  });
+
+  test("a cold catalog returns null", () => {
+    _setCatalogEntriesForTest(null);
+
+    expect(getCatalogEntries()).toBeNull();
+    expect(latestOpusModelId()).toBeNull();
+    expect(latestOpusModelId() ?? "claude-opus-5").toBe("claude-opus-5");
+  });
+
+  test("never resurrects the dead hardcoded claude-opus-4-1 default", () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("claude-opus-4-5", "2025-08-05"),
+      catalogEntry("claude-opus-4-8", "2025-11-24"),
+      catalogEntry("claude-opus-5", "2026-08-01"),
+    ]);
+
+    // `claude-opus-4-1` is 404 on the live API and was the hardcoded default
+    // that broke the native probe. It must not appear when the catalog omits it.
+    const selected = latestOpusModelId();
+    expect(selected).toBe("claude-opus-5");
+    expect(selected).not.toBe("claude-opus-4-1");
+  });
+});

--- a/packages/cli/src/providers/model-availability.test.ts
+++ b/packages/cli/src/providers/model-availability.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+import { credentials } from "../auth/credentials/authority.js";
+import type { SlimModelEntry } from "./all-models-cache.js";
+import { _resetCatalogClient, _setCatalogEntriesForTest } from "./catalog-client.js";
+import { providerServesModel } from "./model-availability.js";
+import { invalidateModelDiscovery } from "./model-discovery.js";
+import type { ProviderDefinition } from "./provider-definitions.js";
+import { clearRuntimeRegistry, registerRuntimeProvider } from "./runtime-providers.js";
+
+const CATALOG_PROVIDER = "catalog-primary";
+const OTHER_CATALOG_PROVIDER = "catalog-secondary";
+const DISCOVERY_PROVIDER = "availability-discovery-test";
+
+const realFetch = globalThis.fetch;
+const realGetRequestAuth = credentials.getRequestAuth;
+
+function catalogEntry(
+  modelId: string,
+  providers: Array<{ provider: string; externalId?: string }> = [],
+  aliases: string[] = []
+): SlimModelEntry {
+  return {
+    modelId,
+    aliases,
+    sources: { test: { externalId: modelId } },
+    aggregators: providers.map(({ provider, externalId }) => ({
+      provider,
+      externalId: externalId ?? modelId,
+      confidence: "api_official",
+    })),
+  };
+}
+
+function discoveryProvider(): ProviderDefinition {
+  return {
+    name: DISCOVERY_PROVIDER,
+    displayName: "Availability Discovery Test",
+    transport: "openai",
+    baseUrl: "https://discovery.invalid",
+    apiPath: "/v1/chat/completions",
+    apiKeyEnvVar: "AVAILABILITY_DISCOVERY_TEST_API_KEY",
+    apiKeyDescription: "Offline test key",
+    apiKeyUrl: "https://discovery.invalid/key",
+    shortcuts: [],
+    legacyPrefixes: [],
+    modelDiscovery: { path: "/v1/models", format: "openai-models-list" },
+    isDirectApi: true,
+  };
+}
+
+function stubRoster(...ids: string[]): void {
+  globalThis.fetch = mock(
+    async () =>
+      new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+  ) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  _resetCatalogClient();
+  // Keep every test off the real on-disk catalog, including discovery tests.
+  _setCatalogEntriesForTest([]);
+  invalidateModelDiscovery();
+  clearRuntimeRegistry();
+  registerRuntimeProvider(discoveryProvider());
+
+  credentials.getRequestAuth = mock(async () => ({
+    headers: { Authorization: "Bearer offline-test-token" },
+  }));
+  globalThis.fetch = mock(async () => {
+    throw new Error("Unexpected fetch call");
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  _resetCatalogClient();
+  invalidateModelDiscovery();
+  clearRuntimeRegistry();
+  credentials.getRequestAuth = realGetRequestAuth;
+  globalThis.fetch = realFetch;
+});
+
+describe("providerServesModel catalog evidence", () => {
+  test("returns serves when the matching row lists the provider", async () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("model-one", [{ provider: CATALOG_PROVIDER, externalId: "vendor/model-one" }]),
+    ]);
+
+    expect(await providerServesModel(CATALOG_PROVIDER, "model-one")).toBe("serves");
+  });
+
+  test("returns not-served when the provider is in the vocabulary but absent from the row", async () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("model-one", [{ provider: OTHER_CATALOG_PROVIDER }]),
+      catalogEntry("model-two", [{ provider: CATALOG_PROVIDER }]),
+    ]);
+
+    expect(await providerServesModel(CATALOG_PROVIDER, "model-one")).toBe("not-served");
+  });
+
+  test("returns unknown when the provider never appears in the catalog vocabulary", async () => {
+    _setCatalogEntriesForTest([catalogEntry("model-one", [{ provider: OTHER_CATALOG_PROVIDER }])]);
+
+    // This guard stops subscription providers, which the aggregator catalog
+    // usually does not cover, from being dropped from every paid routing chain.
+    expect(await providerServesModel("subscription-provider", "model-one")).toBe("unknown");
+  });
+
+  test("returns unknown when the catalog is cold", async () => {
+    _setCatalogEntriesForTest(null);
+
+    expect(await providerServesModel(CATALOG_PROVIDER, "model-one")).toBe("unknown");
+  });
+
+  test("returns unknown when a vocabulary provider has no matching row", async () => {
+    _setCatalogEntriesForTest([catalogEntry("known-model", [{ provider: CATALOG_PROVIDER }])]);
+
+    expect(await providerServesModel(CATALOG_PROVIDER, "newer-than-cache")).toBe("unknown");
+  });
+
+  test.each([
+    [
+      "alias",
+      "MODEL-ALIAS",
+      catalogEntry("canonical-model", [{ provider: CATALOG_PROVIDER }], ["model-alias"]),
+    ],
+    [
+      "aggregator external id",
+      "VENDOR/MODEL-ONE",
+      catalogEntry("canonical-model", [
+        { provider: CATALOG_PROVIDER, externalId: "vendor/model-one" },
+      ]),
+    ],
+  ])("matches a row by %s, not only modelId", async (_kind, wireId, entry) => {
+    _setCatalogEntriesForTest([entry]);
+
+    expect(await providerServesModel(CATALOG_PROVIDER, wireId)).toBe("serves");
+  });
+});
+
+describe("providerServesModel live discovery", () => {
+  test("returns serves for exact and case-insensitive roster membership", async () => {
+    stubRoster("MiniMax-M3");
+
+    expect(await providerServesModel(DISCOVERY_PROVIDER, "MiniMax-M3")).toBe("serves");
+    expect(await providerServesModel(DISCOVERY_PROVIDER, "minimax-m3")).toBe("serves");
+  });
+
+  test("returns not-served when a non-empty roster omits the model", async () => {
+    stubRoster("available-model");
+
+    expect(await providerServesModel(DISCOVERY_PROVIDER, "missing-model")).toBe("not-served");
+  });
+
+  test("returns unknown when discovery returns an empty roster", async () => {
+    stubRoster();
+
+    // A temporarily unavailable listing endpoint must not silently switch the
+    // user away from the provider they selected and may already pay for.
+    expect(await providerServesModel(DISCOVERY_PROVIDER, "model-one")).toBe("unknown");
+  });
+
+  test("uses discovery before conflicting catalog evidence", async () => {
+    _setCatalogEntriesForTest([catalogEntry("model-one", [{ provider: DISCOVERY_PROVIDER }])]);
+    stubRoster("different-model");
+
+    expect(await providerServesModel(DISCOVERY_PROVIDER, "model-one")).toBe("not-served");
+  });
+});

--- a/packages/cli/src/providers/model-availability.ts
+++ b/packages/cli/src/providers/model-availability.ts
@@ -1,0 +1,136 @@
+/**
+ * "Does provider P actually serve model M?" — answered from BOTH data sources.
+ *
+ * ## Why two sources, and which one wins
+ *
+ * `catalog-client.ts` states the split this module depends on:
+ *
+ *   - The cloud catalog owns model IDENTITY — what a model is, what each vendor
+ *     calls it. Same for everyone.
+ *   - A provider's own live endpoint owns ENTITLEMENT — which subset of those
+ *     models THIS key may use. Per-user, and impossible to hold statically.
+ *
+ * Neither is sufficient alone. Measured 2026-08-18: the catalog's `aggregators[]`
+ * vocabulary names 18 providers while claudish routes to 23, and the 10 it never
+ * mentions are almost entirely the SUBSCRIPTION providers — `glm-coding`,
+ * `minimax-coding`, `qwen-cloud`, `sakana-subscription`, `devin`,
+ * `opencode-zen-go`. That is not a catalog defect: a plan's contents are an
+ * entitlement, so they were never in scope for a field describing marketplaces.
+ *
+ * Live discovery covers exactly that gap, and it is AUTHORITATIVE where it
+ * answers — it is the provider replying about the caller's own key.
+ *
+ * ## Why the result is three-valued
+ *
+ * `unknown` is not indecision, it is the answer that prevents a catastrophe. If
+ * absence of evidence were read as "not served", every provider neither source
+ * covers would be dropped from every chain — which for a while would have meant
+ * dropping the user's paid subscription in favour of a metered hop. So a
+ * candidate is removed only on POSITIVE evidence of exclusion; silence leaves it
+ * exactly where it was.
+ *
+ * ## The case this exists for
+ *
+ * `deepseek-v4-pro-0813` on a bare chain reaches `opencode-zen-go` first. Zen Go
+ * does not carry it and says so with **HTTP 401** — a status that reads as a
+ * credential failure, and which masked the live OpenRouter hop further down the
+ * same chain. Its live roster answers the question before any request is sent:
+ *
+ *     Zen Go serves 26 models; 'deepseek-v4-pro-0813' is not among them
+ *     (it serves the undated `deepseek-v4-pro`), while 'kimi-k3' is.
+ *
+ * Note the naming detail — the roster also settles what to SEND, which a
+ * membership test against catalog ids alone could not.
+ */
+
+import { getCatalogEntries } from "./catalog-client.js";
+import { discoverProviderModels, getDiscoveryFailure } from "./model-discovery.js";
+import { getProviderByName } from "./provider-definitions.js";
+
+/**
+ * - `serves`      — positive evidence this provider carries the model.
+ * - `not-served`  — positive evidence it does NOT. The only value a caller may
+ *                   act on destructively (dropping a candidate).
+ * - `unknown`     — no source could answer. Treat exactly as today's behaviour.
+ */
+export type ModelAvailability = "serves" | "not-served" | "unknown";
+
+/** Case-insensitive membership, since rosters disagree on casing (`MiniMax-M3`). */
+function rosterHas(ids: string[], wireId: string): boolean {
+  const needle = wireId.trim().toLowerCase();
+  return ids.some((id) => id.trim().toLowerCase() === needle);
+}
+
+/**
+ * Every provider name the catalog uses anywhere in `aggregators[]`.
+ *
+ * This is what makes a catalog "no" trustworthy. A provider absent from one
+ * model's row but present elsewhere in the catalog is genuinely not offered for
+ * that model; a provider the catalog never mentions at all is simply outside its
+ * scope, and its absence from a row means nothing.
+ */
+function catalogProviderVocabulary(): Set<string> | null {
+  const entries = getCatalogEntries();
+  if (!entries) return null;
+  const vocab = new Set<string>();
+  for (const entry of entries) {
+    for (const agg of entry.aggregators ?? []) vocab.add(agg.provider);
+  }
+  return vocab.size > 0 ? vocab : null;
+}
+
+/**
+ * Whether `provider` serves `wireId` — the id that would actually be SENT, not
+ * the name the user typed. Callers hold the resolved spec already
+ * (`buildRoutingChain` computes it), and passing the typed name instead would
+ * compare against the wrong side of an `externalId` mapping.
+ *
+ * Never throws and never blocks meaningfully: discovery is TTL-cached and
+ * fail-soft, and any failure degrades to `unknown`.
+ */
+export async function providerServesModel(
+  provider: string,
+  wireId: string
+): Promise<ModelAvailability> {
+  // 1. ENTITLEMENT — the provider's own answer about this key. Authoritative
+  //    wherever it exists, because it reflects the caller's actual plan rather
+  //    than what the vendor offers in general.
+  const def = getProviderByName(provider);
+  if (def?.modelDiscovery) {
+    const models = await discoverProviderModels(provider);
+    if (models.length > 0) {
+      return rosterHas(
+        models.map((m) => m.id),
+        wireId
+      )
+        ? "serves"
+        : "not-served";
+    }
+    // An empty roster is never a "no". `empty-roster` means the endpoint
+    // answered with nothing to offer; every other kind (unauthorized,
+    // unreachable, malformed…) means we failed to ask. Both are `unknown` —
+    // dropping a candidate because its listing endpoint was briefly down would
+    // turn a transient blip into a silent provider switch.
+    getDiscoveryFailure(provider);
+    return "unknown";
+  }
+
+  // 2. IDENTITY — the catalog, for providers it actually tracks.
+  const entries = getCatalogEntries();
+  if (!entries) return "unknown";
+  const vocab = catalogProviderVocabulary();
+  if (!vocab?.has(provider)) return "unknown";
+
+  const needle = wireId.trim().toLowerCase();
+  const row = entries.find(
+    (e) =>
+      e.modelId.toLowerCase() === needle ||
+      e.aliases.some((a) => a.toLowerCase() === needle) ||
+      (e.aggregators ?? []).some((a) => a.externalId?.toLowerCase() === needle)
+  );
+  // No row at all: the catalog does not know this model, so it cannot say the
+  // provider lacks it. A model newer than the cache lands here.
+  if (!row) return "unknown";
+
+  return (row.aggregators ?? []).some((a) => a.provider === provider) ? "serves" : "not-served";
+}

--- a/packages/cli/src/providers/model-discovery.test.ts
+++ b/packages/cli/src/providers/model-discovery.test.ts
@@ -21,6 +21,8 @@ import {
   invalidateModelDiscovery,
   rankDiscoveredModels,
 } from "./model-discovery.js";
+import type { ProviderDefinition } from "./provider-definitions.js";
+import { clearRuntimeRegistry, registerRuntimeProvider } from "./runtime-providers.js";
 
 const realFetch = globalThis.fetch;
 const realGetRequestAuth = credentials.getRequestAuth;
@@ -39,6 +41,7 @@ function stubJsonResponse(body: unknown, status = 200) {
 
 beforeEach(() => {
   invalidateModelDiscovery();
+  clearRuntimeRegistry();
   globalThis.fetch = realFetch;
   credentials.getRequestAuth = realGetRequestAuth;
 
@@ -52,11 +55,76 @@ beforeEach(() => {
 
 afterEach(() => {
   invalidateModelDiscovery();
+  clearRuntimeRegistry();
   globalThis.fetch = realFetch;
   credentials.getRequestAuth = realGetRequestAuth;
 });
 
 describe("discoverProviderModels", () => {
+  test("sends a claudish User-Agent on discovery requests", async () => {
+    let requestInit: RequestInit | undefined;
+    globalThis.fetch = mock(async (_input, init) => {
+      requestInit = init;
+      return new Response(JSON.stringify({ data: [{ id: "header-test-model" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await discoverProviderModels("kimi-coding");
+
+    const requestHeaders = new Headers(requestInit?.headers);
+    expect(requestHeaders.get("User-Agent")).toMatch(/^claudish\//);
+  });
+
+  test("applies credential headers after definition headers and the default User-Agent", async () => {
+    const provider: ProviderDefinition = {
+      name: "discovery-header-merge-test",
+      displayName: "Discovery Header Merge Test",
+      transport: "openai",
+      baseUrl: "https://header-merge.invalid",
+      apiPath: "/v1/chat/completions",
+      apiKeyEnvVar: "DISCOVERY_HEADER_MERGE_TEST_API_KEY",
+      apiKeyDescription: "Offline test key",
+      apiKeyUrl: "https://header-merge.invalid/key",
+      shortcuts: [],
+      legacyPrefixes: [],
+      modelDiscovery: { path: "/v1/models", format: "openai-models-list" },
+      headers: {
+        Authorization: "Bearer definition-token",
+        "X-API-Key": "definition-api-key",
+        "User-Agent": "definition-agent",
+        "X-Definition-Header": "preserved",
+      },
+      isDirectApi: true,
+    };
+    registerRuntimeProvider(provider);
+    credentials.getRequestAuth = mock(async () => ({
+      headers: {
+        Authorization: "Bearer authority-token",
+        "X-API-Key": "authority-api-key",
+        "User-Agent": "authority-agent",
+      },
+    }));
+
+    let requestInit: RequestInit | undefined;
+    globalThis.fetch = mock(async (_input, init) => {
+      requestInit = init;
+      return new Response(JSON.stringify({ data: [{ id: "header-test-model" }] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    await discoverProviderModels(provider.name);
+
+    const requestHeaders = new Headers(requestInit?.headers);
+    expect(requestHeaders.get("Authorization")).toBe("Bearer authority-token");
+    expect(requestHeaders.get("X-API-Key")).toBe("authority-api-key");
+    expect(requestHeaders.get("User-Agent")).toBe("authority-agent");
+    expect(requestHeaders.get("X-Definition-Header")).toBe("preserved");
+  });
+
   test("parses an OpenAI-style model list", async () => {
     stubJsonResponse({
       data: [

--- a/packages/cli/src/providers/model-discovery.ts
+++ b/packages/cli/src/providers/model-discovery.ts
@@ -25,6 +25,7 @@
 
 import { credentials } from "../auth/credentials/authority.js";
 import { log } from "../logger.js";
+import { VERSION } from "../version.js";
 import type { ModelOffer, RosterAxis, RosterEntry } from "./model-resolvers/types.js";
 import { getProviderByName } from "./provider-definitions.js";
 
@@ -407,6 +408,24 @@ export async function discoverProviderModels(providerName: string): Promise<Disc
       return recordFailure({ kind: "no-credentials", provider: providerName, endpoint });
     }
   }
+
+  // Identify ourselves, and honour the definition's own headers.
+  //
+  // `getRequestAuth` mints AUTH headers only, so a roster request went out with
+  // whatever User-Agent the runtime defaults to. Measured 2026-08-18: OpenCode
+  // Zen Go answers such a request with `403 error code: 1010` — Cloudflare's
+  // browser-integrity block, not an auth failure — while the identical request
+  // carrying a User-Agent returns 200 with 26 models. Without this, adding a
+  // `modelDiscovery` entry for that provider would look like a broken endpoint
+  // and be classified `unauthorized`, sending the user to check a working key.
+  //
+  // `def.headers` is applied AFTER, so a provider that needs a specific value
+  // still wins; auth headers are applied last so nothing can displace them.
+  headers = {
+    "User-Agent": `claudish/${VERSION}`,
+    ...(def.headers ?? {}),
+    ...headers,
+  };
 
   let response: Response;
   try {

--- a/packages/cli/src/providers/probe-effort.test.ts
+++ b/packages/cli/src/providers/probe-effort.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { probeLink } from "./probe-live.js";
+
+interface CapturedProbeBody {
+  output_config?: {
+    effort?: string;
+  };
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+async function captureProbeBody(provider: string): Promise<CapturedProbeBody> {
+  let captured: CapturedProbeBody | undefined;
+  globalThis.fetch = (async (_input: string | URL | Request, init?: RequestInit) => {
+    const rawBody = init?.body;
+    if (typeof rawBody !== "string") {
+      throw new Error("Expected probe request body to be JSON text");
+    }
+    captured = JSON.parse(rawBody) as CapturedProbeBody;
+    return new Response("{}", {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+
+  await probeLink(
+    "http://proxy.test",
+    {
+      provider,
+      modelSpec: `${provider}@test-model`,
+      hasCredentials: true,
+    },
+    1000
+  );
+
+  if (!captured) throw new Error("probeLink did not call fetch");
+  return captured;
+}
+
+describe("probeLink effort selection", () => {
+  test("native-anthropic sends low effort", async () => {
+    const body = await captureProbeBody("native-anthropic");
+
+    expect(body.output_config?.effort).toBe("low");
+  });
+
+  test("anthropic sends low effort", async () => {
+    const body = await captureProbeBody("anthropic");
+
+    expect(body.output_config?.effort).toBe("low");
+  });
+
+  test("OpenAI-style providers keep minimal effort", async () => {
+    for (const provider of ["openai", "openrouter"]) {
+      const body = await captureProbeBody(provider);
+      expect(body.output_config?.effort).toBe("minimal");
+    }
+  });
+
+  test("never sends literal minimal to an unsupported provider", async () => {
+    for (const provider of ["native-anthropic", "anthropic"]) {
+      const body = await captureProbeBody(provider);
+      expect(body.output_config?.effort).not.toBe("minimal");
+    }
+  });
+});

--- a/packages/cli/src/providers/probe-live-classify.test.ts
+++ b/packages/cli/src/providers/probe-live-classify.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildSurfacedErrorMessage,
+  wrapAnthropicError,
+} from "../handlers/shared/anthropic-error.js";
+import { classifyHttpError } from "./probe-live.js";
+
+/** The Anthropic-style error body emitted by the proxy for an upstream failure. */
+function proxyErrorBody(status: number, message: string): string {
+  return JSON.stringify(wrapAnthropicError(status, message));
+}
+
+/** The exact body shape emitted when the proxy remaps a terminal upstream error to HTTP 400. */
+function remappedTerminalBody(
+  upstreamStatus: number,
+  providerMessage: string,
+  hint: string
+): string {
+  const surfaced = buildSurfacedErrorMessage({
+    providerDisplayName: "OpenCode Zen Go",
+    status: upstreamStatus,
+    hint,
+    providerMessage,
+  });
+  return JSON.stringify(wrapAnthropicError(400, surfaced, "invalid_request_error", upstreamStatus));
+}
+
+describe("classifyHttpError — auth-shaped model errors", () => {
+  test("classifies a 401 unsupported-model response without rewriting its status", () => {
+    const body = proxyErrorBody(401, "Model deepseek-v4-pro-0813 is not supported");
+
+    const result = classifyHttpError(401, body, 37);
+
+    expect(result.state).toBe("model-not-found");
+    // Keep the provider's real (misused) status visible rather than laundering it into a 404.
+    expect(result.httpStatus).toBe(401);
+  });
+
+  test("keeps the captured invalid-key 401 classified as an authentication failure", () => {
+    const body = proxyErrorBody(401, "Invalid API key.");
+
+    const result = classifyHttpError(401, body, 38);
+
+    expect(result.state).toBe("auth-failed");
+    expect(result.httpStatus).toBe(401);
+  });
+
+  test("distinguishes unsupported-model and authentication wording under HTTP 403", () => {
+    const unsupported = classifyHttpError(
+      403,
+      proxyErrorBody(403, "Unsupported model: deepseek-v4-pro-0813"),
+      39
+    );
+    const forbidden = classifyHttpError(403, proxyErrorBody(403, "Forbidden"), 40);
+
+    expect(unsupported.state).toBe("model-not-found");
+    expect(unsupported.httpStatus).toBe(403);
+    expect(forbidden.state).toBe("auth-failed");
+    expect(forbidden.httpStatus).toBe(403);
+  });
+
+  test("uses an embedded upstream 401 for both remapped terminal-error arms", () => {
+    const unsupported = classifyHttpError(
+      400,
+      remappedTerminalBody(
+        401,
+        "Model deepseek-v4-pro-0813 is not supported",
+        "Model not supported by this provider. Verify model name."
+      ),
+      41
+    );
+    const unauthorized = classifyHttpError(
+      400,
+      remappedTerminalBody(401, "Unauthorized", "Check API key / OAuth credentials."),
+      42
+    );
+
+    expect(unsupported.state).toBe("model-not-found");
+    expect(unsupported.httpStatus).toBe(401);
+    expect(unauthorized.state).toBe("auth-failed");
+    expect(unauthorized.httpStatus).toBe(401);
+  });
+
+  test("leaves unrelated HTTP classifications unchanged", () => {
+    const cases = [
+      { status: 404, message: "Requested model does not exist", state: "model-not-found" },
+      { status: 429, message: "Rate limit exceeded", state: "rate-limited" },
+      { status: 500, message: "Internal server error", state: "server-error" },
+    ] as const;
+
+    for (const { status, message, state } of cases) {
+      const result = classifyHttpError(status, proxyErrorBody(status, message), 43);
+      expect(result.state).toBe(state);
+      expect(result.httpStatus).toBe(status);
+    }
+  });
+});

--- a/packages/cli/src/providers/probe-live.ts
+++ b/packages/cli/src/providers/probe-live.ts
@@ -12,6 +12,8 @@
  * not a silent failover to something else.
  */
 
+import { hasModelUnsupportedWording } from "../handlers/shared/model-unsupported.js";
+
 export type ProbeState =
   | "live"
   | "key-missing"
@@ -318,6 +320,25 @@ export function classifyHttpError(status: number, body: string, latencyMs: numbe
   const upstream = status === 400 ? extractUpstreamStatus(body) : undefined;
   if (status === 401 || status === 403 || upstream === 401 || upstream === 403) {
     const authStatus = upstream ?? status;
+    // An auth-shaped status does NOT prove an auth problem. OpenCode Zen Go
+    // answers 401 with "Model <id> is not supported" for models it does not
+    // carry — measured with a real key, where `zgo@deepseek-v4-pro-0813` 401s
+    // while `zgo@kimi-k3` on the SAME key returns 200. Reporting that as
+    // `auth-failed` sent the user to check a credential that was working, and
+    // buried the live OpenRouter hop sitting further down the same chain.
+    //
+    // Classified from the BODY, using the same predicate composed-handler's hint
+    // uses, so the state and the explanation cannot disagree about one response.
+    // The status is preserved: it is what the provider really said, and rewriting
+    // it would hide the provider's misuse of 401 rather than explain it.
+    if (hasModelUnsupportedWording(body)) {
+      return {
+        state: "model-not-found",
+        latencyMs,
+        httpStatus: authStatus,
+        errorMessage: extractErrorMessage(body) || `HTTP ${authStatus}`,
+      };
+    }
     return {
       state: "auth-failed",
       latencyMs,

--- a/packages/cli/src/providers/probe-live.ts
+++ b/packages/cli/src/providers/probe-live.ts
@@ -94,6 +94,23 @@ export interface ProbeLinkInput {
   credentialHint?: string;
 }
 
+/**
+ * Providers whose API validates `output_config.effort` against an enum that has
+ * no "minimal". Anthropic's is `low | medium | high | xhigh | max`, and the
+ * native passthrough reaches it directly — no adapter clamp in between — so an
+ * unmapped "minimal" is a 400 before the request is ever evaluated.
+ *
+ * "low" rather than omitting the field: the point of setting effort at all is to
+ * stop a reasoning model spending the whole probe cap on hidden reasoning and
+ * returning 200 with zero visible text. "low" preserves that intent and is
+ * accepted (both verified against the live API).
+ */
+const MINIMAL_EFFORT_UNSUPPORTED = new Set(["native-anthropic", "anthropic"]);
+
+function effortForProvider(provider: string): string {
+  return MINIMAL_EFFORT_UNSUPPORTED.has(provider) ? "low" : "minimal";
+}
+
 export async function probeLink(
   proxyUrl: string,
   link: ProbeLinkInput,
@@ -133,11 +150,20 @@ export async function probeLink(
         // chars — intermittent FAIL, ~60% in testing). "minimal" zeroes the
         // reasoning budget → deterministic visible output in ~1s (10/10 vs the
         // default's 2/5). The v7.11.0 effort mapping clamps "minimal" per model
-        // family and non-reasoning/non-OpenAI providers ignore output_config,
-        // so this is safe for every probe target. Real user sessions are
-        // unaffected — Claude Code builds its own output_config from the user's
-        // effort setting; this field is set ONLY here, on the probe request.
-        output_config: { effort: "minimal" },
+        // family. Real user sessions are unaffected — Claude Code builds its own
+        // output_config from the user's effort setting; this field is set ONLY
+        // here, on the probe request.
+        //
+        // "non-reasoning/non-OpenAI providers ignore output_config, so this is
+        // safe for every probe target" — that used to be written here and is
+        // FALSE. The native-anthropic link reaches api.anthropic.com directly,
+        // bypassing the effort clamp, and that API validates the enum:
+        // `output_config.effort: Input should be 'low', 'medium', 'high',
+        // 'xhigh' or 'max'`. Measured 2026-08-18 — "minimal" 400s, "low" and
+        // omitting the field both return 200. So EVERY native-anthropic probe
+        // failed on the payload before the model id was even considered, which
+        // is why that link could never report `live`.
+        output_config: { effort: effortForProvider(link.provider) },
         stream: true,
       }),
       signal: AbortSignal.timeout(timeoutMs),

--- a/packages/cli/src/providers/provider-definitions.ts
+++ b/packages/cli/src/providers/provider-definitions.ts
@@ -365,6 +365,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     baseUrl: "https://api.minimax.io",
     baseUrlEnvVars: ["MINIMAX_CODING_BASE_URL"],
     apiPath: "/anthropic/v1/messages",
+    modelDiscovery: { path: "/v1/models", format: "openai-models-list" },
     apiKeyEnvVar: "MINIMAX_CODING_API_KEY",
     apiKeyDescription: "MiniMax Coding Plan API Key",
     apiKeyUrl: "https://platform.minimax.io/user-center/basic-information/interface-key",
@@ -411,6 +412,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     baseUrl: "https://api.moonshot.ai",
     baseUrlEnvVars: ["MOONSHOT_BASE_URL", "KIMI_BASE_URL"],
     apiPath: "/anthropic/v1/messages",
+    modelDiscovery: { path: "/v1/models", format: "openai-models-list" },
     apiKeyEnvVar: "MOONSHOT_API_KEY",
     apiKeyAliases: ["KIMI_API_KEY"],
     apiKeyDescription: "Kimi/Moonshot API Key",
@@ -468,6 +470,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     tokenStrategy: "delta-aware",
     baseUrl: "https://api.z.ai",
     apiPath: "/api/coding/paas/v4/chat/completions",
+    modelDiscovery: { path: "/api/coding/paas/v4/models", format: "openai-models-list" },
     apiKeyEnvVar: "GLM_CODING_API_KEY",
     apiKeyAliases: ["ZAI_CODING_API_KEY"],
     apiKeyDescription: "GLM Coding Plan API Key",
@@ -554,6 +557,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     baseUrl: "https://opencode.ai/zen/go",
     baseUrlEnvVars: ["OPENCODE_GO_BASE_URL"],
     apiPath: "/v1/chat/completions",
+    modelDiscovery: { path: "/v1/models", format: "openai-models-list" },
     // Zen Go is a separate paid tier from the free Zen plan — keys for one
     // tier are not accepted by the other (401). Old single OPENCODE_API_KEY
     // kept as an alias for backward compat, but new users should set
@@ -834,6 +838,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     baseUrl: "https://api.sakana.ai",
     baseUrlEnvVars: ["SAKANA_BASE_URL"],
     apiPath: "/v1/chat/completions",
+    modelDiscovery: { path: "/v1/models", format: "openai-models-list" },
     // Primary env var matches Sakana's own term ("subscription"). The old
     // SAKANA_CODING_API_KEY is kept only as a back-compat alias. NEITHER aliases
     // the API-usage SAKANA_API_KEY — that's the PAYG key and would bill prepaid

--- a/packages/cli/src/providers/provider-definitions.ts
+++ b/packages/cli/src/providers/provider-definitions.ts
@@ -197,15 +197,28 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
       { prefix: "dv/", stripPrefix: true },
       { prefix: "devin/", stripPrefix: true },
     ],
-    // NO nativeModelPatterns, and no DEFAULT_ROUTING_RULES entry either. Devin's
-    // uids collide head-on with other providers' namespaces —
-    // `claude-opus-5-medium` matches native-anthropic's /^claude-/i,
-    // `gpt-5-6-luna-medium` matches OpenAI's, `glm-5-2` matches GLM's,
-    // `kimi-k3-high` matches Kimi's — so a bare name must never auto-detect as
-    // Devin, and Devin must never be prepended to those chains. Same reasoning
-    // as Qwen Plan, which also serves other vendors' models: access to the plan
-    // stays EXPLICIT (`dv@claude-opus-5`). Users who want otherwise can add a
-    // rule in ~/.claudish/config.json.
+    // EXACTLY ONE pattern, and it is Cognition's OWN family.
+    //
+    // The rule this narrows: Devin's RE-SERVED uids collide head-on with other
+    // providers' namespaces — `claude-opus-5-medium` matches native-anthropic's
+    // /^claude-/i, `gpt-5-6-luna-medium` matches OpenAI's, `glm-5-2` matches
+    // GLM's, `kimi-k3-high` matches Kimi's — so those must never auto-detect as
+    // Devin, and Devin must never be prepended to their chains. That reasoning
+    // is intact: access to another vendor's model through the plan stays
+    // EXPLICIT (`dv@claude-opus-5`), same as Qwen Plan.
+    //
+    // `swe-*` is different in kind: it is Cognition's own model line, no other
+    // provider in the catalog carries it, and it collides with nothing. Without
+    // a pattern here, `parseModelSpec` sends every unrecognised bare name to
+    // native-anthropic (model-parser.ts, "No '/' - treat as native Anthropic
+    // model"), so `swe-1.7` never even reached the routing rules — it was
+    // silently rewritten to `claude-opus-4-1` and answered by a different
+    // vendor's model, probing byte-identically to a nonsense string while
+    // `dv@swe-1.7` served fine. A DEFAULT_ROUTING_RULES entry alone cannot fix
+    // that, because the native-anthropic catch-all preempts rule matching.
+    //
+    // Do NOT extend this list to Devin's re-served families.
+    nativeModelPatterns: [{ pattern: /^swe-/i }],
     modelDiscovery: { path: "", format: "devin-connect" },
     isDirectApi: true,
     description: "Devin subscription (dv@, devin@)",

--- a/packages/cli/src/providers/swe-routing.test.ts
+++ b/packages/cli/src/providers/swe-routing.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { DEFAULT_ROUTING_RULES } from "./default-routing-rules.js";
+import { parseModelSpec } from "./model-parser.js";
+
+describe("SWE model routing", () => {
+  test("auto-detects bare swe-* names as Devin without marking them explicit", () => {
+    for (const modelId of ["swe-1.7", "SWE-1.7", "swe-2"]) {
+      const parsed = parseModelSpec(modelId);
+
+      expect(parsed.provider).toBe("devin");
+      expect(parsed.isExplicitProvider).toBe(false);
+    }
+  });
+
+  test("routes swe-* only to Devin with no fallback", () => {
+    const routes = DEFAULT_ROUTING_RULES["swe-*"];
+
+    expect(routes).toEqual(["devin"]);
+    expect(routes).toHaveLength(1);
+  });
+
+  test("never auto-detects Devin's re-served vendor model collisions", () => {
+    // Devin re-serves these other vendors' models under colliding UIDs. Auto-detecting
+    // a bare name as Devin would let the wrong vendor answer the request.
+    for (const modelId of [
+      "claude-opus-5-medium",
+      "gpt-5-6-luna-medium",
+      "glm-5-2",
+      "kimi-k3-high",
+    ]) {
+      expect(parseModelSpec(modelId).provider).not.toBe("devin");
+    }
+  });
+
+  test("keeps explicit dv@swe-1.7 addressing working", () => {
+    const parsed = parseModelSpec("dv@swe-1.7");
+
+    expect(parsed.provider).toBe("devin");
+    expect(parsed.model).toBe("swe-1.7");
+    expect(parsed.isExplicitProvider).toBe(true);
+  });
+});


### PR DESCRIPTION
All five open items from the Antigravity report. Each fix was reproduced live before and after.

## 1. `preflight` — check a roster before spending a run on it

`--probe` is fast but **CLI-only**. The MCP surface had 11 tools and no probe, so a consumer either shelled out to the CLI or discovered provisioning failures minutes in, slots already spent. The session behind the report **lost 3 of 10 `team` slots** to failures a probe would have caught.

`preflight` answers three questions per model:

- **Which provider** serves it — via `route()`, the same rules and credential filter a real run uses.
- **How it's billed** — subscription vs metered is a property of the *provider*, not the model. The same model can be flat-rate through a plan and per-token through a vendor API, and which one a bare name lands on is exactly what a caller cannot see. Metered hops get an explicit callout.
- **Whether it's reachable** — live probe by default; `probe: false` gives routing/billing only and says so.

Verified over real MCP JSON-RPC:

```
| swe-1.7                    | Devin       | SUB | live     | dv@swe-1.7 |
| ag@gemini-3.7-flash        | Antigravity | SUB | timeout  |            |
| definitely-not-a-model-xyz | —           | —   | no route |            |
```

`heartbeat: true` — a large roster is the intended use and exactly the shape the MCP idle timer aborts.

## 2. An auth-shaped 401 was classified by status instead of body

OpenCode Zen Go returns HTTP 401 for two different conditions:

```
valid key,   model not served  -> 401  "Model deepseek-v4-pro-0813 is not supported"
invalid key, model served      -> 401  "Invalid API key."
```

Only the body separates them. Two functions read that response and disagreed: `getRecoveryHint()` inspected the body and returned the correct string, while `classifyHttpError()` branched on status alone and returned `auth-failed`. `--probe` and the TUI group by `state`, not message text, so the row rendered as a credential failure — telling the user to fix a working credential, and obscuring that `openrouter` probes `live` further down the same chain.

**Scope is diagnostics only.** `isRetryableError()` returns true for 401, so the chain already advanced at runtime. No request was failing; the reporting was wrong.

The body test moved to `handlers/shared/model-unsupported.ts`, used by both call sites so `state` and `errorMessage` derive from one rule. `httpStatus` stays 401 — rewriting it to 404 would hide the provider's misuse rather than explain it. Import-free, keeping `probe-live` at zero dependencies. Same pattern as `quota-exhaustion.ts`, which exists because a spent plan also arrives under an auth-shaped status.

Verified live with a real `OPENCODE_GO_API_KEY`:

| key | model | HTTP | body | before | after |
|---|---|---|---|---|---|
| valid | `deepseek-v4-pro-0813` | 401 | `is not supported` | `auth-failed` | `model-not-found` |
| valid | `kimi-k3` | 200 | — | `live` | `live` |
| **invalid** | `kimi-k3` | 401 | `Invalid API key.` | `auth-failed` | `auth-failed` |

Row 3 is the negative control. The phrase list never matches "invalid", "unauthorized" or "denied" — a false positive would tell a user with genuinely broken credentials to check their model name.

## 3. `swe-1.7` was answered by another vendor's model

**A routing rule alone could never have fixed this.** `parseModelSpec` sends every unrecognised bare name to `native-anthropic` (`model-parser.ts`, *"No '/' - treat as native Anthropic model"*) **before** rules are consulted. So `swe-1.7` became `claude-opus-4-1` and probed byte-identically to a nonsense string, while `dv@swe-1.7` served fine.

Devin gains exactly one `nativeModelPatterns` entry `/^swe-/i`, plus `"swe-*": ["devin"]` with no fallback (same shape as `labs-*` — no other provider carries it).

**This narrows a documented invariant deliberately.** "No bare name ever routes to Devin" exists because Devin's *re-served* uids collide with other vendors' namespaces — `claude-opus-5-medium`, `gpt-5-6-luna-medium`, `glm-5-2`, `kimi-k3-high`. `swe-*` is Cognition's own line and collides with nothing. A test enforces it.

Measured: `key-missing` on `claude-opus-4-1` → `devin`/`dv@swe-1.7`, probe **live, 408 tokens, 110 tok/s**.

## 4. `--probe --json` reported a healthy explicit address as `chain: []`

An explicit address has no chain to walk, so the outcome hid in `directProbe`. Anyone reading `chain` concluded "dead route" — `dv@swe-1.7` was filed as unroutable **twice** on exactly this.

Explicit addresses now emit a one-item chain via `buildDirectChainEntry`, shared with `buildResultLinks` so the TUI and JSON cannot disagree. `[]` is reserved for its literal meaning: no provider can serve this.

## 5. `N/A` pricing read as "not provisioned" — not a Firebase bug

Both models the report cites are subscription-only with no published per-token rate, and the catalog says so per model:

```
swe-1.7  "Cognition does not publish standalone token pricing…"   subscriptionPlans: [cognition-devin]
glm-5.3  "Z.ai says the standalone API is coming soon…"           subscriptionPlans: [z-ai-glm-coding-plan]
```

`formatListingPrice` now renders `SUB` when there's no rate **and** the catalog names a subscription, so `N/A` genuinely means "unknown". `compact` keeps the fixed-width column aligned.

Also fixes a **silent field drift**: `ModelDoc.availableInPlans` was declared and read by *nothing* while the backend sends `subscriptionPlans`.

Measured: `swe-1.7` → `SUB`. `glm-5.3` correctly still `N/A` — it lacks `subscription` on `?catalog=recommended`, filed as `ai-docs/reports/models-index-recommended-catalog-subscription-gap.md`.

## Not implemented, with reason

The report's premise that routing should drop providers lacking a model **cannot** be built on `aggregators[]`: its vocabulary is 18 providers and contains no `devin`, `glm-coding`, `qwen-cloud`, `opencode-zen-go`, or any predefined vendor. Dropping on absence would delete nearly every subscription provider from every chain — the silent-fallback failure class.

## Tests

Mutation proofs, each independently re-run:

| Mutation | Reintroduces | Result |
|---|---|---|
| Widen devin's pattern to `/^(swe\|glm)-/i` | bare `glm-5-2` answered by Devin | 1 red |
| Add `openrouter` fallback to `swe-*` | claims reachability that doesn't exist | 1 red |
| `formatListingPrice` returns raw rate | `SUB` regresses to `N/A` | 2 red |
| Rename `preflight` | tool silently dropped from the roster | 1 red |
| Delete the body check in `classifyHttpError` | 401 always `auth-failed` | 3 red |
| Add `"invalid"` to the phrase list | real auth failure misreported | 3 red |

Local hermetic run (CI's exact invocation): 2535 tests, 0 fail.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
