### PR TITLE
fix(probe): tell a spent plan apart from an empty balance

### DIFF
--- a/ai-docs/architecture/adapters.md
+++ b/ai-docs/architecture/adapters.md
@@ -106,6 +106,38 @@ Three properties keep this safe:
   This closes the auth half: a revoked or rotated key, where the wording check has
   nothing to match on.
 
+### "Out of credit" and "plan limit reached" are two different facts
+
+`quota-exhaustion.ts` holds two phrase families, not one list. `BALANCE_PHRASES`
+means the account cannot be billed and the remedy is to pay; `PLAN_LIMIT_PHRASES`
+means a flat-rate allowance is spent and the remedy is to wait or upgrade.
+`EXHAUSTION_PHRASES` is their union, so `hasQuotaExhaustionWording` and every
+caller of it behave exactly as before — the split only adds
+`hasPlanLimitWording`, which `probe-live.ts` uses to choose between the
+`out-of-credit` and `plan-limit` probe states.
+
+Balance wins ties: a body carrying both families is a payment problem with plan
+wording next to it, and "pay" is the safer of the two instructions to give.
+
+Two live 429s, measured the same afternoon, are why the distinction exists:
+
+| Provider | Body | State |
+|---|---|---|
+| MiniMax Coding | `Token Plan usage limit reached: Upgrade your Token Plan or purchase Credits for more usage. (2056)` | `plan-limit` |
+| GLM (metered) | `Insufficient balance or no resource package. Please recharge.` | `out-of-credit` |
+
+Both rendered as `out of credit` before. For a flat-rate subscriber that is
+actively misleading — it sends someone to a billing page to fix a plan that is
+working and resets on its own.
+
+The provider's own sentence is the diagnosis, so it must survive to the screen.
+`extractErrorMessage`'s cap is therefore sized for the WIDEST consumer (400
+chars), not the narrowest: every consumer already bounds itself — the probe row
+clips to its column, the TUI detail panel wraps to 2 lines, and
+`probe-results-printer` word-wraps to `MAX_ERROR_LINES`. At its old 160 the cap
+was no longer protecting a layout, only deleting the remedy from the end of the
+MiniMax sentence.
+
 **`exhaustedChainStatus` had the same defect, and fixing the first one exposed it.**
 It read `e.status` to decide whether a whole chain failed transiently, and by then
 the remap may have rewritten that to 400 — so it was asking a number that no longer

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -56,7 +56,7 @@ import { buildConnectionErrorMessage, classifyConnectionError } from "./shared/c
 import { sniffDevinStreamHead } from "./shared/devin-stream-head-sniffer.js";
 import { hasActionableLink, hasModelUnsupportedWording } from "./shared/model-unsupported.js";
 import { filterIdentity } from "./shared/openai-compat.js";
-import { isQuotaExhaustionError } from "./shared/quota-exhaustion.js";
+import { hasPlanLimitWording, isQuotaExhaustionError } from "./shared/quota-exhaustion.js";
 import { sniffResponsesStreamHead } from "./shared/stream-head-sniffer.js";
 import { createAnthropicPassthroughStream } from "./shared/stream-parsers/anthropic-sse.js";
 import { createDevinConnectStream } from "./shared/stream-parsers/devin-connect.js";
@@ -1594,6 +1594,19 @@ function getRecoveryHint(
     return "Provider overloaded. Retry or use a different model.";
   }
   if (status === 429 && (transportTerminal429 ?? isTerminal429(errorText))) {
+    // Terminal, but WHICH terminal? "Out of quota — check your plan & billing
+    // details" tells a flat-rate subscriber their money ran out when the real
+    // state is a billing cycle that has not reset, sending them to a billing
+    // page to fix a plan that is working. MiniMax Coding is the measured case:
+    // `429 "Token Plan usage limit reached: Upgrade your Token Plan or purchase
+    // Credits for more usage. (2056)"`.
+    //
+    // Same predicate the probe's `plan-limit` state uses, so this hint and the
+    // TUI row cannot disagree about one response — the recurring failure mode
+    // this file already guards against for auth vs model-unsupported.
+    if (hasPlanLimitWording(errorText)) {
+      return "Plan limit reached — your allowance is spent for this cycle and refills on the provider's own schedule (see the message below). Wait, upgrade the plan, or switch provider.";
+    }
     return "Out of quota — check your plan & billing details. This won't recover on retry.";
   }
   // The transport has positively identified this 429 as transient. Return the
