### PR TITLE
feat(proxy): keep upstream error bodies, and let /v1/models answer

### DIFF
--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -64,6 +64,7 @@ import { createOllamaJsonlStream } from "./shared/stream-parsers/ollama-jsonl.js
 import { createResponsesStreamHandler } from "./shared/stream-parsers/openai-responses-sse.js";
 import { createStreamingResponseHandler } from "./shared/stream-parsers/openai-sse.js";
 import { TokenTracker } from "./shared/token-tracker.js";
+import { captureUpstreamError } from "./shared/upstream-error-capture.js";
 
 /**
  * Backoff schedule for a retryable error that arrived inside an HTTP 200 stream.
@@ -772,6 +773,16 @@ export class ComposedHandler implements ModelHandler {
       } else {
         const errorText = await response.text();
         log(`[${this.provider.displayName}] Error: ${errorText}`);
+        // Durable copy, opt-in via CLAUDISH_UPSTREAM_ERROR_LOG. `log()` only
+        // persists under --debug, so without this the body that distinguishes a
+        // retryable rate limit from a hard quota wall is gone the moment it is
+        // classified. No-op and non-throwing when the env var is unset.
+        captureUpstreamError({
+          provider: this.provider.displayName,
+          model: this.bareModelName,
+          status: response.status,
+          body: errorText,
+        });
         // A transport that parses its provider's structured errors outranks the
         // shared substring heuristics — computed ONCE here so the user-facing
         // hint and the terminal/retryable remap below cannot disagree about what

--- a/packages/cli/src/handlers/shared/upstream-error-capture.test.ts
+++ b/packages/cli/src/handlers/shared/upstream-error-capture.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  MAX_CAPTURED_BODY_BYTES,
+  UPSTREAM_ERROR_LOG_ENV,
+  captureUpstreamError,
+} from "./upstream-error-capture.js";
+
+interface CapturedRecord {
+  at: string;
+  provider: string;
+  model: string;
+  status: number;
+  body: string;
+  truncated?: boolean;
+  original_bytes?: number;
+}
+
+let tempFile: string | undefined;
+
+function uniqueTempFile(): string {
+  tempFile = join(tmpdir(), `claudish-upstream-error-${randomUUID()}.jsonl`);
+  return tempFile;
+}
+
+function readRecord(path: string): CapturedRecord {
+  return JSON.parse(readFileSync(path, "utf8").trimEnd()) as CapturedRecord;
+}
+
+afterEach(() => {
+  delete process.env[UPSTREAM_ERROR_LOG_ENV];
+
+  if (tempFile) {
+    rmSync(tempFile, { force: true });
+    tempFile = undefined;
+  }
+});
+
+describe("captureUpstreamError", () => {
+  test("is off by default", () => {
+    const path = uniqueTempFile();
+    delete process.env[UPSTREAM_ERROR_LOG_ENV];
+
+    const written = captureUpstreamError({
+      provider: "Example",
+      model: "example-model",
+      status: 500,
+      body: "upstream failed",
+    });
+
+    expect(written).toBe(false);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("appends records instead of overwriting the file", () => {
+    const path = uniqueTempFile();
+    process.env[UPSTREAM_ERROR_LOG_ENV] = path;
+
+    expect(
+      captureUpstreamError({
+        provider: "Example",
+        model: "example-model",
+        status: 429,
+        body: "rate limited",
+      })
+    ).toBe(true);
+    expect(
+      captureUpstreamError({
+        provider: "Example",
+        model: "example-model",
+        status: 503,
+        body: "temporarily unavailable",
+      })
+    ).toBe(true);
+
+    const lines = readFileSync(path, "utf8").trimEnd().split("\n");
+    expect(lines).toHaveLength(2);
+
+    const records = lines.map((line) => JSON.parse(line) as CapturedRecord);
+    expect(records[0]?.status).toBe(429);
+    expect(records[1]?.status).toBe(503);
+  });
+
+  test("records the fields that matter and honours an explicit timestamp", () => {
+    const path = uniqueTempFile();
+    const at = "2026-08-18T01:02:03.456Z";
+    process.env[UPSTREAM_ERROR_LOG_ENV] = path;
+
+    expect(
+      captureUpstreamError({
+        provider: "GLM Coding",
+        model: "glm-5.2",
+        status: 429,
+        body: '{"error":"quota"}',
+        at,
+      })
+    ).toBe(true);
+
+    const record = readRecord(path);
+    expect(record.provider).toBe("GLM Coding");
+    expect(record.model).toBe("glm-5.2");
+    expect(record.status).toBe(429);
+    expect(record.body).toBe('{"error":"quota"}');
+    expect(Number.isNaN(Date.parse(record.at))).toBe(false);
+    expect(new Date(record.at).toISOString()).toBe(at);
+    expect(record.at).toBe(at);
+  });
+
+  test("marks a truncated body with its original size", () => {
+    const path = uniqueTempFile();
+    const body = "x".repeat(5000);
+    process.env[UPSTREAM_ERROR_LOG_ENV] = path;
+
+    expect(
+      captureUpstreamError({
+        provider: "Example",
+        model: "example-model",
+        status: 500,
+        body,
+      })
+    ).toBe(true);
+
+    const record = readRecord(path);
+    expect(record.body).toHaveLength(MAX_CAPTURED_BODY_BYTES);
+    expect(record.body).toBe(body.slice(0, MAX_CAPTURED_BODY_BYTES));
+    expect(record.truncated).toBe(true);
+    expect(record.original_bytes).toBe(5000);
+  });
+
+  test("does not mark a short body as truncated", () => {
+    const path = uniqueTempFile();
+    const body = "complete upstream error";
+    process.env[UPSTREAM_ERROR_LOG_ENV] = path;
+
+    expect(
+      captureUpstreamError({
+        provider: "Example",
+        model: "example-model",
+        status: 400,
+        body,
+      })
+    ).toBe(true);
+
+    const record = readRecord(path);
+    expect(record.body).toBe(body);
+    expect(record).not.toHaveProperty("truncated");
+  });
+
+  test("never throws when the capture path is unwritable", () => {
+    const path = uniqueTempFile();
+    writeFileSync(path, "regular file");
+    process.env[UPSTREAM_ERROR_LOG_ENV] = join(path, "nope.log");
+    let written = true;
+
+    expect(() => {
+      written = captureUpstreamError({
+        provider: "Example",
+        model: "example-model",
+        status: 500,
+        body: "upstream failed",
+      });
+    }).not.toThrow();
+    expect(written).toBe(false);
+  });
+});

--- a/packages/cli/src/handlers/shared/upstream-error-capture.ts
+++ b/packages/cli/src/handlers/shared/upstream-error-capture.ts
@@ -1,0 +1,86 @@
+/**
+ * Durable capture of upstream error bodies.
+ *
+ * A non-ok upstream response short-circuits before the stream parser, so
+ * `response-capture` never sees it. The body is read once in ComposedHandler,
+ * handed to the classifier, and then dropped:
+ *
+ *     const errorText = await response.text();
+ *     log(`[${this.provider.displayName}] Error: ${errorText}`);
+ *
+ * `log()` persists nothing unless `--debug` set a log file, so on a normal run
+ * that body is gone the instant it has been classified. That is the one piece
+ * of evidence that distinguishes a rate limit you should retry from a hard
+ * quota wall you should not, and by the time anyone wants to look at it there
+ * is nothing to look at.
+ *
+ * Reported by @jsboige in #184, from a real incident: a GLM coding-plan 5h cap
+ * saturated, the shape was reconstructable from request counts, and the literal
+ * 429 body was unrecoverable.
+ *
+ * Opt-in, because this writes provider error text — which can carry account
+ * identifiers — to a path the user names. Off by default, no directory is ever
+ * created, and nothing here can throw into the request path.
+ */
+
+import { appendFileSync } from "node:fs";
+
+/** Env var naming the capture file. Unset = feature off. */
+export const UPSTREAM_ERROR_LOG_ENV = "CLAUDISH_UPSTREAM_ERROR_LOG";
+
+/**
+ * Bytes of upstream body kept per record.
+ *
+ * An error body is normally a short JSON object, but a misconfigured gateway
+ * can return a full HTML page, and this file is appended to on every failure.
+ * 2KB keeps the useful head of any real error while bounding a pathological
+ * one. Truncation is marked so a reader never mistakes a cut body for the
+ * whole of it.
+ */
+export const MAX_CAPTURED_BODY_BYTES = 2048;
+
+export interface UpstreamErrorRecord {
+  provider: string;
+  model: string;
+  status: number;
+  body: string;
+  /** ISO timestamp; injectable so tests need no clock control. */
+  at?: string;
+}
+
+/**
+ * Append one JSON line describing a failed upstream response.
+ *
+ * Returns true when a record was written, false when the feature is off or the
+ * write failed. The boolean is for tests and callers that want to log their own
+ * diagnostic — nothing in the request path should branch on it.
+ *
+ * NEVER THROWS. A capture facility that can break a request is worse than no
+ * capture facility, and this runs on the error path, where the process is
+ * already handling something going wrong.
+ */
+export function captureUpstreamError(record: UpstreamErrorRecord): boolean {
+  const path = process.env[UPSTREAM_ERROR_LOG_ENV];
+  if (!path) return false;
+
+  try {
+    const raw = record.body ?? "";
+    const truncated = raw.length > MAX_CAPTURED_BODY_BYTES;
+    const line = JSON.stringify({
+      at: record.at ?? new Date().toISOString(),
+      provider: record.provider,
+      model: record.model,
+      status: record.status,
+      body: truncated ? raw.slice(0, MAX_CAPTURED_BODY_BYTES) : raw,
+      // Present only when it happened, so a reader who does not see the key can
+      // trust the body is complete.
+      ...(truncated ? { truncated: true, original_bytes: raw.length } : {}),
+    });
+    appendFileSync(path, `${line}\n`);
+    return true;
+  } catch {
+    // Unwritable path, full disk, permissions — all of which mean the user does
+    // not get their capture, and none of which mean the request should fail.
+    return false;
+  }
+}

