### PR TITLE
fix(errors): report the provider's actual reason; glm discovery; qwen reasoning-knob conflict

### DIFF
--- a/packages/cli/src/adapters/qwen-model-dialect.test.ts
+++ b/packages/cli/src/adapters/qwen-model-dialect.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { EFFORT_LEVELS, type EffortLevel } from "./base-api-format.js";
+import { QwenModelDialect } from "./qwen-model-dialect.js";
+
+interface PreparedQwenRequest {
+  enable_thinking?: boolean;
+  reasoning_effort?: string;
+  thinking?: unknown;
+  thinking_budget?: number;
+}
+
+function prepareWithIncomingReasoningEffort(effort: EffortLevel): PreparedQwenRequest {
+  return new QwenModelDialect("qwen3.7-plus").prepareRequest(
+    { messages: [], reasoning_effort: "high" },
+    { output_config: { effort }, messages: [] }
+  );
+}
+
+describe("QwenModelDialect reasoning request cleanup", () => {
+  test("removes incoming reasoning_effort when enabling thinking with a budget", () => {
+    const cases = [
+      { effort: "high", thinkingBudget: 24576 },
+      { effort: "medium", thinkingBudget: 8192 },
+    ] as const;
+
+    for (const { effort, thinkingBudget } of cases) {
+      const out = prepareWithIncomingReasoningEffort(effort);
+
+      expect(out.reasoning_effort).toBeUndefined();
+      expect(out.enable_thinking).toBe(true);
+      expect(out.thinking_budget).toBe(thinkingBudget);
+      expect(typeof out.thinking_budget).toBe("number");
+    }
+  });
+
+  test("removes incoming reasoning_effort when disabling thinking without a budget", () => {
+    for (const effort of ["minimal", "none"] as const) {
+      const out = prepareWithIncomingReasoningEffort(effort);
+
+      expect(out.reasoning_effort).toBeUndefined();
+      expect(out.enable_thinking).toBe(false);
+      expect(out.thinking_budget).toBeUndefined();
+    }
+  });
+
+  test("never sends reasoning_effort together with thinking_budget at any supported effort", () => {
+    for (const effort of EFFORT_LEVELS) {
+      const out = prepareWithIncomingReasoningEffort(effort);
+
+      // DashScope hard-400s this exact pair; it does not silently ignore either field.
+      expect(!(out.reasoning_effort !== undefined && out.thinking_budget !== undefined)).toBe(true);
+    }
+  });
+
+  test("still removes a raw thinking object from the prepared request", () => {
+    const rawThinking = { budget_tokens: 4096, type: "enabled" };
+    const out = new QwenModelDialect("qwen3.7-plus").prepareRequest(
+      { messages: [], thinking: rawThinking },
+      { messages: [], output_config: { effort: "high" }, thinking: rawThinking }
+    );
+
+    expect(out.thinking).toBeUndefined();
+    expect(out.enable_thinking).toBe(true);
+    expect(out.thinking_budget).toBe(24576);
+  });
+});

--- a/packages/cli/src/adapters/qwen-model-dialect.ts
+++ b/packages/cli/src/adapters/qwen-model-dialect.ts
@@ -92,6 +92,25 @@ export class QwenModelDialect extends BaseAPIFormat {
     // Cleanup: remove raw thinking object so it doesn't double-send.
     if (originalRequest.thinking) delete request.thinking;
 
+    // …and remove `reasoning_effort` for the same reason, one knob over.
+    //
+    // DashScope does not merely ignore the pair, it REJECTS it:
+    //
+    //   400 [invalid_parameter_error] 'reasoning_effort' and 'thinking_budget'
+    //       cannot be set simultaneously
+    //
+    // Reported 2026-08-19 through Zen Go, which fronts Qwen and passes the
+    // upstream verdict back verbatim. `reasoning_effort` is OpenAI's spelling of
+    // the same intent this method has just expressed in DashScope's spelling, so
+    // leaving it is a contradiction on the wire regardless of who set it — and
+    // it costs the whole turn, not just the reasoning depth.
+    //
+    // GLMModelDialect already does this ("never leave a depth knob contradicting
+    // the off-switch"); Qwen cleaned up `thinking` but not this one. Unconditional
+    // rather than gated on `originalRequest`, because the field can arrive from
+    // the OpenAI-shaped base format as well as from the caller.
+    if (request.reasoning_effort !== undefined) delete request.reasoning_effort;
+
     return request;
   }
 

