### PR TITLE
refactor(adapters): resolve a model dialect with a function, not a manager

### DIFF
--- a/packages/cli/src/adapters/dialect-manager.ts
+++ b/packages/cli/src/adapters/dialect-manager.ts
@@ -1,5 +1,5 @@
 /**
- * DialectManager — selects the appropriate Layer 2 ModelDialect for a given model.
+ * resolveModelDialect — selects the appropriate Layer 2 ModelDialect for a model.
  *
  * This allows ComposedHandler to apply model-specific quirks independent of
  * which Layer 1 APIFormat or Layer 3 ProviderTransport are used:
@@ -20,58 +20,46 @@ import { OpenAIAPIFormat } from "./openai-api-format.js";
 import { QwenModelDialect } from "./qwen-model-dialect.js";
 import { XiaomiModelDialect } from "./xiaomi-model-dialect.js";
 
-export class DialectManager {
-  private adapters: BaseAPIFormat[];
-  private defaultAdapter: DefaultAPIFormat;
+/**
+ * Candidate dialects, in match order. ORDER IS LOAD-BEARING: Codex must be
+ * tried before OpenAI, because a codex model id also satisfies OpenAI's test
+ * and whichever runs first wins.
+ *
+ * These are factories rather than instances because `shouldHandle` is an
+ * instance method, so asking "does this dialect want the model" requires
+ * constructing it. Building them one at a time and stopping at the first match
+ * means a `grok-*` request constructs one object instead of ten.
+ */
+const DIALECT_FACTORIES: ReadonlyArray<(modelId: string, wire?: StreamFormat) => BaseAPIFormat> = [
+  (m, w) => new GrokModelDialect(m, w),
+  (m, w) => new GeminiAPIFormat(m, w),
+  (m, w) => new CodexAPIFormat(m, w),
+  (m, w) => new OpenAIAPIFormat(m, w),
+  (m, w) => new QwenModelDialect(m, w),
+  (m, w) => new MiniMaxModelDialect(m, w),
+  (m, w) => new DeepSeekModelDialect(m, w),
+  (m, w) => new GLMModelDialect(m, w),
+  (m, w) => new XiaomiModelDialect(m, w),
+];
 