@@ -1629,6 +1642,13 @@ function getRecoveryHint(
     // it as one — see shared/quota-exhaustion.ts for why this is shared with the
     // fallback gate rather than duplicated here.
     if (isQuotaExhaustionError(status, errorText)) {
+      // Kimi's coding plan is exactly this shape: `403 permission_error
+      // "You've reached your usage limit for this billing cycle"`. It is a spent
+      // ALLOWANCE arriving on an auth status, so it takes the plan wording, not
+      // the balance wording — same split as the 429 branch above.
+      if (hasPlanLimitWording(errorText)) {
+        return "Plan limit reached — your allowance is spent for this cycle and refills on the provider's own schedule (see the message below). Wait, upgrade the plan, or switch provider.";
+      }
       return "Out of quota — check your plan & billing details. This won't recover on retry.";
     }
     // The provider already said what to do, and it is not "check your key".

--- a/packages/cli/src/handlers/shared/quota-exhaustion.ts
+++ b/packages/cli/src/handlers/shared/quota-exhaustion.ts
@@ -34,30 +34,58 @@
  */
 
 /**
- * Phrases that indicate a spent allowance rather than a bad credential.
+ * Phrases that indicate a spent allowance rather than a bad credential, split
+ * into the two families below and re-joined as {@link EXHAUSTION_PHRASES}.
  *
- * Deliberately narrow. A false positive here is not harmless in the other
- * direction: it would tell a user with genuinely broken credentials to go and
- * check their billing. So this matches only wording about limits, cycles and
+ * Both lists are deliberately narrow. A false positive is not harmless in the
+ * other direction: it would tell a user with genuinely broken credentials to go
+ * and check their billing. So they match only wording about limits, cycles and
  * balances — never bare "permission", "denied", "forbidden" or "invalid",
  * which are the vocabulary of real auth failures.
  */
-const EXHAUSTION_PHRASES = [
+
+/**
+ * The account cannot be BILLED: the balance is empty and the remedy is to pay.
+ *
+ * Checked before {@link PLAN_LIMIT_PHRASES}, which is why `insufficient_quota`
+ * lives here rather than being swallowed by the bare `quota` entry below.
+ * OpenAI's `insufficient_quota` is a billing code, not an allowance window.
+ */
+const BALANCE_PHRASES = [
+  "insufficient balance",
+  "insufficient_quota",
+  "out of credits",
+  "credit balance",
+] as const;
+
+/**
+ * A flat-rate ALLOWANCE is spent and refills on a clock. The remedy is to wait,
+ * or to buy a bigger plan — never to top up a balance.
+ *
+ * MiniMax answers `429 "Token Plan usage limit reached: Upgrade your Token Plan
+ * or purchase Credits for more usage. (2056)"`, which is caught by "usage
+ * limit". Reporting that as "out of credit" told a subscriber their money had
+ * run out when their billing cycle had simply not reset.
+ */
+const PLAN_LIMIT_PHRASES = [
   "usage limit",
   "billing cycle",
   "quota",
-  "insufficient balance",
-  "insufficient_quota",
   "upgrade your plan",
   "exceeded your current",
-  "out of credits",
-  "credit balance",
   // Rolling-window wording. Zen Go says "5-hour usage limit reached" (caught by
   // "usage limit"), but "daily limit" / "plan limit" are the same event in other
   // vendors' phrasing and share no vocabulary with an auth failure.
   "daily limit",
   "plan limit",
 ] as const;
+
+/**
+ * The union both families belong to. Callers that only need "is the allowance
+ * spent, whatever the reason" read THIS, so splitting the families above
+ * changed no existing behaviour.
+ */
+const EXHAUSTION_PHRASES = [...BALANCE_PHRASES, ...PLAN_LIMIT_PHRASES] as const;
 
 /**
  * Wording-only check: does this body say the allowance is spent?
@@ -85,6 +113,25 @@ const EXHAUSTION_PHRASES = [
 export function hasQuotaExhaustionWording(errorBody: string): boolean {
   const lower = (errorBody || "").toLowerCase();
   return EXHAUSTION_PHRASES.some((phrase) => lower.includes(phrase));
+}
+
+/**
+ * Narrower than {@link hasQuotaExhaustionWording}: true only when the body says
+ * a flat-rate ALLOWANCE is spent, and never when it says the BALANCE is empty.
+ *
+ * The two need different words in front of the user because they need different
+ * actions. "Out of credit" tells a subscriber to go and pay; when the real state
+ * is a spent billing cycle, that sends them to a billing page to fix a plan that
+ * is working and will reset on its own.
+ *
+ * Balance wins ties. A body carrying both families is reporting a payment
+ * problem that some plan wording happens to sit next to, and "pay" is the
+ * safer of the two instructions to give.
+ */
+export function hasPlanLimitWording(errorBody: string): boolean {
+  const lower = (errorBody || "").toLowerCase();
+  if (BALANCE_PHRASES.some((phrase) => lower.includes(phrase))) return false;
+  return PLAN_LIMIT_PHRASES.some((phrase) => lower.includes(phrase));
 }
 
 /**

--- a/packages/cli/src/probe/probe-results-printer.ts
+++ b/packages/cli/src/probe/probe-results-printer.ts
@@ -418,6 +418,8 @@ function shortStatusLabel(
       return `${pc.red}⊗ rate-limited${pc.reset}`;
     case "out-of-credit":
       return `${pc.red}⊗ no credit${pc.reset}`;
+    case "plan-limit":
+      return `${pc.red}⊗ plan limit${pc.reset}`;
     case "server-error":
       return `${pc.red}⊗ server ${probe.httpStatus ?? ""}${pc.reset}`;
     case "timeout":

--- a/packages/cli/src/providers/probe-live.ts
+++ b/packages/cli/src/providers/probe-live.ts
@@ -17,6 +17,7 @@ import {
   hasActionableLink,
   hasModelUnsupportedWording,
 } from "../handlers/shared/model-unsupported.js";
+import { hasPlanLimitWording } from "../handlers/shared/quota-exhaustion.js";
 
 export type ProbeState =
   | "live"
@@ -25,6 +26,12 @@ export type ProbeState =
   | "model-not-found"
   | "rate-limited"
   | "out-of-credit"
+  /**
+   * A flat-rate allowance is spent for this cycle. Distinct from
+   * `out-of-credit`: the account CAN be billed, the plan window simply has not
+   * reset, so the remedy is to wait or upgrade rather than to top up a balance.
+   */
+  | "plan-limit"
   | "server-error"
   | "timeout"
   | "network-error"
@@ -386,6 +393,21 @@ export function classifyHttpError(status: number, body: string, latencyMs: numbe
     };
   }
   if (status === 429) {
+    // A 429 is the channel for BOTH transient throttling and a spent flat-rate
+    // allowance, so the status alone cannot tell them apart — only the body can.
+    // MiniMax Coding answers `429 "Token Plan usage limit reached: Upgrade your
+    // Token Plan or purchase Credits for more usage. (2056)"`, which is a plan
+    // window, not throttling: retrying in a second cannot help, and the TUI
+    // treats throttling as healthy. Wording-gated, so an ordinary throttle with
+    // no allowance vocabulary still reads as "rate limited".
+    if (hasPlanLimitWording(body)) {
+      return {
+        state: "plan-limit",
+        latencyMs,
+        httpStatus: status,
+        errorMessage: extractErrorMessage(body) || "Plan allowance spent for this cycle",
+      };
+    }
     return {
       state: "rate-limited",
       latencyMs,
@@ -404,6 +426,22 @@ export function classifyHttpError(status: number, body: string, latencyMs: numbe
   // healthy ("throttled" note) — an exhausted account must read as a failure
   // with an honest cause instead of an opaque "error · 400".
   if (upstream === 429 || status === 402) {
+    // Same fork as the raw 429 above, on the remapped shape. This is the path a
+    // TUI probe takes, because the proxy turns a terminal 429 into a 400 that
+    // carries the real upstream status. A spent SUBSCRIPTION reaching the user
+    // as "out of credit" is actively misleading: it sends a flat-rate user to a
+    // billing page to fix a plan that is working and resets on its own.
+    //
+    // 402 is deliberately NOT forked. It means Payment Required, which is a
+    // balance fact whatever wording rides along with it.
+    if (status !== 402 && hasPlanLimitWording(body)) {
+      return {
+        state: "plan-limit",
+        latencyMs,
+        httpStatus: upstream ?? status,
+        errorMessage: extractErrorMessage(body) || "Plan allowance spent for this cycle",
+      };
+    }
     return {
       state: "out-of-credit",
       latencyMs,
@@ -429,16 +467,24 @@ export function classifyHttpError(status: number, body: string, latencyMs: numbe
 }
 
 /**
- * Shorten a provider message for a probe row WITHOUT severing a URL.
+ * Shorten a provider message WITHOUT severing a URL.
  *
- * The row is one line, so a cap is necessary — but a blind 160-char cut removed
- * the only actionable part of Zen Go's region error, leaving
- * "…requires explicit opt in: https://opencode.ai/workspa..." on screen. The
- * user is told there is a specific fix and then denied the address of it.
+ * A cap is necessary — but a blind cut removed the only actionable part of Zen
+ * Go's region error, leaving "…requires explicit opt in:
+ * https://opencode.ai/workspa..." on screen. The user is told there is a
+ * specific fix and then denied the address of it. So the link is kept whole and
+ * the PROSE around it absorbs the cut instead.
  *
- * So the link is kept whole and the PROSE around it absorbs the cut instead.
+ * The cap is sized for the WIDEST consumer, not the narrowest. It was 160,
+ * chosen when the only consumer was a one-line probe row — but every consumer
+ * now bounds itself (the row clips to its column, the TUI detail panel wraps to
+ * 2 lines, `probe-results-printer` word-wraps to `MAX_ERROR_LINES` 4), so 160
+ * was no longer protecting a layout, only deleting text. It cut MiniMax
+ * Coding's `429 "Token Plan usage limit reached: Upgrade your Token Plan or
+ * purchase Credits for more usage. (2056)"` at "Upgrade you..." — losing the
+ * remedy, which is the only part of the sentence the user can act on.
  */
-function truncateKeepingLink(text: string, max = 160): string {
+function truncateKeepingLink(text: string, max = 400): string {
   if (text.length <= max) return text;
   const url = text.match(/https?:\/\/\S+/i)?.[0];
   if (!url) return `${text.slice(0, max - 3)}...`;
@@ -747,6 +793,11 @@ export function describeProbeState(result: ProbeResult): string {
       return withDetail(`rate limited · ${result.latencyMs}ms`, result.errorMessage);
     case "out-of-credit":
       return withDetail(`out of credit · ${status}${latency}`.trim(), result.errorMessage);
+    case "plan-limit":
+      // "plan limit reached", not "out of credit": the account can be billed,
+      // the allowance simply has not reset. The provider's own sentence follows,
+      // and it is the part that names the plan and the way out.
+      return withDetail(`plan limit reached · ${status}${latency}`.trim(), result.errorMessage);
     case "server-error":
       return withDetail(`server error · ${status} · ${result.latencyMs}ms`, result.errorMessage);
     case "timeout":
@@ -774,6 +825,7 @@ export function isFailureState(state: ProbeState): boolean {
     state === "model-not-found" ||
     state === "rate-limited" ||
     state === "out-of-credit" ||
+    state === "plan-limit" ||
     state === "server-error" ||
     state === "timeout" ||
     state === "network-error" ||

--- a/packages/cli/src/tui/App.tsx
+++ b/packages/cli/src/tui/App.tsx
@@ -1423,7 +1423,12 @@ export function App({ requestLogin }: AppProps = {}) {
         const error = tried.size > 1 ? `${baseError} (tried ${tried.size} models)` : baseError;
         setTestResults((prev) => ({
           ...prev,
-          [provName]: { status: "failed", error, ms },
+          // `errorMessage` is carried alongside the rendered `error` rather than
+          // re-derived from it: the detail panel needs the upstream's own words
+          // without the state/status/latency prefix, and splitting a formatted
+          // string back apart would break on any provider whose message
+          // contains the same separator.
+          [provName]: { status: "failed", error, providerMessage: result.errorMessage, ms },
         }));
       }
     } catch (err: unknown) {

--- a/packages/cli/src/tui/components/ProviderDetail.tsx
+++ b/packages/cli/src/tui/components/ProviderDetail.tsx
@@ -5,15 +5,48 @@ import { A, C } from "../theme.js";
 import type { Mode, TestResultsMap } from "../types.js";
 
 /**
- * Collapse newlines and clip an error string to a single line that fits
- * inside the detail box without wrapping. Used for `tr.error` which can
- * come back from describeProbeState as a multi-line, 200-char message.
+ * Break an error into at most `maxLines` lines that fit `maxWidth`, on word
+ * boundaries, with an ellipsis if it still does not fit.
+ *
+ * One line was not enough for the thing the user actually needs. A surfaced
+ * error is `"<Provider> error (HTTP <status>): <claudish hint> — <the
+ * provider's own sentence>"` (see `buildSurfacedErrorMessage`), so claudish's
+ * attribution and advice eat the first ~120 characters and the provider's
+ * sentence — the only part naming the plan and the way out — fell off the end.
+ * MiniMax Coding rendered as "… Out of quota - check your plan & bil…" with
+ * "Token Plan usage limit reached: Upgrade your Token Plan…" never shown.
+ *
+ * Bounded on purpose rather than free-wrapping: the detail box is a fixed
+ * DETAIL_H, and a wrap that overflows bleeds into the provider rows above,
+ * which the renderer cannot invalidate.
  */
-function truncateOneLine(text: string, maxWidth: number): string {
+function wrapToLines(text: string, maxWidth: number, maxLines: number): string[] {
   const collapsed = text.replace(/\s+/g, " ").trim();
   const limit = Math.max(20, maxWidth);
-  if (collapsed.length <= limit) return collapsed;
-  return `${collapsed.slice(0, limit - 1)}…`;
+  if (collapsed.length <= limit) return [collapsed];
+
+  const lines: string[] = [];
+  let rest = collapsed;
+  while (rest.length > 0 && lines.length < maxLines) {
+    if (rest.length <= limit) {
+      lines.push(rest);
+      break;
+    }
+    // Break at the last space inside the budget; fall back to a hard cut for a
+    // single token longer than the line (a URL, a base64 blob).
+    const slice = rest.slice(0, limit);
+    const cut = slice.lastIndexOf(" ");
+    const at = cut > limit * 0.5 ? cut : limit;
+    lines.push(rest.slice(0, at));
+    rest = rest.slice(at).trimStart();
+  }
+  // Anything still left is dropped, so say so on the last line rather than
+  // ending mid-sentence as if that were the whole message.
+  if (rest.length > 0 && lines.length === maxLines) {
+    const last = lines[maxLines - 1] ?? "";
+    lines[maxLines - 1] = `${last.slice(0, Math.max(1, limit - 1))}…`;
+  }
+  return lines;
 }
 
 interface ProviderDetailProps {
@@ -149,6 +182,28 @@ export function ProviderDetail({
 
   const tr = testResults[selectedProvider.name];
 
+  // The provider's OWN sentence, given lines of its own below.
+  //
+  // It used to share the "Test:" line, clipped to `width - 16`, which is where
+  // the part that names the cause went missing: MiniMax Coding's `429 "Token
+  // Plan usage limit reached: Upgrade your Token Plan or purchase Credits for
+  // more usage. (2056)"` reached the user as "out of credit · 429 · 2371ms —
+  // MiniMax". The status is a bucket; this sentence is the diagnosis, and it is
+  // the only place the plan and the way out are named.
+  //
+  // `providerMessage` rather than `error` because the row directly above
+  // already prints the `<state> · <status> · <ms>` prefix that `error` repeats.
+  // `error` remains the fallback for states with no upstream message to quote
+  // (a local server that is not running, a proxy that never answered), where
+  // the rendered line IS the explanation.
+  //
+  // `Desc:` and `Get Key:` yield their lines to make room (see below). Nothing
+  // is lost: both appear elsewhere, and this text appears nowhere else.
+  const failureText =
+    tr && (tr.status === "failed" || tr.status === "unavailable")
+      ? (tr.providerMessage ?? tr.error)
+      : undefined;
+
   return (
     <box
       height={DETAIL_H}
@@ -283,13 +338,20 @@ export function ProviderDetail({
           <span fg={C.cyan}>{activeEndpoint || selectedProvider.defaultEndpoint || "default"}</span>
         </text>
       )}
-      <text>
-        <span fg={C.blue} attributes={A.bold}>
-          Desc:{" "}
-        </span>
-        <span fg={C.strong}>{selectedProvider.description}</span>
-      </text>
-      {selectedProvider.keyUrl && (
+      {!failureText && (
+        <text>
+          <span fg={C.blue} attributes={A.bold}>
+            Desc:{" "}
+          </span>
+          <span fg={C.strong}>{selectedProvider.description}</span>
+        </text>
+      )}
+      {/* `Desc:` and `Get Key:` both yield their line while a failure is on
+          screen, which is what buys the message two lines inside a fixed
+          DETAIL_H. Neither is lost: the description is in the row's
+          DESCRIPTION column, and the key URL is one keypress away once the
+          error has been read. The provider's sentence has nowhere else to go. */}
+      {selectedProvider.keyUrl && !failureText && (
         <text>
           <span fg={C.blue} attributes={A.bold}>
             Get Key:{" "}
@@ -320,37 +382,32 @@ export function ProviderDetail({
               </span>
             </>
           )}
+          {/* The message itself is NOT here any more — it gets its own
+              full-width line below, where the provider's sentence survives
+              instead of being clipped to `width - 16`. */}
           {tr.status === "failed" && (
-            <>
-              <span fg={C.red} attributes={A.bold}>
-                {"✗ failed"}
-              </span>
-              {tr.error && (
-                <span fg={C.red}>
-                  {/* Clip the error to a single line. describeProbeState can
-                      produce 200+ char strings ("HTTP 400. Request format
-                      may be incompatible…") that wrap and overflow the
-                      fixed-height detail box, bleeding into the provider
-                      rows above. */}
-                  {`  ${truncateOneLine(tr.error, width - 16)}`}
-                </span>
-              )}
-            </>
+            <span fg={C.red} attributes={A.bold}>
+              {"✗ failed"}
+            </span>
           )}
           {tr.status === "unavailable" && (
-            <>
-              {/* Not a failure — the server is off or has no chat model to probe.
-                  Neutral yellow, not red. */}
-              <span fg={C.yellow} attributes={A.bold}>
-                {"○ unavailable"}
-              </span>
-              {tr.error && (
-                <span fg={C.yellow}>{`  ${truncateOneLine(tr.error, width - 16)}`}</span>
-              )}
-            </>
+            /* Not a failure — the server is off or has no chat model to probe.
+               Neutral yellow, not red. */
+            <span fg={C.yellow} attributes={A.bold}>
+              {"○ unavailable"}
+            </span>
           )}
         </text>
       )}
+      {failureText &&
+        wrapToLines(failureText, width - 4, 2).map((line, i) => (
+          // Index key: these are positional slices of one string, not a
+          // reorderable list, so the index IS the stable identity.
+          // biome-ignore lint/suspicious/noArrayIndexKey: positional slices of one string
+          <text key={i}>
+            <span fg={tr?.status === "unavailable" ? C.yellow : C.red}>{line}</span>
+          </text>
+        ))}
     </box>
   );
 }

--- a/packages/cli/src/tui/types.ts
+++ b/packages/cli/src/tui/types.ts
@@ -83,6 +83,18 @@ export interface TestResult {
    */
   status: "testing" | "valid" | "failed" | "unavailable";
   error?: string;
+  /**
+   * The upstream's own explanation, WITHOUT the `<state> · <status> · <ms> —`
+   * prefix that `error` carries.
+   *
+   * The detail panel shows this rather than `error` because the provider row
+   * directly above already prints that prefix, and repeating it cost ~36
+   * characters of the only place the provider's sentence can be read. On
+   * MiniMax Coding that was the difference between stopping at "Upgrade
+   * you…" and showing "Upgrade your Token Plan or purchase Credits for more
+   * usage. (2056)" — the part that names the plan and the way out.
+   */
+  providerMessage?: string;
   ms?: number;
   /** Optional annotation when status is "valid" but the endpoint reported a
    *  non-fatal condition (e.g. "throttled" for 429-but-healthy). */


### PR DESCRIPTION
## The problem

MiniMax Coding answers with `429`:

```json
{"type":"error","error":{"type":"rate_limit_error","message":"Token Plan usage limit reached: Upgrade your Token Plan or purchase Credits for more usage. (2056)"}}
```

claudish rendered that as **`out of credit`**, which tells a flat-rate subscriber their money ran out when their billing cycle simply has not reset. It sends them to a billing page to fix a plan that is working.

Measured the same afternoon, GLM's metered `429` says `Insufficient balance or no resource package. Please recharge.` — a genuinely different fact that carried the identical label.

Worse, the sentence naming the remedy never reached the screen at all. The row read:

```
out of credit · 429 · 2371ms — MiniMax
```

## The changes

| Change | Why |
|---|---|
| Split `quota-exhaustion.ts` into `BALANCE_PHRASES` / `PLAN_LIMIT_PHRASES`, union kept as `EXHAUSTION_PHRASES` | Two facts, two remedies. The union means every existing `hasQuotaExhaustionWording` caller is untouched. Balance wins ties. |
| New `plan-limit` probe state | Forked on both the raw 429 and the proxy's remapped 400 + upstream 429. A throttle with no allowance vocabulary still reads `rate limited`. |
| Same fork in `getRecoveryHint` (429 and 401/403) | The fallback path already said "subscription allowance is spent" while the chat path said "Out of quota". Two surfaces disagreeing about one response. |
| `extractErrorMessage` cap 160 → 400 | **The real bug.** 160 severed MiniMax's message at `Upgrade you...` before any renderer saw it. Its own comment justified the cap with "the row is one line" — a premise that stopped being true. Every consumer already bounds itself. |
| Detail panel wraps the message to 2 lines, carries `providerMessage` | Instead of sharing the `Test:` line clipped to `width - 16`. `Desc:`/`Get Key:` yield their lines during a failure so the box stays within its fixed `DETAIL_H`. |

## Result

Row: `plan limit reached · 429 · 2874ms`

Detail panel:

```
Test:  ✗ failed
MiniMax Coding error (HTTP 429): Out of quota — check your plan & billing details. This won't recover on
retry. — Token Plan usage limit reached: Upgrade your Token Plan or purchase Credits for more usage.…
```

## Verification

Against **live provider bodies**, not fixtures:

| Body (source) | State |
|---|---|
| MiniMax `Token Plan usage limit reached…` (captured live) | `plan-limit` |
| GLM `Insufficient balance or no resource package.` (live, from the e2e run) | `out-of-credit` |
| Moonshot `suspended due to insufficient balance` | `out-of-credit` |
| Kimi `usage limit for this billing cycle` | `plan-limit` |

- Typecheck clean, formatting clean.
- No new lint warnings — compared per file against `git show HEAD:` baselines (27→27, 10→10).
- Full suite: **2930 pass / 14 skip / 6 fail**, a byte-identical failure list to the pre-change run. The 6 are pre-existing `route()` tests in `routing-rules.test.ts` that assert `no-route` on a machine whose keychain legitimately supplies a credential; they fail identically in isolation and import nothing touched here.
- TUI change verified by live screenshot, since a module-level `C.*` snapshot is only caught that way.

## Not included

No unit tests for `hasPlanLimitWording` or the `plan-limit` state yet — test-writing is delegated separately.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