--- a/packages/cli/src/handlers/composed-handler-error.test.ts
+++ b/packages/cli/src/handlers/composed-handler-error.test.ts
@@ -130,6 +130,8 @@ const PAYLOAD = {
   messages: [{ role: "user", content: "hi" }],
 };
 
+const REGION_OPT_IN_URL = "https://opencode.ai/workspace/0123456789abcdef0123456789abcdef/go";
+
 function makeHandler(): ComposedHandler {
   return new ComposedHandler(makeTransport(), "fugu-ultra", "fugu-ultra", 8080, {});
 }
@@ -186,6 +188,22 @@ describe("ComposedHandler.handle — error surfacing wiring", () => {
 
     expect(captured.body?.error?.message).toContain("Check API key / OAuth credentials");
     expect(captured.body?.error?.message).not.toContain("Model not supported by this provider");
+  });
+
+  test("an actionable RegionError 403 surfaces its URL instead of an API-key hint", async () => {
+    stubUpstream(403, {
+      type: "error",
+      error: {
+        type: "RegionError",
+        message: `The latest version of this model is only available hosted in China and requires explicit opt in: ${REGION_OPT_IN_URL}`,
+      },
+    });
+    const { c, captured } = makeContext();
+
+    await makeHandler().handle(c, PAYLOAD);
+
+    expect(captured.body?.error?.message).not.toContain("Check API key");
+    expect(captured.body?.error?.message).toContain(REGION_OPT_IN_URL);
   });
 
   test("transient 503 keeps its retryable status (Claude Code SHOULD retry)", async () => {

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -54,7 +54,7 @@ import {
 import { sseResponseToJson } from "./shared/collect-sse-message.js";
 import { buildConnectionErrorMessage, classifyConnectionError } from "./shared/connection-error.js";
 import { sniffDevinStreamHead } from "./shared/devin-stream-head-sniffer.js";
-import { hasModelUnsupportedWording } from "./shared/model-unsupported.js";
+import { hasActionableLink, hasModelUnsupportedWording } from "./shared/model-unsupported.js";
 import { filterIdentity } from "./shared/openai-compat.js";
 import { isQuotaExhaustionError } from "./shared/quota-exhaustion.js";
 import { sniffResponsesStreamHead } from "./shared/stream-head-sniffer.js";
@@ -1630,6 +1630,16 @@ function getRecoveryHint(
     // fallback gate rather than duplicated here.
     if (isQuotaExhaustionError(status, errorText)) {
       return "Out of quota — check your plan & billing details. This won't recover on retry.";
+    }
+    // The provider already said what to do, and it is not "check your key".
+    // Measured: Zen Go answers a model the account has not opted into with
+    // `403 RegionError … requires explicit opt in: <url>`. The route, the
+    // credential and the model are all fine — so telling the user to audit a
+    // working credential talks over the fix sitting in the same sentence.
+    // Checked LAST, so a genuine auth failure that happens to cite a docs link
+    // still reaches the credential advice above via its own wording.
+    if (hasActionableLink(errorText)) {
+      return "Provider rejected the request and gave a specific fix — follow the link in the message below.";
     }
     return "Check API key / OAuth credentials.";
   }

--- a/packages/cli/src/handlers/shared/model-unsupported.test.ts
+++ b/packages/cli/src/handlers/shared/model-unsupported.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { hasModelUnsupportedWording } from "./model-unsupported.js";
+import { hasActionableLink, hasModelUnsupportedWording } from "./model-unsupported.js";
 
 const UNSUPPORTED_PHRASES = [
   "not supported",
@@ -57,5 +57,31 @@ describe("hasModelUnsupportedWording", () => {
       expect(invoke).not.toThrow();
       expect(invoke()).toBe(false);
     }
+  });
+});
+
+describe("hasActionableLink", () => {
+  test("finds http and https URLs embedded in JSON error bodies", () => {
+    const bodies = [
+      anthropicErrorBody("RegionError", "Opt in at https://opencode.ai/workspace/test/go"),
+      anthropicErrorBody("PolicyError", "Resolve at http://provider.test/account/settings"),
+    ];
+
+    for (const body of bodies) {
+      expect(hasActionableLink(body)).toBe(true);
+    }
+  });
+
+  test("returns false for an error body with no URL", () => {
+    expect(hasActionableLink(anthropicErrorBody("authentication_error", "Invalid API key."))).toBe(
+      false
+    );
+  });
+
+  test("returns false without throwing for an empty string", () => {
+    const invoke = () => hasActionableLink("");
+
+    expect(invoke).not.toThrow();
+    expect(invoke()).toBe(false);
   });
 });

--- a/packages/cli/src/handlers/shared/model-unsupported.ts
+++ b/packages/cli/src/handlers/shared/model-unsupported.ts
@@ -65,3 +65,32 @@ export function hasModelUnsupportedWording(errorBody: string): boolean {
   const lower = (errorBody || "").toLowerCase();
   return UNSUPPORTED_PHRASES.some((phrase) => lower.includes(phrase));
 }
+
+/**
+ * Whether the provider already told the caller what to DO — i.e. its message
+ * carries a link to act on.
+ *
+ * A generic recovery hint is a guess. When the provider has supplied an
+ * actionable instruction, that guess stops being merely unhelpful and starts
+ * CONTRADICTING the truth sitting next to it. Measured 2026-08-19, Zen Go
+ * answers a model its account has not opted into with:
+ *
+ *   403 {"error":{"type":"RegionError","message":"The latest version of this
+ *        model is only available hosted in China and requires explicit opt in:
+ *        https://opencode.ai/workspace/<id>/go"}}
+ *
+ * The route is fine, the credential is fine, the model IS carried (it is in the
+ * live roster, so the availability filter correctly kept the provider) — the
+ * account simply has not opted into that region. claudish rendered it as
+ * "Check API key / OAuth credentials.", sending the user to audit a working key
+ * while the fix — a link — sat in the same sentence.
+ *
+ * Detecting the LINK rather than the wording is deliberate. "RegionError" is one
+ * vendor's type name for one policy; the next provider will invent a different
+ * one, and a phrase list would have to grow forever to keep up. A URL means the
+ * same thing everywhere: there is a specific place to go, and claudish should
+ * step out of the way rather than talk over it.
+ */
+export function hasActionableLink(errorBody: string): boolean {
+  return /https?:\/\/\S+/i.test(errorBody || "");
+}

--- a/packages/cli/src/providers/probe-live-classify.test.ts
+++ b/packages/cli/src/providers/probe-live-classify.test.ts
@@ -25,6 +25,15 @@ function remappedTerminalBody(
   return JSON.stringify(wrapAnthropicError(400, surfaced, "invalid_request_error", upstreamStatus));
 }
 
+const REGION_OPT_IN_URL = "https://opencode.ai/workspace/0123456789abcdef0123456789abcdef/go";
+const REGION_ERROR_BODY = JSON.stringify({
+  type: "error",
+  error: {
+    type: "RegionError",
+    message: `The latest version of this model is only available hosted in China and requires explicit opt in: ${REGION_OPT_IN_URL}`,
+  },
+});
+
 describe("classifyHttpError — auth-shaped model errors", () => {
   test("classifies a 401 unsupported-model response without rewriting its status", () => {
     const body = proxyErrorBody(401, "Model deepseek-v4-pro-0813 is not supported");
@@ -45,13 +54,28 @@ describe("classifyHttpError — auth-shaped model errors", () => {
     expect(result.httpStatus).toBe(401);
   });
 
+  test("classifies a 403 with the provider's opt-in link as error and preserves the full URL", () => {
+    const result = classifyHttpError(403, REGION_ERROR_BODY, 39);
+
+    expect(result.state).toBe("error");
+    expect(result.httpStatus).toBe(403);
+    expect(result.errorMessage).toContain(REGION_OPT_IN_URL);
+  });
+
+  test("keeps a URL-free invalid-key 401 classified as an authentication failure", () => {
+    const result = classifyHttpError(401, "Invalid API key.", 40);
+
+    expect(result.state).toBe("auth-failed");
+    expect(result.httpStatus).toBe(401);
+  });
+
   test("distinguishes unsupported-model and authentication wording under HTTP 403", () => {
     const unsupported = classifyHttpError(
       403,
       proxyErrorBody(403, "Unsupported model: deepseek-v4-pro-0813"),
-      39
+      41
     );
-    const forbidden = classifyHttpError(403, proxyErrorBody(403, "Forbidden"), 40);
+    const forbidden = classifyHttpError(403, proxyErrorBody(403, "Forbidden"), 42);
 
     expect(unsupported.state).toBe("model-not-found");
     expect(unsupported.httpStatus).toBe(403);
@@ -67,12 +91,12 @@ describe("classifyHttpError — auth-shaped model errors", () => {
         "Model deepseek-v4-pro-0813 is not supported",
         "Model not supported by this provider. Verify model name."
       ),
-      41
+      43
     );
     const unauthorized = classifyHttpError(
       400,
       remappedTerminalBody(401, "Unauthorized", "Check API key / OAuth credentials."),
-      42
+      44
     );
 
     expect(unsupported.state).toBe("model-not-found");
@@ -89,7 +113,7 @@ describe("classifyHttpError — auth-shaped model errors", () => {
     ] as const;
 
     for (const { status, message, state } of cases) {
-      const result = classifyHttpError(status, proxyErrorBody(status, message), 43);
+      const result = classifyHttpError(status, proxyErrorBody(status, message), 45);
       expect(result.state).toBe(state);
       expect(result.httpStatus).toBe(status);
     }

--- a/packages/cli/src/providers/probe-live.ts
+++ b/packages/cli/src/providers/probe-live.ts
@@ -12,7 +12,10 @@
  * not a silent failover to something else.
  */
 
-import { hasModelUnsupportedWording } from "../handlers/shared/model-unsupported.js";
+import {
+  hasActionableLink,
+  hasModelUnsupportedWording,
+} from "../handlers/shared/model-unsupported.js";
 
 export type ProbeState =
   | "live"
@@ -365,6 +368,20 @@ export function classifyHttpError(status: number, body: string, latencyMs: numbe
         errorMessage: extractErrorMessage(body) || `HTTP ${authStatus}`,
       };
     }
+    // Nor is it an auth failure when the provider handed back a link to act on.
+    // Measured: Zen Go answers a model the account has not opted into with
+    // `403 RegionError … requires explicit opt in: <url>` — the credential is
+    // fine, the model IS in its live roster, and the fix is a click. Reporting
+    // `auth-failed` there points the user at a working key. `error` keeps the
+    // failure semantics (it is in `isFailureState`) without the false cause.
+    if (hasActionableLink(body)) {
+      return {
+        state: "error",
+        latencyMs,
+        httpStatus: authStatus,
+        errorMessage: extractErrorMessage(body) || `HTTP ${authStatus}`,
+      };
+    }
     return {
       state: "auth-failed",
       latencyMs,
@@ -423,6 +440,31 @@ export function classifyHttpError(status: number, body: string, latencyMs: numbe
   };
 }
 
+/**
+ * Shorten a provider message for a probe row WITHOUT severing a URL.
+ *
+ * The row is one line, so a cap is necessary — but a blind 160-char cut removed
+ * the only actionable part of Zen Go's region error, leaving
+ * "…requires explicit opt in: https://opencode.ai/workspa..." on screen. The
+ * user is told there is a specific fix and then denied the address of it.
+ *
+ * So the link is kept whole and the PROSE around it absorbs the cut instead.
+ */
+function truncateKeepingLink(text: string, max = 160): string {
+  if (text.length <= max) return text;
+  const url = text.match(/https?:\/\/\S+/i)?.[0];
+  if (!url) return `${text.slice(0, max - 3)}...`;
+  // Reserve room for the link plus the ellipsis joining it to the trimmed prose.
+  const room = max - url.length - 4;
+  if (room <= 0) return url;
+  // Cut at a word boundary — the prose is being sacrificed for the link, so it
+  // should at least end on a whole word rather than "follow the l...".
+  const head = text.slice(0, room);
+  const lastSpace = head.lastIndexOf(" ");
+  const prose = (lastSpace > room * 0.5 ? head.slice(0, lastSpace) : head).trimEnd();
+  return `${prose}... ${url}`;
+}
+
 function extractErrorMessage(body: string): string | undefined {
   if (!body) return undefined;
   try {
@@ -430,14 +472,14 @@ function extractErrorMessage(body: string): string | undefined {
     const msg =
       parsed?.error?.message || parsed?.error?.error?.message || parsed?.message || parsed?.detail;
     if (typeof msg === "string" && msg.length > 0) {
-      return msg.length > 160 ? `${msg.slice(0, 157)}...` : msg;
+      return truncateKeepingLink(msg);
     }
   } catch {
     // not JSON, fall through
   }
   const trimmed = body.trim();
   if (!trimmed) return undefined;
-  return trimmed.length > 160 ? `${trimmed.slice(0, 157)}...` : trimmed;
+  return truncateKeepingLink(trimmed);
 }
 
 /**

--- a/packages/cli/src/providers/provider-definitions.ts
+++ b/packages/cli/src/providers/provider-definitions.ts
@@ -503,6 +503,7 @@ export const BUILTIN_PROVIDERS: ProviderDefinition[] = [
     baseUrl: "https://api.z.ai",
     baseUrlEnvVars: ["ZHIPU_BASE_URL", "GLM_BASE_URL"],
     apiPath: "/api/paas/v4/chat/completions",
+    modelDiscovery: { path: "/api/paas/v4/models", format: "openai-models-list" },
     apiKeyEnvVar: "ZHIPU_API_KEY",
     apiKeyAliases: ["GLM_API_KEY"],
     apiKeyDescription: "GLM/Zhipu API Key",


### PR DESCRIPTION
Three fixes, two of them from live bug reports.

## 1. Qwen sent two contradictory reasoning knobs

Reported through Zen Go:

```
400 [invalid_parameter_error] 'reasoning_effort' and 'thinking_budget'
    cannot be set simultaneously
```

`QwenModelDialect.applyNativeReasoning` translates the caller's effort into DashScope's spelling (`enable_thinking` + `thinking_budget`) and deletes the raw `thinking` object so it can't double-send. It never deleted **`reasoning_effort`** — OpenAI's spelling of the *same intent*, which can arrive from the OpenAI-shaped base format as well as from the caller.

DashScope **rejects** that pair rather than ignoring it, so the whole turn is lost — not just the reasoning depth.

`GLMModelDialect` already had this rule one knob over (*"never leave a depth knob contradicting the off-switch"*); Qwen hadn't caught up.

Verified at the adapter, passing a request that already carries `reasoning_effort: "high"`:

```
effort=high     reasoning_effort=undefined  enable_thinking=true   thinking_budget=24576
effort=medium   reasoning_effort=undefined  enable_thinking=true   thinking_budget=8192
effort=minimal  reasoning_effort=undefined  enable_thinking=false  thinking_budget=undefined
```

## 2. "Check API key" when the provider had already given the fix

Zen Go answers a model the account hasn't opted into with:

```json
403 {"error":{"type":"RegionError","message":"…requires explicit opt in:
     https://opencode.ai/workspace/<id>/go"}}
```

The route is fine, the credential is fine, and the model **is** carried — it's in Zen Go's live roster, so the availability filter correctly kept the provider. The account simply isn't opted into the China-hosted region, and Zen Go said so with a link. claudish talked over it with *"Check API key / OAuth credentials"*, sending the user to audit a working key.

This is a **third** failure shape at 401/403, after "bad credential" and "model not carried": the provider carries it and refuses on policy.

`hasActionableLink()` detects the **link**, not the wording — `RegionError` is one vendor's name for one policy, and a phrase list would have to grow forever. A URL means the same thing everywhere. Checked **last**, so a genuine auth failure that merely cites a docs link still reaches the credential advice through its own wording.

Three surfaces:

| surface | before | after |
|---|---|---|
| `getRecoveryHint` | "Check API key / OAuth credentials." | defers to the provider's instruction |
| `classifyHttpError` | `auth-failed` | `error` (still in `isFailureState`; false cause gone) |
| message truncation | cut the URL at `…/workspa...` | URL kept whole, prose absorbs the cut |

That last one mattered: the old blind 160-char slice told the user there was a specific fix and then withheld its address.

```
zgo@deepseek-v4-pro  error  403  …follow the… https://opencode.ai/workspace/<id>/go
zgo@kimi-k3          live        unchanged
```

## 3. Live model discovery for `glm`

The last routed provider neither data source could answer for — absent from the catalog's aggregator vocabulary and without a roster endpoint, so every `providerServesModel("glm", …)` returned `unknown`.

Probed with a real key before adding: `https://api.z.ai/api/paas/v4/models` → 200, 9 models.

```
glm / glm-5.2       -> serves
glm / glm-4.5-air   -> serves
glm / gpt-5.6-luna  -> not-served

route("glm-5.2")      glm-coding -> opencode-zen-go -> glm -> openrouter
route("glm-4.5-air")  glm-coding -> glm -> openrouter
```

The second route is the availability filter working: Zen Go's roster carries `glm-5.x` only, so it's dropped for `glm-4.5-air` rather than sent a request it would refuse.

**Measured and worth knowing:** the PAYG and Coding Plan rosters are **identical** — same 9 ids, nothing exclusive either way. The plan changes how you're billed, not what you can reach.

## Note on "Console Go"

Not a claudish provider — it's **Zen Go's own upstream naming**. Zen Go fronts other vendors and passes their verdicts back as `Error from provider (Console Go): Upstream request failed: …`, which `fallback-handler` already keys on to advance the chain rather than dying at the first candidate.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