--- a/packages/cli/src/proxy-server.test.ts
+++ b/packages/cli/src/proxy-server.test.ts
@@ -1,7 +1,55 @@
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Hono } from "hono";
+import { setConfigFileOverride } from "./config-override.js";
 import { wrapAnthropicError } from "./handlers/shared/anthropic-error.js";
 import { log, logStderr } from "./logger.js";
+import { createProxyServer } from "./proxy-server.js";
+import type { ProxyServer } from "./types.js";
+
+interface ModelsResponse {
+  object: string;
+  has_more: boolean;
+  data: Array<{
+    id: string;
+    object: string;
+    type: string;
+    created: number;
+    owned_by: string;
+  }>;
+}
+
+async function requestModels(
+  config: Record<string, unknown>,
+  servedSlotIds?: string[]
+): Promise<{ status: number; body: ModelsResponse }> {
+  const tempDir = mkdtempSync(join(tmpdir(), "claudish-model-discovery-"));
+  const configPath = join(tempDir, "config.json");
+  writeFileSync(configPath, JSON.stringify(config), "utf8");
+
+  // The CLI bootstrap turns CLAUDISH_CONFIG into this process-wide override.
+  // Tests invoke createProxyServer directly, so install the same override here.
+  setConfigFileOverride(configPath);
+  let proxy: ProxyServer | undefined;
+
+  try {
+    proxy = await createProxyServer(0, undefined, undefined, false, undefined, undefined, {
+      quiet: true,
+      servedSlotIds,
+    });
+    const response = await fetch(`${proxy.url}/v1/models`);
+    return {
+      status: response.status,
+      body: (await response.json()) as ModelsResponse,
+    };
+  } finally {
+    if (proxy) await proxy.shutdown();
+    setConfigFileOverride(null);
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+}
 
 const realConsoleError = console.error;
 const realStderrWrite = process.stderr.write;
@@ -55,5 +103,91 @@ describe("proxy unhandled-error backstop", () => {
       console.error = realConsoleError;
       process.stderr.write = realStderrWrite;
     }
+  });
+});
+
+describe("GET /v1/models", () => {
+  test("slot mode is unchanged", async () => {
+    const { status, body } = await requestModels({}, ["claude-haiku-4-5"]);
+
+    expect(status).toBe(200);
+    expect(body.data).toEqual([
+      {
+        id: "claude-haiku-4-5",
+        object: "model",
+        type: "model",
+        created: 1716000000,
+        owned_by: "claudish",
+      },
+    ]);
+  });
+
+  test("slot mode wins over discoverable config models", async () => {
+    const { body } = await requestModels(
+      {
+        routing: { "routing-model": ["openrouter"] },
+        customEndpoints: {
+          "slot-wins-fixture": {
+            kind: "simple",
+            url: "http://127.0.0.1:1/v1",
+            format: "openai",
+            apiKey: "test-key",
+            models: ["custom-model"],
+          },
+        },
+      },
+      ["claude-opus-4-1", "claude-sonnet-4-5"]
+    );
+
+    expect(body.data.map(({ id }) => id)).toEqual(["claude-opus-4-1", "claude-sonnet-4-5"]);
+  });
+
+  test("discovery lists routing rule names", async () => {
+    const { body } = await requestModels({
+      routing: {
+        "routing-model-a": ["openrouter"],
+        "routing-model-b": ["openai"],
+      },
+    });
+
+    expect(body.data.map(({ id }) => id)).toEqual(["routing-model-a", "routing-model-b"]);
+  });
+
+  test("discovery excludes the routing wildcard", async () => {
+    const { body } = await requestModels({
+      routing: {
+        "*": ["openrouter"],
+        "named-model": ["openrouter"],
+      },
+    });
+
+    expect(body.data.map(({ id }) => id)).toEqual(["named-model"]);
+  });
+
+  test("discovery includes custom endpoint models", async () => {
+    const { body } = await requestModels({
+      customEndpoints: {
+        "model-list-fixture": {
+          kind: "simple",
+          url: "http://127.0.0.1:1/v1",
+          format: "openai",
+          apiKey: "test-key",
+          models: ["a", "b"],
+        },
+      },
+    });
+
+    expect(body.data.map(({ id }) => id)).toEqual(["a", "b"]);
+  });
+
+  test("empty config returns an empty list with HTTP 200", async () => {
+    // Positive control: an always-empty implementation must not make this
+    // negative case pass while bypassing config discovery altogether.
+    const populated = await requestModels({ routing: { "discovery-control": ["openrouter"] } });
+    expect(populated.body.data.map(({ id }) => id)).toEqual(["discovery-control"]);
+
+    const { status, body } = await requestModels({});
+    expect(status).toBe(200);
+    expect(body).toEqual({ object: "list", has_more: false, data: [] });
   });
 });

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -773,11 +773,56 @@ export async function createProxyServer(
   // NOT the real model ids those slots route to. Defaults to an empty list
   // for non-serve callers (the picker is irrelevant to them).
   const servedSlotIds = options.servedSlotIds ?? [];
+  /**
+   * Model ids advertised to a NON-serve caller.
+   *
+   * Computed once, at server construction, deliberately. The obvious shape is
+   * to build this per request so a config edit shows up live, but this route
+   * feeds a picker that gets refreshed on a whim, and every per-request option
+   * is worse than it looks: `loadConfig()` is a disk read, and credential-
+   * filtering the list means resolving each rule's provider chain, which can
+   * reach 1Password — where a burst of concurrent handshakes trips a
+   * 15-second machine-wide suppression that then fails unrelated requests.
+   * A picker refresh must not be able to do that.
+   *
+   * NOT credential-filtered, and that is a decision rather than an omission.
+   * Filtering has two failure modes and they are not symmetric. Advertising a
+   * model with no key costs the user one clear credential error, which claudish
+   * already renders inline complete with the 1Password notice. Hiding a model
+   * whose key lives somewhere a SYNC check cannot see — an `op://` reference,
+   * resolvable at request time — makes a working model unpickable with no
+   * error at all and nothing to diagnose. The second is worse, so the list is
+   * everything routable by configuration.
+   */
+  const discoverableModelIds = ((): string[] => {
+    const seen = new Set<string>();
+    try {
+      const cfg = loadConfig();
+      for (const name of Object.keys(cfg.routing ?? {})) {
+        // `*` is the catch-all routing wildcard, not a model anyone can ask for.
+        if (name === "*") continue;
+        seen.add(name);
+      }
+      for (const ep of Object.values(cfg.customEndpoints ?? {})) {
+        for (const m of (ep as { models?: string[] }).models ?? []) seen.add(m);
+      }
+    } catch (err) {
+      // Same posture as every other optional read in this file: a broken config
+      // degrades the picker, it does not take the proxy down.
+      log(`[Proxy] /v1/models discovery skipped: ${err instanceof Error ? err.message : err}`);
+    }
+    return [...seen];
+  })();
+
   app.get("/v1/models", (c) => {
+    // Slot mode wins whenever `serve` supplied ids: Claude Desktop only
+    // recognizes the slot ids, and this branch must stay byte-identical to what
+    // it has always returned.
+    const ids = servedSlotIds.length > 0 ? servedSlotIds : discoverableModelIds;
     return c.json({
       object: "list",
       has_more: false,
-      data: servedSlotIds.map((id) => ({
+      data: ids.map((id) => ({
         id,
         object: "model",
         type: "model",


### PR DESCRIPTION
## What

Two findings from @jsboige's #184 and #180. I closed both PRs because their diffs were against a fork and referenced files that don't exist here — then went back and checked the underlying claims against our own source. **Both hold.** Rebuilt from scratch, credit on the commit.

---

## 1. Upstream error bodies were unrecoverable (#184)

`composed-handler.ts` reads a non-ok upstream body, hands it to the classifier, and drops it:

```ts
const errorText = await response.text();
log(`[${this.provider.displayName}] Error: ${errorText}`);
```

`log()` persists nothing unless `--debug` set a log file. So on a normal run that body is gone the moment it's classified — and it's the one thing that distinguishes a rate limit worth retrying from a hard quota wall that isn't.

Their report came from a real incident: a GLM coding-plan 5h cap saturated, the shape was reconstructable from request counts, the literal 429 body was not.

**`CLAUDISH_UPSTREAM_ERROR_LOG=<path>`** now appends one JSON line per non-ok upstream response.

- **Opt-in**, not always-on — this writes provider error text, which can carry account identifiers, to a path the user names
- Body capped at 2KB, and **truncation is marked**, so a reader who sees no `truncated` key can trust the body is whole
- **Never throws.** It runs on the error path, where something is already going wrong; a capture facility that can break a request is worse than none

---

## 2. `/v1/models` answered nothing for non-serve callers (#180)

The route returned `servedSlotIds`, empty unless `serve` supplied it. Everyone else got `[]`. It now falls back to routing-rule names plus custom-endpoint models. **Slot mode still wins outright and is byte-identical.**

Two deliberate departures from the original PR:

**Computed once at construction, not per request.** A picker refreshes on a whim. Per-request meant a `loadConfig()` disk read plus — in the original — `await route()` for every rule, which credential-filters and can reach 1Password, where concurrent handshakes trip a 15-second machine-wide suppression that then fails unrelated requests.

**Not credential-filtered**, which is where I disagree with the original's reasoning that "a 401-only option is strictly worse than not advertising it." The failure modes aren't symmetric:

| | Cost |
|---|---|
| Advertise a model with no key | one clear credential error, rendered inline with the 1Password notice |
| Hide a model whose key is behind `op://` | working model unpickable, no error, nothing to diagnose |

A sync check can't see an `op://` key that resolves fine at request time. Silent absence only beats a loud error when the check is sound.

---

## Tests

Six for the capture, seven for the route. Both **mutation-checked**:

- disabling the append → 5 of 6 fail
- reverting the route handler → 4 of 7 fail (`proxy-server.ts` restored to checksum `8e08b48b…` afterwards)

The route tests drive the **real** route via `createProxyServer`. The original PR's tests built a copy of the handler inside the test file, so deleting the entire production change left them all passing — that's why it was closed.

`2621 pass / 18 skip` locally. The one local failure is `team-grid.e2e` hitting `magmux: cannot lay out 1 panes in 0x-1` — no TTY in a background shell. It touches nothing this PR changes, and CI skips live e2e entirely.

Closes #184
Closes #180
