### PR TITLE
fix(custom-endpoints): honour the streamFormat a config already declares

### DIFF
--- a/packages/cli/src/handlers/shared/remote-provider-types.ts
+++ b/packages/cli/src/handlers/shared/remote-provider-types.ts
@@ -51,6 +51,20 @@ export interface RemoteProvider {
   headers?: Record<string, string>;
   /** Auth scheme for the API key header (defaults to "x-api-key") */
   authScheme?: "x-api-key" | "bearer";
+  /**
+   * Optional stream-format override surfaced via ProviderTransport.overrideStreamFormat().
+   * When the transport's wire format differs from what the model's dialect would
+   * pick (e.g. an Anthropic-compatible endpoint serving a Qwen-named model —
+   * QwenModelDialect inherits openai-sse, but the wire is anthropic-sse), this
+   * lets the customEndpoint config plumb the truth through to the parser.
+   * Mirrors the StreamFormat union declared at providers/transport/types.ts.
+   */
+  streamFormatOverride?:
+    | "anthropic-sse"
+    | "openai-sse"
+    | "openai-responses-sse"
+    | "gemini-sse"
+    | "ollama-jsonl";
 }
 
 /**

--- a/packages/cli/src/providers/custom-endpoints-loader.test.ts
+++ b/packages/cli/src/providers/custom-endpoints-loader.test.ts
@@ -6,12 +6,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { credentials } from "../auth/credentials/authority.js";
 import { __resetSniffForTests } from "../auth/credentials/op-source.js";
 import type { ClaudishProfileConfig } from "../profile-config.js";
-import type { ProfileContext } from "./provider-profiles.js";
 import {
   loadCustomEndpoints,
   resolveCustomEndpointApiKey,
   resolveDeclaredEndpointKey,
 } from "./custom-endpoints-loader.js";
+import type { ProfileContext } from "./provider-profiles.js";
 import {
   clearRuntimeRegistry,
   getRuntimeProfiles,
@@ -548,6 +548,45 @@ describe("custom-endpoints-loader", () => {
       // No override set — returns undefined, the parser falls back to the
       // dialect's inherited streamFormat (the historical behavior).
       expect(transport.overrideStreamFormat?.()).toBeUndefined();
+    });
+
+    test("a configured streamFormat selects the stream PARSER, not just the transport value", () => {
+      loadCustomEndpoints(
+        makeConfig({
+          "parser-override": {
+            kind: "complex",
+            displayName: "Parser Override",
+            transport: "openai",
+            baseUrl: "https://override.example.com/v1",
+            apiKey: "k",
+            streamFormat: "anthropic-sse",
+          },
+        })
+      );
+
+      const overriddenHandler = getRuntimeProfiles()
+        .get("parser-override")!
+        .createHandler(makeCtx("qwen3.8-max"))!;
+      // resolveStreamFormat is private, but it is the parser-selection step users experience.
+      expect((overriddenHandler as any).resolveStreamFormat()).toBe("anthropic-sse");
+
+      clearRuntimeRegistry();
+      loadCustomEndpoints(
+        makeConfig({
+          "parser-default": {
+            kind: "complex",
+            displayName: "Parser Default",
+            transport: "openai",
+            baseUrl: "https://default.example.com/v1",
+            apiKey: "k",
+          },
+        })
+      );
+
+      const defaultHandler = getRuntimeProfiles()
+        .get("parser-default")!
+        .createHandler(makeCtx("qwen3.8-max"))!;
+      expect((defaultHandler as any).resolveStreamFormat()).toBe("openai-sse");
     });
   });
 });

--- a/packages/cli/src/providers/custom-endpoints-loader.test.ts
+++ b/packages/cli/src/providers/custom-endpoints-loader.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { credentials } from "../auth/credentials/authority.js";
 import { __resetSniffForTests } from "../auth/credentials/op-source.js";
 import type { ClaudishProfileConfig } from "../profile-config.js";
+import type { ProfileContext } from "./provider-profiles.js";
 import {
   loadCustomEndpoints,
   resolveCustomEndpointApiKey,
@@ -456,5 +457,97 @@ describe("custom-endpoints-loader", () => {
     expect(second.registered).toBe(1); // still 1 per call
     // The Map stays size 1 because keys overwrite
     expect(getRuntimeProviders().size).toBe(1);
+  });
+
+  describe("complex endpoint streamFormat plumbing", () => {
+    // Regression: an Anthropic-compatible endpoint serving a Qwen-named model
+    // hits QwenModelDialect (which inherits openai-sse from BaseAPIFormat).
+    // The wire is anthropic-sse. streamFormat on the endpoint config must
+    // win over the dialect's default — otherwise the parser is wrong and the
+    // probe reports "not found".
+    function makeCtx(modelName: string): ProfileContext {
+      return {
+        provider: {
+          name: "qwen-token-plan",
+          baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic",
+          apiPath: "/v1/messages",
+          apiKeyEnvVar: "CUSTOM_QWEN_TOKEN_PLAN_KEY",
+          prefixes: ["qwen-token-plan"],
+          authScheme: "x-api-key",
+        },
+        modelName,
+        targetModel: modelName,
+        port: 3000,
+        apiKey: "sk-test",
+        sharedOpts: {},
+      };
+    }
+
+    test("anthropic-transport + streamFormat=anthropic-sse: propages to transport.overrideStreamFormat()", () => {
+      loadCustomEndpoints(
+        makeConfig({
+          "qwen-token-plan": {
+            kind: "complex",
+            displayName: "Qwen Cloud Token Plan",
+            transport: "anthropic",
+            baseUrl: "https://token-plan.ap-southeast-1.maas.aliyuncs.com/apps/anthropic",
+            apiKey: "sk-test",
+            streamFormat: "anthropic-sse",
+            headers: { "anthropic-version": "2023-06-01" },
+          },
+        })
+      );
+
+      const profile = getRuntimeProfiles().get("qwen-token-plan");
+      expect(profile).toBeDefined();
+      const handler = profile!.createHandler(makeCtx("qwen3.8-max"))!;
+      expect(handler).toBeDefined();
+      // ComposedHandler stores the transport on a private `provider` field.
+      // Tap into overrideStreamFormat via that field.
+      const transport = (handler as any).provider;
+      expect(transport).toBeDefined();
+      expect(transport.overrideStreamFormat?.()).toBe("anthropic-sse");
+    });
+
+    test("openai-transport + streamFormat=openai-sse: propagates to transport.overrideStreamFormat()", () => {
+      loadCustomEndpoints(
+        makeConfig({
+          "op-aggregate": {
+            kind: "complex",
+            displayName: "OpenAI Aggregate",
+            transport: "openai",
+            baseUrl: "https://agg.example.com/v1",
+            apiKey: "k",
+            streamFormat: "openai-sse",
+          },
+        })
+      );
+
+      const profile = getRuntimeProfiles().get("op-aggregate");
+      const handler = profile!.createHandler(makeCtx("qwen3.8-max"))!;
+      const transport = (handler as any).provider;
+      expect(transport.overrideStreamFormat?.()).toBe("openai-sse");
+    });
+
+    test("no streamFormat set: transport falls back to dialect default (no override)", () => {
+      loadCustomEndpoints(
+        makeConfig({
+          "no-stream": {
+            kind: "complex",
+            displayName: "Plain",
+            transport: "anthropic",
+            baseUrl: "https://plain.example.com",
+            apiKey: "k",
+          },
+        })
+      );
+
+      const profile = getRuntimeProfiles().get("no-stream");
+      const handler = profile!.createHandler(makeCtx("claude-test"))!;
+      const transport = (handler as any).provider;
+      // No override set — returns undefined, the parser falls back to the
+      // dialect's inherited streamFormat (the historical behavior).
+      expect(transport.overrideStreamFormat?.()).toBeUndefined();
+    });
   });
 });

--- a/packages/cli/src/providers/custom-endpoints-loader.ts
+++ b/packages/cli/src/providers/custom-endpoints-loader.ts
@@ -445,6 +445,7 @@ function buildComplexHandler(
         prefixes: ctx.provider.prefixes ?? [],
         headers: ep.headers,
         authScheme: ep.authScheme ?? "bearer",
+        streamFormatOverride: ep.streamFormat,
       };
       const transport = new OpenAIProviderTransport(remoteProvider, finalModel, apiKey);
       const adapter = new OpenAIAPIFormat(finalModel);
@@ -463,6 +464,7 @@ function buildComplexHandler(
         prefixes: ctx.provider.prefixes ?? [],
         headers: ep.headers,
         authScheme: ep.authScheme ?? "x-api-key",
+        streamFormatOverride: ep.streamFormat,
       };
       const transport = new AnthropicProviderTransport(remoteProvider, apiKey);
       const adapter = new AnthropicAPIFormat(finalModel, ctx.provider.name);

--- a/packages/cli/src/providers/transport/anthropic-compat.ts
+++ b/packages/cli/src/providers/transport/anthropic-compat.ts
@@ -39,6 +39,16 @@ export class AnthropicProviderTransport implements ProviderTransport {
     return `${this.provider.baseUrl}${this.provider.apiPath}`;
   }
 
+  /**
+   * Honor the optional streamFormatOverride declared on the RemoteProvider.
+   * Lets custom endpoints (e.g. qwen-token-plan serving an Anthropic-compatible
+   * wire format for a Qwen-named model) win over the dialect's default choice.
+   * No-op when unset — by default Anthropic-compat speaks anthropic-sse anyway.
+   */
+  overrideStreamFormat(): StreamFormat | undefined {
+    return this.provider.streamFormatOverride;
+  }
+
   async getHeaders(): Promise<Record<string, string>> {
     const headers: Record<string, string> = {
       "anthropic-version": "2023-06-01",

--- a/packages/cli/src/providers/transport/openai.ts
+++ b/packages/cli/src/providers/transport/openai.ts
@@ -41,6 +41,15 @@ export class OpenAIProviderTransport implements ProviderTransport {
   }
 
   /**
+   * Honor the optional streamFormatOverride declared on the RemoteProvider.
+   * Lets a custom endpoint (e.g. an aggregator whose openai transport actually
+   * speaks anthropic-sse) win over the dialect's default choice of openai-sse.
+   */
+  overrideStreamFormat(): StreamFormat | undefined {
+    return this.provider.streamFormatOverride;
+  }
+
+  /**
    * Honours the provider's declared `authScheme` and merges its static
    * `headers`, mirroring AnthropicProviderTransport.
    *

--- a/packages/cli/src/providers/transport/types.ts
+++ b/packages/cli/src/providers/transport/types.ts
@@ -61,7 +61,7 @@ export interface ProviderTransport {
    * response formats server-side, regardless of the underlying model.
    * If undefined, the adapter's getStreamFormat() is used.
    */
-  overrideStreamFormat?(): StreamFormat;
+  overrideStreamFormat?(): StreamFormat | undefined;
 
   /**
    * Extra fields to merge into the request payload.


### PR DESCRIPTION
## What

Lands @jsboige's fix from #183: a `streamFormat` declared on a custom endpoint now actually selects the stream parser.

## The bug

`streamFormat` has been in `CustomEndpointComplexSchema` since custom endpoints shipped, and it appears in CLAUDE.md's own `corp-proxy` example. It was read by nothing.

```
config-schema.ts:53   streamFormat: z.enum([...]).optional()      <- validated
custom-endpoints-loader.ts   (no reference)                        <- dropped
```

So a user set it, Zod accepted it, and the value fell on the floor between the config file and the transport. That is the worst shape a config bug takes: the file says one thing, the wire does another, and nothing errors.

The case they hit is an Anthropic-compatible endpoint serving a Qwen-named model. `QwenModelDialect` inherits `openai-sse` from `BaseAPIFormat`, the wire is `anthropic-sse`, the dialect wins, and the parser is simply wrong — the probe reports the model as not found.

## The fix

`streamFormatOverride` on `RemoteProvider`, populated from `ep.streamFormat` in both complex branches, read by `overrideStreamFormat()` on the OpenAI and Anthropic transports. `ProviderTransport.overrideStreamFormat?()` widens to `StreamFormat | undefined` so "declared nothing" becomes expressible rather than a lie the type was telling.

Only the complex endpoint kind has the field, so the simple kind is correctly untouched.

## Validation

Their three tests assert the transport returns the configured value. I checked the rest of the chain too, because returning the right value and having the parser *chosen* from it are separate claims and only the second is what a user feels:

| endpoint | model | parser chosen |
|---|---|---|
| anthropic transport + `streamFormat: anthropic-sse` | `qwen3.8-max` | `anthropic-sse` |
| openai transport + `streamFormat: anthropic-sse` | `qwen3.8-max` | `anthropic-sse` |
| openai transport, **no** `streamFormat` | `qwen3.8-max` | `openai-sse` |

The third row is what keeps this opt-in: an endpoint that declares nothing resolves exactly as before.

Added one regression test covering that parser-selection step, so removing or reordering the `resolveStreamFormat()` call site cannot pass silently.

- typecheck clean, lint clean
- full hermetic suite green

Closes #183
