### PR TITLE
docs(testing): the two ways a green local run lied during the v7.65.0 release

### DIFF
--- a/ai-docs/architecture/testing.md
+++ b/ai-docs/architecture/testing.md
@@ -41,3 +41,38 @@ it can only repeat its default.
 
 Same shape as `team`'s exit 0 (`team-capture.md`): a status whose failure mode is to look
 like a confident answer. Prefer "unknown" to a plausible guess in any automated report.
+
+## A fixture must live where the test lives, never in scratch space
+
+`channel/test-helpers/captured-stream-json.ts` reads real captured stream-json frames at
+MODULE LOAD, via an IIFE. Its `PROBE_DIR` originally pointed at
+`ai-docs/sessions/dev-arch-*/probes/` — where the probe that recorded them happened to write.
+
+`.gitignore:56` excludes `ai-docs/sessions/`. So the files existed on exactly one machine and
+in no clone. In CI the `readFileSync` threw during module init, the exported consts were never
+assigned, and every test in the file died with:
+
+```
+ReferenceError: Cannot access 'CAPTURED_ASSISTANT_FRAME' before initialization.
+```
+
+which names a symbol, not a missing file — the real cause is two frames up the stack.
+
+Fixed by copying both captures VERBATIM into `packages/cli/src/channel/test-helpers/captures/`
+and pointing `PROBE_DIR` at `resolve(import.meta.dir, "captures")`. Byte-identical: fixtures
+come from real logs and must never be regenerated or reformatted in a move.
+
+**The rule, stated generally:** a fixture is BY DEFINITION something meant to outlive the
+session that produced it, so a session directory is never its home — however convenient that
+is at capture time. CLAUDE.md already warns that `ai-docs/sessions/` "does not survive a fresh
+clone or `git worktree remove`" and that "three write-ups already died this way". This was the
+fourth, and the first to take a test gate down rather than a document.
+
+The trap is that it is invisible locally in the only direction that matters: the suite is
+green on the machine that recorded the captures and red everywhere else, so local green is not
+weaker evidence than CI red — it is ACTIVELY MISLEADING. Same family as the gated diagnostic
+above: a signal that reports success because the question could only be asked where the answer
+was already yes.
+
+Cheap check before trusting any new fixture: `git ls-files <path>` must list it, and
+`git check-ignore -v <path>` must say nothing.


### PR DESCRIPTION
Docs only — no source, no test changes. Adds 35 lines to `ai-docs/architecture/testing.md`.

Both of these cost a CI round on #216, and **neither was visible from a local run**. Writing
them down because the shared shape will recur, and each has a cheap check that catches it.

## 1. A gate must not also gate its own diagnostic

`e2e-channel.test.ts` decides whether Group 2 can run by probing for an authenticated
`claude -p` — good design — but the probe itself sits inside `if (!SKIP_LIVE_E2E)`. Running
the suite the recommended way therefore never asks, and the skip message

```
[e2e-channel] Group 2 SKIPPED — `claude -p` is unavailable or not authenticated
```

is a claim about the environment that was never checked. It is indistinguishable from the
same message on a machine with genuinely no credential, and it was repeated in status reports
for hours as "environment-gated". Removing the flag turned 4 skips into **15 pass / 0 skip**.

**Prescription:** where a skip is conditional, compute its REASON unconditionally, or say
"not checked" rather than naming a cause.

## 2. A fixture must live where the test lives

`captured-stream-json.ts` read real captures at MODULE LOAD from `ai-docs/sessions/*/probes/`,
which `.gitignore:56` excludes. They existed on one machine and in no clone, so CI threw
during module init and surfaced as

```
ReferenceError: Cannot access 'CAPTURED_ASSISTANT_FRAME' before initialization
```

— a symbol name, two frames below the real cause. Fixed in 74a6541 by moving the captures
into `test-helpers/captures/` (byte-identical; fixtures come from real logs and are never
regenerated).

CLAUDE.md already warns that `ai-docs/sessions/` does not survive a fresh clone and that
"three write-ups already died this way". **This was the fourth, and the first to take a test
gate down instead of a document.** The class is broader than write-ups: a fixture is by
definition something meant to outlive the session that produced it.

## Why these belong together

In both cases local green was not weaker evidence than CI red — it was **actively
misleading**: a signal that reports success because the question could only be asked where the
answer was already yes.

## Checks recorded with each

- Truncated lint gate naming an innocent file → `bunx biome check --diagnostic-level=error --max-diagnostics=50 .`
  (Biome caps output at "Diagnostics not shown: 921" and names the loudest file, not the failing one.)
- Before trusting any new fixture → `git ls-files <path>` must list it, `git check-ignore -v <path>` must say nothing.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)