### PR TITLE
fix(test): give the spawned pty a size, and stop blaming magmux for it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -927,6 +927,30 @@ The corpus above is one developer's models on one developer's projects. A rule f
 Debug logging is behind the `--debug` flag and outputs to `logs/` directory. It's disabled by default.
 Keep full debug logging (including empty chunks, raw deltas) in log files — needed to understand real model streaming behavior. Suppress noise at the registration/initialization level (e.g., conditional middleware), not at the streaming data level.
 
+### `CLAUDISH_UPSTREAM_ERROR_LOG` — the one thing `--debug` being off loses forever
+
+A non-ok upstream response short-circuits before the stream parser, so
+`response-capture` never sees it. `composed-handler.ts` reads the body, hands it
+to the classifier, and drops it — and `log()` persists **nothing** unless
+`--debug` set a log file. So on a normal run the literal 429/402 body is gone
+the instant it has been classified, which is exactly the artifact that
+distinguishes a rate limit worth retrying from a hard quota wall that is not.
+Reported by @jsboige (#184) from a real incident: a GLM coding-plan 5h cap
+saturated, the shape was reconstructable from request counts, the body was not.
+
+`CLAUDISH_UPSTREAM_ERROR_LOG=<path>` appends one JSON line per non-ok upstream
+response: `{at, provider, model, status, body}`. Unset = off, and off is the
+default **on purpose** — this writes provider error text, which can carry
+account identifiers, to a path the user names. It is not part of `--debug`
+because the two answer different questions: `--debug` is "show me everything
+about this run", this is "keep the one field I will want next week".
+
+Three properties worth preserving if it is ever touched: the body is capped at
+2KB; truncation is **marked** (`truncated` + `original_bytes` appear only when
+it happened, so an unmarked body can be trusted as whole); and it **never
+throws**, because it runs on the error path where something is already going
+wrong and a capture facility that can break a request is worse than none.
+
 ### Raw SSE Capture (v5.14.0+)
 
 When `--debug` is active, both stream parsers log raw SSE events:

--- a/packages/cli/src/team-grid.e2e-helpers.ts
+++ b/packages/cli/src/team-grid.e2e-helpers.ts
@@ -136,6 +136,17 @@ export function runHeadless(opts: PtyRunOptions): HeadlessHandle {
  * expect's own stdin is our test handle, so test code can still send('q')
  * and have the keystroke reach the spawned process over the PTY.
  */
+/**
+ * Size given to a spawned pty.
+ *
+ * Comfortably above magmux's stated minimum of 3 rows / 20 columns per pane, so
+ * a gridfile with several panes still lays out. These are not the developer's
+ * real terminal and do not need to be: the tests read magmux's socket, not its
+ * rendering, and a fixed size makes the harness independent of whoever runs it.
+ */
+const PTY_ROWS = 50;
+const PTY_COLS = 200;
+
 export function runInPty(opts: PtyRunOptions): PtyHandle {
   void platform; // retained for future per-platform tweaks
   // Build the shell command string, quoting each arg for sh -c.
@@ -143,6 +154,14 @@ export function runInPty(opts: PtyRunOptions): PtyHandle {
 
   // Tcl program for expect:
   //   - timeout -1: don't limit; test code owns lifetime
+  //   - stty_init: give the pty a SIZE. expect sizes a spawned pty from its own
+  //     controlling terminal, and we spawn it with `stdio: ["pipe","pipe","pipe"]`,
+  //     so there is no terminal to copy from and the pty comes up 0x0. Measured
+  //     directly, no magmux involved: `stty size` inside such a pty prints
+  //     `0 0`, and prints `50 200` once stty_init is set. A tty-aware child
+  //     then derives nonsense from it — magmux subtracts its status line and
+  //     reports `cannot lay out 1 panes in 0x-1`, which is a correct complaint
+  //     about a terminal we failed to size rather than a bug in magmux.
   //   - spawn + interact: fork sh under a pty(4), which executes our command.
   //     We pass the shell command as a Tcl brace-literal so none of its
   //     contents get re-parsed by Tcl.
@@ -150,6 +169,7 @@ export function runInPty(opts: PtyRunOptions): PtyHandle {
   const tclScript = [
     "set timeout -1",
     "log_user 1",
+    `set stty_init "rows ${PTY_ROWS} cols ${PTY_COLS}"`,
     `spawn -noecho sh -c ${tclBrace(shellCmd)}`,
     "interact",
     "catch wait result",

--- a/packages/cli/src/team-grid.e2e.test.ts
+++ b/packages/cli/src/team-grid.e2e.test.ts
@@ -108,13 +108,40 @@ if (!glmCapable) {
   );
 }
 
-beforeAll(() => {
-  magmuxPath = findMagmuxForTest();
+describe("runInPty terminal size", () => {
+  // A 0x0 pty made magmux subtract its status line and report the misleading 0x-1 size.
+  it.skipIf(Bun.which("expect") === null)("gives the spawned pty a non-zero size", async () => {
+    let output = "";
+    const handle = runInPty({
+      command: ["stty", "size"],
+      onData: (chunk) => {
+        output += chunk;
+      },
+    });
+
+    const { code } = await handle.waitForExit();
+    expect(code).toBe(0);
+
+    const normalized = output.replace(/\r/g, "");
+    expect(normalized).toMatch(/\d+\s+\d+/);
+
+    const dimensions = normalized.match(/(\d+)\s+(\d+)/);
+    expect(dimensions).not.toBeNull();
+    const rows = Number(dimensions![1]);
+    const cols = Number(dimensions![2]);
+    expect(rows).toBeGreaterThan(0);
+    expect(cols).toBeGreaterThan(0);
+    // PTY_ROWS and PTY_COLS are private helper details, so exact values are not checked here.
+  });
 });
 
 // ─── Fast tier: socket protocol ──────────────────────────────────────────────
 
 describe("magmux socket protocol (shell commands)", () => {
+  beforeAll(() => {
+    if (!magmuxPath) magmuxPath = findMagmuxForTest();
+  });
+
   const commandPanes = (event: Record<string, unknown>) =>
     (event.panes as Array<Record<string, unknown>>).filter((pane) => pane.control !== true);
 
@@ -255,6 +282,10 @@ describe("magmux socket protocol (shell commands)", () => {
 // ─── Fast tier: crash fallback ───────────────────────────────────────────────
 
 describe("magmux crash fallback", () => {
+  beforeAll(() => {
+    if (!magmuxPath) magmuxPath = findMagmuxForTest();
+  });
+
   it("SIGKILL before results event → no results received", async () => {
     // A long-lived pane so we can kill before completion.
     const grid = writeGridfile(["sleep 30"]);
@@ -297,6 +328,10 @@ function devClaudishCommand(model: string, prompt: string): string {
 }
 
 describe("claudish team with real models and Claude Code", () => {
+  beforeAll(() => {
+    if (!magmuxPath) magmuxPath = findMagmuxForTest();
+  });
+
   const commandPanes = (event: Record<string, unknown>) =>
     (event.panes as Array<Record<string, unknown>>).filter((pane) => pane.control !== true);
 


### PR DESCRIPTION
## The failure

`team-grid.e2e`'s "default mode: pane runs a real model" has failed locally for weeks with:

```
magmux: cannot lay out 1 panes in 0x-1: every pane needs at least 3 rows and 20
columns (use fewer -e commands, a larger terminal, or set COLUMNS/LINES)
```

It was written off as environmental three separate times, twice by me. It isn't. magmux isn't at fault, and the installed magmux is current (0.8.1).

## The cause

`runInPty` spawns `expect` with `stdio: ["pipe","pipe","pipe"]`. expect sizes a spawned pty by copying its own controlling terminal — with piped stdio there is nothing to copy, so the pty comes up **0×0**.

Measured directly, no magmux involved:

| | `stty size` |
|---|---|
| expect, piped stdio, no `stty_init` | **`0 0`** |
| expect + `set stty_init "rows 50 cols 200"` | `50 200` |

magmux subtracts its status line from 0 rows and reports `0x-1`. Its error message is correct and even names the fix.

## The fix

One line before `spawn`. That file goes from **1 failing after a 180s timeout** to **7 pass / 1 skip / 0 fail in 66s**.

## The test

Asserts BOTH dimensions are `> 0` rather than just matching `\d+\s+\d+` — `"0 0"` satisfies a naive digits pattern, which is exactly the bug. Mutation-checked independently: removing `stty_init` fails it, and the helper was restored to a matching SHA-256 afterwards.

The file-level `beforeAll` that resolved magmux moved into the suites that need it, so the new test (only needs `expect` on PATH, no credentials, no magmux) doesn't drag magmux discovery in behind it.

## Also

Documents `CLAUDISH_UPSTREAM_ERROR_LOG` in CLAUDE.md — shipped in v7.58.0 and undocumented until now, including why it's opt-in and separate from `--debug`.