-  /**
-   * @param modelId     Bare model name — dialects self-select on it.
-   * @param wireFormat  The wire format of the Layer 1 FormatConverter this
-   *   dialect will be composed with (ComposedHandler knows it; the dialect
-   *   cannot, because selection is by model NAME). BaseAPIFormat — not the
-   *   dialect — consumes it, substituting the Anthropic Messages reasoning knob
-   *   and enabling unsigned-thinking filtering on `anthropic-sse`. That is why
-   *   a multi-vendor Anthropic endpoint (Alibaba's Qwen Plan serves qwen3.x,
-   *   glm-5.2 and deepseek-v4-* over one URL, i.e. three different dialects)
-   *   works without each dialect opting in. Omit for "unknown" → the OpenAI
-   *   default, which keeps every pre-existing call site byte-identical.
-   */
-  constructor(modelId: string, wireFormat?: StreamFormat) {
-    // Register all available dialects/formats
-    this.adapters = [
-      new GrokModelDialect(modelId, wireFormat),
-      new GeminiAPIFormat(modelId, wireFormat),
-      new CodexAPIFormat(modelId, wireFormat), // Must be before OpenAIAPIFormat (codex matches first)
-      new OpenAIAPIFormat(modelId, wireFormat),
-      new QwenModelDialect(modelId, wireFormat),
-      new MiniMaxModelDialect(modelId, wireFormat),
-      new DeepSeekModelDialect(modelId, wireFormat),
-      new GLMModelDialect(modelId, wireFormat),
-      new XiaomiModelDialect(modelId, wireFormat),
-    ];
-    this.defaultAdapter = new DefaultAPIFormat(modelId, wireFormat);
+/**
+ * Resolve the dialect for a model, or the OpenAI-shaped default.
+ *
+ * @param modelId     Bare model name — dialects self-select on it.
+ * @param wireFormat  The wire format of the Layer 1 FormatConverter this
+ *   dialect will be composed with (ComposedHandler knows it; the dialect
+ *   cannot, because selection is by model NAME). BaseAPIFormat — not the
+ *   dialect — consumes it, substituting the Anthropic Messages reasoning knob
+ *   and enabling unsigned-thinking filtering on `anthropic-sse`. That is why
+ *   a multi-vendor Anthropic endpoint (Alibaba's Qwen Plan serves qwen3.x,
+ *   glm-5.2 and deepseek-v4-* over one URL, i.e. three different dialects)
+ *   works without each dialect opting in. Omit for "unknown" → the OpenAI
+ *   default, which keeps every pre-existing call site byte-identical.
+ */
+export function resolveModelDialect(modelId: string, wireFormat?: StreamFormat): BaseAPIFormat {
+  for (const make of DIALECT_FACTORIES) {
+    const dialect = make(modelId, wireFormat);
+    if (dialect.shouldHandle(modelId)) return dialect;
   }
-
-  /**
-   * Get the appropriate dialect/format for the current model
-   */
-  getAdapter(): BaseAPIFormat {
-    for (const adapter of this.adapters) {
-      if (adapter.shouldHandle(this.defaultAdapter.getModelId())) {
-        return adapter;
-      }
-    }
-    return this.defaultAdapter;
-  }
-
-  /**
-   * Check if current model needs special handling
-   */
-  needsTransformation(): boolean {
-    return this.getAdapter() !== this.defaultAdapter;
-  }
+  return new DefaultAPIFormat(modelId, wireFormat);
 }
-
-// Backward-compatible alias
-/** @deprecated Use DialectManager */
-export { DialectManager as AdapterManager };

--- a/packages/cli/src/adapters/effort-not-silently-dropped.test.ts
+++ b/packages/cli/src/adapters/effort-not-silently-dropped.test.ts
@@ -6,7 +6,7 @@
 import { beforeEach, expect, test } from "bun:test";
 import { readAllModelsCache } from "../providers/all-models-cache.js";
 import { DeepSeekModelDialect } from "./deepseek-model-dialect.js";
-import { DialectManager } from "./dialect-manager.js";
+import { resolveModelDialect } from "./dialect-manager.js";
 import { resetReasoningEffortMemo } from "./grok-effort-support.js";
 import { GrokModelDialect } from "./grok-model-dialect.js";
 
@@ -55,7 +55,7 @@ if (hostedEntries.length === 0) {
     );
 
     for (const entry of effortControlled) {
-      const dialect = new DialectManager(entry.modelId).getAdapter();
+      const dialect = resolveModelDialect(entry.modelId);
       const dialectName = dialect.getName();
 
       // Layer-1 format converters own effort for models with no Layer-2 dialect.

--- a/packages/cli/src/adapters/index.ts
+++ b/packages/cli/src/adapters/index.ts
@@ -5,7 +5,7 @@
 export { BaseAPIFormat, DefaultAPIFormat } from "./base-api-format.js";
 export type { ToolCall, AdapterResult } from "./base-api-format.js";
 export { GrokModelDialect } from "./grok-model-dialect.js";
-export { DialectManager } from "./dialect-manager.js";
+export { resolveModelDialect } from "./dialect-manager.js";
 
 // Backward-compatible aliases
 export {
@@ -13,4 +13,3 @@ export {
   DefaultAPIFormat as DefaultAdapter,
 } from "./base-api-format.js";
 export { GrokModelDialect as GrokAdapter } from "./grok-model-dialect.js";
-export { DialectManager as AdapterManager } from "./dialect-manager.js";

--- a/packages/cli/src/adapters/local-adapter.ts
+++ b/packages/cli/src/adapters/local-adapter.ts
@@ -13,7 +13,7 @@
 
 import { log } from "../logger.js";
 import { type AdapterResult, BaseAPIFormat } from "./base-api-format.js";
-import { DialectManager } from "./dialect-manager.js";
+import { resolveModelDialect } from "./dialect-manager.js";
 
 interface SamplingParams {
   temperature: number;
@@ -31,8 +31,7 @@ export class LocalModelAdapter extends BaseAPIFormat {
     super(modelId);
     this.providerName = providerName;
 
-    const manager = new DialectManager(modelId);
-    this.innerAdapter = manager.getAdapter();
+    this.innerAdapter = resolveModelDialect(modelId);
   }
 
   // ─── Text processing delegates to inner adapter ───────────────────

--- a/packages/cli/src/adapters/openrouter-api-format.ts
+++ b/packages/cli/src/adapters/openrouter-api-format.ts
@@ -12,7 +12,7 @@
 
 import { removeUriFormat } from "../transform.js";
 import { type AdapterResult, BaseAPIFormat } from "./base-api-format.js";
-import { DialectManager } from "./dialect-manager.js";
+import { resolveModelDialect } from "./dialect-manager.js";
 
 export class OpenRouterAPIFormat extends BaseAPIFormat {
   private innerAdapter: BaseAPIFormat;
@@ -21,8 +21,7 @@ export class OpenRouterAPIFormat extends BaseAPIFormat {
     super(modelId);
 
     // Get model-specific dialect (GrokModelDialect, GeminiAPIFormat, etc.)
-    const manager = new DialectManager(modelId);
-    this.innerAdapter = manager.getAdapter();
+    this.innerAdapter = resolveModelDialect(modelId);
   }
 
   /** Synchronous reasoning support check via model ID patterns */

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1438,9 +1438,8 @@ async function probeModelRouting(
       declaredStreamFormat = "openai-sse";
     }
 
-    const { DialectManager } = await import("./adapters/dialect-manager.js");
-    const adapterManager = new DialectManager(modelName);
-    const modelTranslator = adapterManager.getAdapter();
+    const { resolveModelDialect } = await import("./adapters/dialect-manager.js");
+    const modelTranslator = resolveModelDialect(modelName);
     const modelTranslatorName = modelTranslator.getName();
 
     const TRANSPORT_OVERRIDES: Record<string, string> = {

--- a/packages/cli/src/glm-adapter.test.ts
+++ b/packages/cli/src/glm-adapter.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { DialectManager } from "./adapters/dialect-manager.js";
+import { resolveModelDialect } from "./adapters/dialect-manager.js";
 import { GLMModelDialect } from "./adapters/glm-model-dialect.js";
 import { LiteLLMAPIFormat } from "./adapters/litellm-api-format.js";
 
@@ -96,8 +96,7 @@ describe("GLMModelDialect — processTextContent", () => {
 describe("Three-layer adapter — model dialect overrides format adapter", () => {
   test("model dialect strips thinking, format adapter does not", () => {
     const litellmAdapter = new LiteLLMAPIFormat("glm-5", "https://example.com");
-    const adapterManager = new DialectManager("glm-5");
-    const modelAdapter = adapterManager.getAdapter();
+    const modelAdapter = resolveModelDialect("glm-5");
 
     // Format adapter does not strip thinking (no override)
     const request1 = { model: "glm-5", thinking: { budget: 10000 }, messages: [] };

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -26,7 +26,7 @@ import type { ProviderTransport } from "../providers/transport/types.js";
 import type { ModelHandler } from "./types.js";
 // Alias for readability within this file
 type BaseModelAdapter = BaseAPIFormat;
-import { DialectManager } from "../adapters/dialect-manager.js";
+import { resolveModelDialect } from "../adapters/dialect-manager.js";
 import { lookupModelForProvider } from "../adapters/model-catalog.js";
 import type { QuotaAdapter } from "../auth/quota/adapter.js";
 import { resolveQuotaAdapter } from "../auth/quota/registry.js";
@@ -110,7 +110,8 @@ export interface ComposedHandlerOptions {
 
 export class ComposedHandler implements ModelHandler {
   private provider: ProviderTransport;
-  private adapterManager: DialectManager;
+  /** The dialect resolved for this model, or the OpenAI-shaped default. */
+  private resolvedDialect: BaseAPIFormat;
   private explicitAdapter?: BaseModelAdapter;
   /** Model-specific adapter (GLM, Grok, etc.) — handles model quirks independent of provider */
   private modelAdapter?: BaseModelAdapter;
@@ -173,14 +174,14 @@ export class ComposedHandler implements ModelHandler {
     // provider.overrideStreamFormat(), which only re-labels the RESPONSE for
     // aggregators. Undefined when no explicit converter was passed (the dialect
     // is then also the converter) → dialects fall back to the OpenAI default.
-    this.adapterManager = new DialectManager(
+    this.resolvedDialect = resolveModelDialect(
       this.bareModelName,
       this.explicitAdapter?.getStreamFormat()
     );
 
     // Always resolve model-specific adapter (GLM, Grok, DeepSeek, etc.)
     // This handles model quirks independent of provider transport (LiteLLM, OpenRouter, etc.)
-    const resolvedModelAdapter = this.adapterManager.getAdapter();
+    const resolvedModelAdapter = this.resolvedDialect;
     if (resolvedModelAdapter.getName() !== "DefaultAPIFormat") {
       this.modelAdapter = resolvedModelAdapter;
     }
@@ -212,7 +213,7 @@ export class ComposedHandler implements ModelHandler {
 
   /** Provider adapter — handles transport format (messages, tools, payload) */
   private getAdapter(): BaseModelAdapter {
-    return this.explicitAdapter || this.adapterManager.getAdapter();
+    return this.explicitAdapter || this.resolvedDialect;
   }
 
   /** Model context window — model adapter wins over provider adapter */


### PR DESCRIPTION
## What

Closes @MayCXC's #79, opened in March. Written fresh rather than rebased, with credit on the commit.

`DialectManager` was a class doing a function's job:

- the constructor eagerly built nine dialects plus a default
- `getAdapter()` then linear-scanned them
- `needsTransformation()` called `getAdapter()` a second time to compare against the default

`resolveModelDialect(modelId, wireFormat?)` replaces it. Candidates are factories rather than instances, so construction stops at the first match: a `grok-*` request now builds one object where it used to build ten.

## Why fresh instead of rebased

Two things moved under the original diff over five months.

**The class gained a second parameter.** `wireFormat?: StreamFormat` arrived after the PR was written, and dropping it would have quietly regressed Alibaba's Qwen Plan endpoint, where one Anthropic URL serves `qwen3.x`, `glm-5.2` and `deepseek-v4-*` and each needs a different reasoning knob. So the signature is `resolveModelDialect(modelId, wireFormat?)`.

**The naming half already landed independently.** `AdapterManager` became `DialectManager` and the files moved to `*-model-dialect.ts` / `*-api-format.ts` back in March, so those hunks were already in. Only the class-to-function collapse was still open.

## The one load-bearing claim

The old `getAdapter()` matched on `this.defaultAdapter.getModelId()`, not on the constructor argument. Those are the same string — `BaseAPIFormat`'s constructor stores `modelId` unmodified and `getModelId()` returns it — so substituting the argument is safe. Flagged in the commit message because it is the single equivalence the refactor rests on, and it would need re-checking if either method ever changes.

## Deletions

- `needsTransformation()` — no callers in source
- the `AdapterManager` alias — same

## Validation

- `2558 pass / 25 skip / 0 fail` across 2583 tests
- typecheck clean, lint clean
- `DIALECT_FACTORIES` preserves the original order exactly, including Codex before OpenAI (a codex id satisfies OpenAI's test too, so whichever runs first wins)

Net −16 lines across 8 files.

Closes #79
