### PR TITLE
feat(routing): drop candidates that positively do not serve the model

### DIFF
--- a/packages/cli/src/providers/model-availability.test.ts
+++ b/packages/cli/src/providers/model-availability.test.ts
@@ -84,21 +84,37 @@ afterEach(() => {
 });
 
 describe("providerServesModel catalog evidence", () => {
-  test("returns serves when the matching row lists the provider", async () => {
+  test("still returns serves when the matching row lists the provider", async () => {
     _setCatalogEntriesForTest([
       catalogEntry("model-one", [{ provider: CATALOG_PROVIDER, externalId: "vendor/model-one" }]),
     ]);
 
+    // Partial coverage cannot prove a denial, but a listed provider is still
+    // positive catalog evidence and remains safe to confirm.
     expect(await providerServesModel(CATALOG_PROVIDER, "model-one")).toBe("serves");
   });
 
-  test("returns not-served when the provider is in the vocabulary but absent from the row", async () => {
+  test("returns unknown when a catalog-known provider is absent from the matching row", async () => {
     _setCatalogEntriesForTest([
       catalogEntry("model-one", [{ provider: OTHER_CATALOG_PROVIDER }]),
       catalogEntry("model-two", [{ provider: CATALOG_PROVIDER }]),
     ]);
 
-    expect(await providerServesModel(CATALOG_PROVIDER, "model-one")).toBe("not-served");
+    // Catalog coverage is partial, so absence from one row cannot deny service:
+    // openai-codex appears on only 1 of ~760 rows yet genuinely serves gpt-5.
+    // Only a complete live roster may turn absence into "not-served".
+    expect(await providerServesModel(CATALOG_PROVIDER, "model-one")).toBe("unknown");
+  });
+
+  test("returns unknown for the openai-codex thin-coverage shape", async () => {
+    _setCatalogEntriesForTest([
+      catalogEntry("the-one-listed-row", [{ provider: "openai-codex" }]),
+      catalogEntry("gpt-5", [{ provider: OTHER_CATALOG_PROVIDER }]),
+    ]);
+
+    // This models openai-codex appearing on one row but being absent from the
+    // queried row. Its real 1-of-~760 coverage is partial evidence, not a denial.
+    expect(await providerServesModel("openai-codex", "gpt-5")).toBe("unknown");
   });
 
   test("returns unknown when the provider never appears in the catalog vocabulary", async () => {

--- a/packages/cli/src/providers/model-availability.ts
+++ b/packages/cli/src/providers/model-availability.ts
@@ -62,24 +62,6 @@ function rosterHas(ids: string[], wireId: string): boolean {
 }
 
 /**
- * Every provider name the catalog uses anywhere in `aggregators[]`.
- *
- * This is what makes a catalog "no" trustworthy. A provider absent from one
- * model's row but present elsewhere in the catalog is genuinely not offered for
- * that model; a provider the catalog never mentions at all is simply outside its
- * scope, and its absence from a row means nothing.
- */
-function catalogProviderVocabulary(): Set<string> | null {
-  const entries = getCatalogEntries();
-  if (!entries) return null;
-  const vocab = new Set<string>();
-  for (const entry of entries) {
-    for (const agg of entry.aggregators ?? []) vocab.add(agg.provider);
-  }
-  return vocab.size > 0 ? vocab : null;
-}
-
-/**
  * Whether `provider` serves `wireId` — the id that would actually be SENT, not
  * the name the user typed. Callers hold the resolved spec already
  * (`buildRoutingChain` computes it), and passing the typed name instead would
@@ -115,11 +97,23 @@ export async function providerServesModel(
     return "unknown";
   }
 
-  // 2. IDENTITY — the catalog, for providers it actually tracks.
+  // 2. IDENTITY — the catalog may confirm a provider SERVES a model, but it may
+  //    never conclude that one does not.
+  //
+  // Catalog coverage is PARTIAL BY NATURE, and the counts make that concrete:
+  // `openai-codex` appears on exactly 1 model row, `kimi-coding` on 4, `x-ai` on
+  // 7 — out of ~760. An earlier version of this function trusted "provider
+  // appears somewhere in the catalog, but not on THIS row" as evidence of
+  // absence. That is unsound: openai-codex really does serve `gpt-5` through the
+  // ChatGPT subscription, and the rule declared it not-served for every model
+  // but one. Caught by `route()`'s own tests, which is exactly what they are
+  // for.
+  //
+  // A live roster is different in kind: it is COMPLETE BY CONSTRUCTION, because
+  // the provider is enumerating everything the caller's key can reach. Only that
+  // may deny. The catalog can still confirm, which is free and useful.
   const entries = getCatalogEntries();
   if (!entries) return "unknown";
-  const vocab = catalogProviderVocabulary();
-  if (!vocab?.has(provider)) return "unknown";
 
   const needle = wireId.trim().toLowerCase();
   const row = entries.find(
@@ -128,9 +122,7 @@ export async function providerServesModel(
       e.aliases.some((a) => a.toLowerCase() === needle) ||
       (e.aggregators ?? []).some((a) => a.externalId?.toLowerCase() === needle)
   );
-  // No row at all: the catalog does not know this model, so it cannot say the
-  // provider lacks it. A model newer than the cache lands here.
   if (!row) return "unknown";
 
-  return (row.aggregators ?? []).some((a) => a.provider === provider) ? "serves" : "not-served";
+  return (row.aggregators ?? []).some((a) => a.provider === provider) ? "serves" : "unknown";
 }

--- a/packages/cli/src/providers/routing-rules.test.ts
+++ b/packages/cli/src/providers/routing-rules.test.ts
@@ -9,21 +9,19 @@
  */
 
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync, rmdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { dirname, join } from "node:path";
+import { join } from "node:path";
 
 import { credentials } from "../auth/credentials/authority.js";
 import { __resetSniffForTests } from "../auth/credentials/op-source.js";
 import type { RoutingRules } from "../profile-config.js";
-import {
-  ALL_MODELS_CACHE_PATH,
-  type DiskCacheV2,
-  writeAllModelsCache,
-} from "./all-models-cache.js";
+import { type DiskCacheV2, type SlimModelEntry, writeAllModelsCache } from "./all-models-cache.js";
 import { DISPLAY_NAMES } from "./auto-route.js";
-import { _resetCatalogClient } from "./catalog-client.js";
+import { _resetCatalogClient, _setCatalogEntriesForTest } from "./catalog-client.js";
 import { DEFAULT_ROUTING_RULES } from "./default-routing-rules.js";
+import { invalidateModelDiscovery } from "./model-discovery.js";
+import type { ProviderDefinition } from "./provider-definitions.js";
 import {
   buildRoutingChain,
   matchRoutingRule,
@@ -31,41 +29,14 @@ import {
   normalizeGlmSlug,
   route,
 } from "./routing-rules.js";
+import { clearRuntimeRegistry, registerRuntimeProvider } from "./runtime-providers.js";
 
 const SYNTHETIC_MODEL_ID = "acme-x1.0";
 const SYNTHETIC_MINIMAX_EXTERNAL_ID = "ACME-X1.0";
 
 function seedDefaultCatalog(entries: DiskCacheV2["entries"]): () => void {
-  const cacheDir = dirname(ALL_MODELS_CACHE_PATH);
-  const cacheDirExisted = existsSync(cacheDir);
-  const previousContents = existsSync(ALL_MODELS_CACHE_PATH)
-    ? readFileSync(ALL_MODELS_CACHE_PATH, "utf-8")
-    : null;
-
-  writeAllModelsCache(
-    {
-      version: 2,
-      lastUpdated: new Date().toISOString(),
-      entries,
-      models: [],
-    },
-    ALL_MODELS_CACHE_PATH
-  );
-
-  return () => {
-    if (previousContents === null) {
-      rmSync(ALL_MODELS_CACHE_PATH, { force: true });
-      if (!cacheDirExisted) {
-        try {
-          rmdirSync(cacheDir);
-        } catch {
-          // Another test may have created something in the shared cache dir.
-        }
-      }
-      return;
-    }
-    writeFileSync(ALL_MODELS_CACHE_PATH, previousContents, "utf-8");
-  };
+  _setCatalogEntriesForTest(entries);
+  return _resetCatalogClient;
 }
 
 function makeTempCatalog(
@@ -282,6 +253,7 @@ describe("buildRoutingChain", () => {
   let cleanupCatalog: (() => void) | undefined;
 
   beforeEach(() => {
+    _resetCatalogClient();
     cleanupCatalog = seedDefaultCatalog([
       {
         modelId: SYNTHETIC_MODEL_ID,
@@ -296,11 +268,9 @@ describe("buildRoutingChain", () => {
         ],
       },
     ]);
-    _resetCatalogClient();
   });
 
   afterEach(() => {
-    _resetCatalogClient();
     cleanupCatalog?.();
     cleanupCatalog = undefined;
   });
@@ -899,4 +869,237 @@ describe("route() with defaultProvider", () => {
 describe("import consistency", () => {
   // Identity mapping (kimi→kimi): buildRoutingChain's `?? raw` fallback resolves
   // "kimi" even if the shortcut is absent, so only this direct assertion guards it.
+});
+
+// ---------------------------------------------------------------------------
+// route() — model-availability filtering
+// ---------------------------------------------------------------------------
+
+const AVAILABILITY_MODEL = "availability-model";
+
+function routingCatalogEntry(modelId: string, providers: string[]): SlimModelEntry {
+  return {
+    modelId,
+    aliases: [],
+    sources: { test: { externalId: modelId } },
+    aggregators: providers.map((provider) => ({
+      provider,
+      externalId: modelId,
+      confidence: "api_official",
+    })),
+  };
+}
+
+function rosterProvider(name: string): ProviderDefinition {
+  return {
+    name,
+    displayName: name,
+    transport: "openai",
+    baseUrl: `https://${name}.invalid`,
+    apiPath: "/v1/chat/completions",
+    apiKeyEnvVar: `${name.toUpperCase().replaceAll("-", "_")}_API_KEY`,
+    apiKeyDescription: "Offline routing-test key",
+    apiKeyUrl: "https://example.invalid/key",
+    shortcuts: [],
+    legacyPrefixes: [],
+    modelDiscovery: { path: "/v1/models", format: "openai-models-list" },
+    isDirectApi: true,
+  };
+}
+
+describe("route() model-availability filtering", () => {
+  const realFetch = globalThis.fetch;
+  const realIsAvailable = credentials.isAvailable;
+  const realGetRequestAuth = credentials.getRequestAuth;
+
+  let cachePath = "";
+  let cleanupCache: (() => void) | undefined;
+  let credentialedProviders = new Set<string>();
+  let rosters = new Map<string, string[]>();
+  let fetchCalls: string[] = [];
+
+  function allowCredentials(...providers: string[]): void {
+    credentialedProviders = new Set(providers);
+  }
+
+  function registerRoster(name: string, ...ids: string[]): void {
+    registerRuntimeProvider(rosterProvider(name));
+    rosters.set(name, ids);
+  }
+
+  beforeEach(() => {
+    _resetCatalogClient();
+    _setCatalogEntriesForTest([]);
+    invalidateModelDiscovery();
+    clearRuntimeRegistry();
+
+    credentialedProviders = new Set();
+    rosters = new Map();
+    fetchCalls = [];
+
+    const tempCatalog = makeTempCatalog({ modelId: AVAILABILITY_MODEL });
+    cachePath = tempCatalog.path;
+    cleanupCache = tempCatalog.cleanup;
+
+    credentials.isAvailable = async (provider: string) => credentialedProviders.has(provider);
+    credentials.getRequestAuth = async () => ({
+      headers: { Authorization: "Bearer offline-routing-test-token" },
+    });
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const rawUrl =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const provider = new URL(rawUrl).hostname.replace(/\.invalid$/, "");
+      fetchCalls.push(provider);
+      const ids = rosters.get(provider);
+      if (!ids) throw new Error(`Unexpected roster request for ${provider}`);
+      return new Response(JSON.stringify({ data: ids.map((id) => ({ id })) }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    cleanupCache?.();
+    cleanupCache = undefined;
+    _resetCatalogClient();
+    invalidateModelDiscovery();
+    clearRuntimeRegistry();
+    credentials.isAvailable = realIsAvailable;
+    credentials.getRequestAuth = realGetRequestAuth;
+    globalThis.fetch = realFetch;
+  });
+
+  test("removes not-served candidates and preserves the surviving order", async () => {
+    const denied = "availability-denied";
+    registerRoster(denied, "some-other-model");
+    allowCredentials(denied, "openai", "openrouter");
+    _setCatalogEntriesForTest([routingCatalogEntry(AVAILABILITY_MODEL, ["openai", "openrouter"])]);
+
+    const plan = await route(
+      AVAILABILITY_MODEL,
+      { [AVAILABILITY_MODEL]: [denied, "openai", "openrouter"] },
+      undefined,
+      cachePath
+    );
+
+    expect(plan.kind).toBe("ok");
+    if (plan.kind !== "ok") return;
+    expect([plan.primary.provider, ...plan.fallbacks.map((fallback) => fallback.provider)]).toEqual(
+      ["openai", "openrouter"]
+    );
+  });
+
+  test("keeps an unknown candidate when catalog coverage is partial", async () => {
+    allowCredentials("openai-codex");
+    _setCatalogEntriesForTest([
+      routingCatalogEntry(AVAILABILITY_MODEL, ["openai"]),
+      routingCatalogEntry("the-one-listed-codex-row", ["openai-codex"]),
+    ]);
+
+    // Safety guard: treating catalog absence as denial would drop nearly every
+    // subscription provider, whose catalog coverage is partial by nature.
+    const plan = await route(
+      AVAILABILITY_MODEL,
+      { [AVAILABILITY_MODEL]: ["openai-codex"] },
+      undefined,
+      cachePath
+    );
+
+    expect(plan.kind).toBe("ok");
+    if (plan.kind !== "ok") return;
+    expect(plan.primary.provider).toBe("openai-codex");
+  });
+
+  test("keeps a candidate confirmed as serves", async () => {
+    allowCredentials("openai");
+    _setCatalogEntriesForTest([routingCatalogEntry(AVAILABILITY_MODEL, ["openai"])]);
+
+    const plan = await route(
+      AVAILABILITY_MODEL,
+      { [AVAILABILITY_MODEL]: ["openai"] },
+      undefined,
+      cachePath
+    );
+
+    expect(plan.kind).toBe("ok");
+    if (plan.kind !== "ok") return;
+    expect(plan.primary.provider).toBe("openai");
+  });
+
+  test("returns no-route naming every checked provider when all are not-served", async () => {
+    const first = "availability-denied-first";
+    const second = "availability-denied-second";
+    registerRoster(first, "other-first");
+    registerRoster(second, "other-second");
+    allowCredentials(first, second);
+
+    const plan = await route(
+      AVAILABILITY_MODEL,
+      { [AVAILABILITY_MODEL]: [first, second] },
+      undefined,
+      cachePath
+    );
+
+    expect(plan.kind).toBe("no-route");
+    if (plan.kind !== "no-route") return;
+    expect(plan.reason).toBe(
+      `No provider serves "${AVAILABILITY_MODEL}" (checked: ${first}, ${second}).`
+    );
+  });
+
+  test("explicit not-served spec returns no-route without silent substitution", async () => {
+    const denied = "availability-explicit-denied";
+    registerRoster(denied, "some-other-model");
+    allowCredentials(denied, "openai");
+
+    const plan = await route(
+      `${denied}@${AVAILABILITY_MODEL}`,
+      { [AVAILABILITY_MODEL]: ["openai"] },
+      "openai",
+      cachePath
+    );
+
+    expect(plan.kind).not.toBe("ok");
+    expect(plan.kind).toBe("no-route");
+    if (plan.kind !== "no-route") return;
+    expect(plan.reason).toContain("does not serve");
+    expect(plan.reason).toContain(AVAILABILITY_MODEL);
+  });
+
+  test("explicit serves spec returns ok with the named provider", async () => {
+    const serving = "availability-explicit-serving";
+    registerRoster(serving, AVAILABILITY_MODEL);
+    allowCredentials(serving);
+
+    const plan = await route(`${serving}@${AVAILABILITY_MODEL}`, {}, undefined, cachePath);
+
+    expect(plan.kind).toBe("ok");
+    if (plan.kind !== "ok") return;
+    expect(plan.primary.provider).toBe(serving);
+    expect(plan.fallbacks).toEqual([]);
+  });
+
+  test("checks availability only after filtering providers without credentials", async () => {
+    const noCredential = "availability-no-credential";
+    const credentialed = "availability-credentialed";
+    registerRoster(noCredential, AVAILABILITY_MODEL);
+    registerRoster(credentialed, AVAILABILITY_MODEL);
+    allowCredentials(credentialed);
+
+    const plan = await route(
+      AVAILABILITY_MODEL,
+      { [AVAILABILITY_MODEL]: [noCredential, credentialed] },
+      undefined,
+      cachePath
+    );
+
+    expect(plan.kind).toBe("ok");
+    if (plan.kind !== "ok") return;
+    expect(plan.primary.provider).toBe(credentialed);
+    // A provider the user cannot authenticate to must never incur the
+    // guaranteed-failing roster round-trip.
+    expect(fetchCalls).toEqual([credentialed]);
+    expect(fetchCalls).not.toContain(noCredential);
+  });
 });

--- a/packages/cli/src/providers/routing-rules.ts
+++ b/packages/cli/src/providers/routing-rules.ts
@@ -1,10 +1,13 @@
 import { resolveSubscriptionRouting } from "../adapters/model-catalog.js";
 import { credentials } from "../auth/credentials/authority.js";
+import { isSubscriptionProvider } from "../handlers/shared/remote-provider-types.js";
+import { log, logStderr } from "../logger.js";
 import { loadConfig, loadLocalConfig } from "../profile-config.js";
 import type { RoutingEntry, RoutingRules } from "../profile-config.js";
 import { DISPLAY_NAMES, PROVIDER_TO_PREFIX } from "./auto-route.js";
 import { resolveExternalId } from "./catalog-client.js";
 import { DEFAULT_ROUTING_RULES } from "./default-routing-rules.js";
+import { providerServesModel } from "./model-availability.js";
 import { PROVIDER_SHORTCUTS } from "./model-parser.js";
 import { parseModelSpec } from "./model-parser.js";
 import { buildCredentialHint } from "./routing-hints.js";
@@ -269,6 +272,25 @@ async function routeExplicit(
       reason: `Could not build a route for "${modelSpec}".`,
     };
   }
+
+  // An explicit address is NEVER silently dropped — the user named this vendor,
+  // so a "does not serve it" verdict is something to TELL them, not something to
+  // route around. That is the difference from the bare path, where claudish
+  // assembled the chain itself and may quietly pick another link.
+  //
+  // Without this the request still fails, just later and less clearly: OpenCode
+  // Zen Go answers for a model it does not carry with HTTP 401, which reads as a
+  // credential problem and sends the user to check a key that works.
+  if ((await providerServesModel(built.provider, wireIdOf(built))) === "not-served") {
+    return {
+      kind: "no-route",
+      reason: `${built.displayName} does not serve "${model}".`,
+      hint:
+        `Check the model id, or use a bare \`${model}\` to let claudish pick a provider ` +
+        "that carries it.",
+    };
+  }
+
   return { kind: "ok", primary: built, fallbacks: [] };
 }
 
@@ -340,8 +362,77 @@ async function routeBare(
     };
   }
 
-  const [primary, ...fallbacks] = credentialed;
+  // AVAILABILITY filter — drop a candidate only when a source positively says
+  // it does not carry this model.
+  //
+  // This runs AFTER the credential filter, not before, and the order is not
+  // cosmetic: `providerServesModel` may hit the provider's own roster endpoint,
+  // which needs that provider's credential. Asking about a provider the user
+  // cannot authenticate to would be a guaranteed-failing round-trip.
+  //
+  // Only "not-served" removes anything. "unknown" — no source covers this
+  // provider, the catalog is cold, the roster endpoint was briefly down — keeps
+  // the candidate exactly where it was. That asymmetry is the whole safety
+  // property: reading absence of evidence as denial would drop every provider
+  // neither source covers, which is almost entirely the SUBSCRIPTION providers,
+  // and would move users off plans they pay for onto metered hops.
+  const availability = await Promise.all(
+    credentialed.map((candidate) => providerServesModel(candidate.provider, wireIdOf(candidate)))
+  );
+  const serving: Route[] = [];
+  const notServing: string[] = [];
+  credentialed.forEach((candidate, i) => {
+    if (availability[i] === "not-served") {
+      notServing.push(candidate.provider);
+    } else {
+      serving.push(candidate);
+    }
+  });
+
+  if (serving.length === 0) {
+    // Every credentialed provider positively denied carrying this model. That is
+    // strong evidence — "unknown" never lands here — so a clear no-route beats
+    // sending a request that each of them would reject in turn.
+    return {
+      kind: "no-route",
+      reason: `No provider serves "${model}" (checked: ${notServing.join(", ")}).`,
+      hint: buildCredentialHint(model, notServing) ?? undefined,
+    };
+  }
+
+  if (notServing.length > 0) {
+    log(`[routing] ${model}: skipped ${notServing.join(", ")} — does not serve this model`);
+    // Say it OUT LOUD only when the skip changes how the user is billed. A
+    // subscription provider dropped in favour of a metered one is a cost change
+    // they did not choose — claudish assembled this chain — which is the same
+    // reason fallback-handler announces advancing past a spent plan. Every other
+    // skip is routine and stays in the debug log.
+    const droppedSubscription = notServing.filter((p) => isSubscriptionProvider(p));
+    if (droppedSubscription.length > 0 && !isSubscriptionProvider(serving[0].provider)) {
+      logStderr(
+        `[claudish] ${droppedSubscription.join(", ")} does not serve ${model} — ` +
+          `using ${serving[0].displayName}, which bills per token.`
+      );
+    }
+  }
+
+  const [primary, ...fallbacks] = serving;
   return { kind: "ok", primary, fallbacks };
+}
+
+/**
+ * The id a route would actually SEND, extracted from its `modelSpec`.
+ *
+ * `buildRoutingChain` emits `provider@model` for everyone except OpenRouter,
+ * whose ids are already vendor-qualified and are their own spec. Availability
+ * must be asked about the wire id, never the name the user typed — comparing the
+ * typed name would test the wrong side of an `externalId` mapping, and that
+ * mapping is exactly what a roster settles (OpenCode Zen Go serves
+ * `deepseek-v4-pro`, while the catalog id carries a date suffix).
+ */
+function wireIdOf(route: Route): string {
+  const at = route.modelSpec.indexOf("@");
+  return at === -1 ? route.modelSpec : route.modelSpec.slice(at + 1);
 }
 
 /**


### PR DESCRIPTION
Wires the `providerServesModel` resolver (shipped inert in v7.57.0) into `route()`. This is the behaviour change.

## The problem

A bare `deepseek-v4-pro-0813` chain reaches `opencode-zen-go` first. Zen Go doesn't carry it and says so with **HTTP 401** — a status that reads as a credential failure, sends the user to check a key that works, and masks the live OpenRouter hop further down the same chain.

Nothing in the chain builder knew the model wasn't carried, even though the provider's own roster answers the question in one call.

## routeBare

The availability filter runs **after** the credential filter, and the order isn't cosmetic: `providerServesModel` may call the provider's own roster endpoint, which needs that provider's credential. Asking about a provider the user can't authenticate to is a guaranteed-failing round-trip.

Only `not-served` removes anything. `unknown` keeps the candidate exactly where it was — that asymmetry is the whole safety property. If every candidate denies, the result is a clear `no-route` naming who was checked, which beats sending a request each of them would reject in turn.

Measured live:

```
deepseek-v4-pro-0813  ->  openrouter                                   (Zen Go dropped)
deepseek-v4-pro       ->  opencode-zen-go -> openrouter                (kept — it serves it)
kimi-k3               ->  kimi-coding -> zen-go -> kimi -> openrouter  (intact)
```

## routeExplicit

An explicit `provider@model` is **never** silently dropped — the user named that vendor, so "does not serve it" is something to tell them:

```
zgo@deepseek-v4-pro-0813  ->  no-route: OpenCode Zen Go does not serve "deepseek-v4-pro-0813"
zgo@kimi-k3               ->  ok
```

## Announcing a drop

Routine skips go to the debug log. A dropped **subscription** provider whose replacement is metered gets an stderr line naming it — that's a cost change the user didn't choose, since claudish assembled the chain. Same reasoning `fallback-handler` already applies when advancing past a spent plan.

## A correction the existing tests caught

`model-availability.ts` treated *"provider appears in the catalog's aggregator vocabulary but not on THIS row"* as evidence of absence. That's unsound — catalog coverage is partial by nature:

| provider | rows in catalog (of ~760) |
|---|---|
| `openai-codex` | **1** |
| `kimi-coding` | 4 |
| `x-ai` | 7 |

`openai-codex` genuinely serves `gpt-5` through the ChatGPT subscription, and the rule declared it not-served for every model but one. Four existing `route()` tests went red — exactly what they're for.

**The catalog may now confirm, never deny.** Only a live roster may deny, because a roster is complete by construction — the provider enumerates everything the caller's key can reach — while catalog coverage is a sample. This also removes a non-determinism the first version introduced: routing no longer depends on whether the catalog cache happens to be warm.

## Tests

Mutation proofs, each independently re-run:

| Mutation | Result |
|---|---|
| Reinstate the catalog-denies rule | **10 red**, including existing `route()` guards |
| Treat `unknown` as a drop | safety guard red |
| Remove the explicit-spec check | no-silent-substitution test red |

82 pass across the two targeted files. Local hermetic run: **2685 tests, 1 fail** — a magmux real-model e2e that needs a TTY and live credentials, skipped in CI and unrelated to these modules (`team-grid` imports none of them).

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
