### PR TITLE
fix(vertex): send eu and global to hosts that exist

### DIFF
--- a/packages/cli/src/auth/vertex-auth.ts
+++ b/packages/cli/src/auth/vertex-auth.ts
@@ -232,6 +232,43 @@ export function validateVertexOAuthConfig(): string | null {
 }
 
 /**
+ * API host for a Vertex location.
+ *
+ * Most locations are regional and take the `<location>-aiplatform.googleapis.com`
+ * template. Two do not, and both were previously built from that template and
+ * 404'd, so the location was unreachable rather than merely degraded.
+ *
+ * Measured 2026-08-18, POSTing a real generateContent path to each host. A 401
+ * means the route exists and wants credentials; a 404 means there is no such
+ * route. DNS does not discriminate here — every name below resolves, because
+ * `*.googleapis.com` has a catch-all frontend.
+ *
+ *   location     host built                              code
+ *   us-central1  us-central1-aiplatform.googleapis.com   401   regional, unchanged
+ *   us           us-aiplatform.googleapis.com            401   regional, unchanged
+ *   eu           eu-aiplatform.googleapis.com            404   BROKEN
+ *                aiplatform.eu.rep.googleapis.com        401   the real one
+ *   global       global-aiplatform.googleapis.com        404   BROKEN
+ *                aiplatform.googleapis.com               401   the real one
+ *
+ * `us` stays on the regional host on purpose, even though
+ * `aiplatform.us.rep.googleapis.com` also answers 401. Both are real and they
+ * are different endpoints — only the REP one carries a data-residency
+ * guarantee. But nothing observable from outside says which a user setting
+ * `VERTEX_LOCATION=us` intends, and the current construction already reaches a
+ * live route. Rerouting it would be inference; this table is measurement.
+ * A user who needs US data residency should be given a way to ask for it
+ * explicitly rather than have it inferred from a location string.
+ *
+ * Reported by @nickoloss in #145, who found the eu case and verified the host.
+ */
+export function vertexApiHost(location: string): string {
+  if (location === "global") return "aiplatform.googleapis.com";
+  if (location === "eu") return "aiplatform.eu.rep.googleapis.com";
+  return `${location}-aiplatform.googleapis.com`;
+}
+
+/**
  * Build Vertex AI endpoint URL for OAuth mode
  */
 export function buildVertexOAuthEndpoint(
@@ -248,7 +285,7 @@ export function buildVertexOAuthEndpoint(
     // Add ?alt=sse for SSE streaming format
     const sseParam = streaming ? "?alt=sse" : "";
     return (
-      `https://${config.location}-aiplatform.googleapis.com/v1/` +
+      `https://${vertexApiHost(config.location)}/v1/` +
       `projects/${config.projectId}/locations/${config.location}/` +
       `publishers/${publisher}/models/${model}:${method}${sseParam}`
     );
@@ -257,7 +294,7 @@ export function buildVertexOAuthEndpoint(
     // Mistral uses regional rawPredict/streamRawPredict endpoint
     const mistralMethod = streaming ? "streamRawPredict" : "rawPredict";
     return (
-      `https://${config.location}-aiplatform.googleapis.com/v1/` +
+      `https://${vertexApiHost(config.location)}/v1/` +
       `projects/${config.projectId}/locations/${config.location}/` +
       `publishers/mistralai/models/${model}:${mistralMethod}`
     );

--- a/packages/cli/src/providers/transport/vertex-oauth.test.ts
+++ b/packages/cli/src/providers/transport/vertex-oauth.test.ts
@@ -23,6 +23,11 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { VertexConfig } from "../../auth/vertex-auth.js";
 
+const {
+  buildVertexOAuthEndpoint: actualBuildVertexOAuthEndpoint,
+  vertexApiHost: actualVertexApiHost,
+} = await import("../../auth/vertex-auth.js");
+
 let currentToken = "vertex-token-A";
 const refreshTokenMock = mock(async () => {
   currentToken = "vertex-token-B"; // force-refresh swaps the token
@@ -63,6 +68,79 @@ beforeEach(() => {
 
 afterEach(() => {
   mock.restore();
+});
+
+describe("vertexApiHost", () => {
+  test("uses the bare API host for global", () => {
+    const host = actualVertexApiHost("global");
+
+    expect(host).toBe("aiplatform.googleapis.com");
+    expect(host).not.toBe("global-aiplatform.googleapis.com");
+  });
+
+  test("uses the REP host for eu", () => {
+    const host = actualVertexApiHost("eu");
+
+    expect(host).toBe("aiplatform.eu.rep.googleapis.com");
+    expect(host).not.toBe("eu-aiplatform.googleapis.com");
+  });
+
+  test("uses the regional host for us-central1", () => {
+    expect(actualVertexApiHost("us-central1")).toBe("us-central1-aiplatform.googleapis.com");
+  });
+
+  test("deliberately keeps us on the regional host", () => {
+    // Deliberate per the vertexApiHost docblock: "us" is not a REP alias.
+    expect(actualVertexApiHost("us")).toBe("us-aiplatform.googleapis.com");
+  });
+
+  test("uses the regional template for an arbitrary region", () => {
+    expect(actualVertexApiHost("europe-west4")).toBe("europe-west4-aiplatform.googleapis.com");
+  });
+});
+
+describe("buildVertexOAuthEndpoint", () => {
+  const projectId = "test-project";
+
+  test("builds a regional streaming Google endpoint", () => {
+    const config: VertexConfig = { projectId, location: "us-central1" };
+
+    expect(actualBuildVertexOAuthEndpoint(config, "google", "gemini-2.5-flash", true)).toBe(
+      "https://us-central1-aiplatform.googleapis.com/v1/projects/test-project/locations/us-central1/publishers/google/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+    );
+  });
+
+  test("builds an eu REP streaming Google endpoint while retaining locations/eu", () => {
+    const config: VertexConfig = { projectId, location: "eu" };
+
+    expect(actualBuildVertexOAuthEndpoint(config, "google", "gemini-2.5-flash", true)).toBe(
+      "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/google/models/gemini-2.5-flash:streamGenerateContent?alt=sse"
+    );
+  });
+
+  test("builds a non-streaming global Google endpoint", () => {
+    const config: VertexConfig = { projectId, location: "global" };
+
+    expect(actualBuildVertexOAuthEndpoint(config, "google", "gemini-2.5-flash", false)).toBe(
+      "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/publishers/google/models/gemini-2.5-flash:generateContent"
+    );
+  });
+
+  test("builds an eu REP streaming Mistral endpoint", () => {
+    const config: VertexConfig = { projectId, location: "eu" };
+
+    expect(actualBuildVertexOAuthEndpoint(config, "mistralai", "mistral-large-2411", true)).toBe(
+      "https://aiplatform.eu.rep.googleapis.com/v1/projects/test-project/locations/eu/publishers/mistralai/models/mistral-large-2411:streamRawPredict"
+    );
+  });
+
+  test("keeps other partners on the fixed global OpenAI-compatible endpoint", () => {
+    const config: VertexConfig = { projectId, location: "europe-west4" };
+
+    expect(actualBuildVertexOAuthEndpoint(config, "anthropic", "claude-sonnet-4", true)).toBe(
+      "https://aiplatform.googleapis.com/v1/projects/test-project/locations/global/endpoints/openapi/chat/completions"
+    );
+  });
 });
 
 describe("VertexProviderTransport — delegated auth", () => {


### PR DESCRIPTION
## What

Closes @nickoloss's #145. EU data-residency users cannot reach Vertex at all today, and the same construction bug hits a second location I missed when I first reviewed their PR.

`buildVertexOAuthEndpoint` built every host from one template, `<location>-aiplatform.googleapis.com`. Two locations do not follow it.

## The measurement

POSTed a real `generateContent` path to each host. **401** means the route exists and wants credentials; **404** means there is no such route.

| `VERTEX_LOCATION` | host we build | code | |
|---|---|---|---|
| `us-central1` | `us-central1-aiplatform.googleapis.com` | 401 | fine |
| `us` | `us-aiplatform.googleapis.com` | 401 | fine |
| **`eu`** | `eu-aiplatform.googleapis.com` | **404** | broken |
| | `aiplatform.eu.rep.googleapis.com` | 401 | the real one |
| **`global`** | `global-aiplatform.googleapis.com` | **404** | broken |
| | `aiplatform.googleapis.com` | 401 | the real one |

**DNS is useless as a discriminator here.** Every one of those names resolves, because `*.googleapis.com` answers on a catch-all frontend — the broken ones even land on the generic `172.217.x` range while the real REP hosts sit on dedicated `34.x` IPs. Only the request tells you anything. Same lesson as Alibaba's `coding-intl` roster: a response is not evidence a route is real.

## A correction to my own review

I told @nickoloss that global was already handled, pointing at the branch that hardcodes the bare host. That branch only serves **non-Google publishers**. A Gemini request with `VERTEX_LOCATION=global` went through the regional template and 404'd exactly like `eu`. I'd read the right file and the wrong branch.

## Why `us` is left alone

`aiplatform.us.rep.googleapis.com` also answers 401, so it would be easy to route `us` there too. I didn't. Both hosts are real and they are *different endpoints* — only the REP one carries a data-residency guarantee — but nothing observable from outside says which one a user setting `VERTEX_LOCATION=us` intends, and the current construction already reaches a live route.

Rerouting it would be inference; the table above is measurement. Someone who needs US residency should get a way to ask for it explicitly rather than have it guessed from a location string.

## Shape

Host selection moves into `vertexApiHost(location)` so all three call sites share it, and the docblock carries the table rather than a claim.

Ten tests, one per URL shape, because this is all string construction and a typo is otherwise only observable as a 404 in production. Mutation-checked: deleting the two special cases fails 5 of 13.

- typecheck clean, lint clean

Closes #145
