### PR TITLE
feat: --model-params, --effort-override, and catalog-driven ultracode presets

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -318,11 +318,21 @@ carry a `routeVariant`, all three of them `gpt-5.6-*-pro`, all recorded on
 `gpt-5.6-sol` lists openai, openrouter, opencode-zen and openai-codex — but each
 `-pro` SKU exists on OpenRouter's roster alone.
 
-**Why scoped rather than applied everywhere.** A preset is an observation about ONE
-provider's roster, not a portable fact about the model. Whether OpenAI's own API
-accepts `reasoning.mode=pro` on `gpt-5.6-sol` is UNVERIFIED — plausible, since
-OpenRouter passes parameters through, but plausible is not measured. Injecting it on
-`oai@` would be a guess, and a wrong guess is a 400 on every ultracode turn.
+**Why scoped rather than applied everywhere — now measured, not assumed.** Sending
+`reasoning.mode=pro` to `gpt-5.6-sol` on each vendor (2026-08-27, real requests):
+
+| Vendor | Result |
+|---|---|
+| `openrouter` | accepted (200) |
+| `openai` (`api.openai.com/v1/responses`) | accepted (200) |
+| `openai-codex` (ChatGPT OAuth backend) | **400** — `` `reasoning.mode` is not supported with this model `` |
+
+So the parameter is neither OpenRouter-only nor universal. Applying it unscoped would
+hard-400 every ultracode turn on `cx@`, which is the single most likely route for this
+model family. The provider gate is what prevents that.
+
+`oai@` accepting it means the CATALOG under-reports reality — the fix belongs in
+models-index, not in a client-side exception list.
 
 **Trigger conditions** (either is sufficient):
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -297,3 +297,73 @@ check.
 
 **Do not start if** the only motivation is tidiness. The comment already prevents the known
 failure; this is worth doing when someone is in these files anyway, not as its own errand.
+
+---
+
+## Ultracode pro-preset: broaden past the OpenRouter-only roster
+
+Status: shipped, deliberately narrow.
+
+`--pro-on-ultracode` applies a model's catalog provider-preset while a Claude Code
+session is in ultracode. It reads BOTH halves of the fact from the slim catalog's
+`routeVariant` — `baseModelId` says which model the preset applies to, `preset`
+(`reasoning.mode=pro`) says what to send — via `lookupVariantPresets()` in
+`adapters/model-catalog.ts`. There is no model name regex and no hardcoded payload;
+the `--model-params` parser doubles as the preset parser.
+
+The gate is PROVIDER-SCOPED, and today that means OpenRouter only. Measured against
+the live catalog on 2026-08-27 (`queryModels?catalog=slim`), exactly 3 of 753 entries
+carry a `routeVariant`, all three of them `gpt-5.6-*-pro`, all recorded on
+`provider: "openrouter"`. The base models are served much more widely —
+`gpt-5.6-sol` lists openai, openrouter, opencode-zen and openai-codex — but each
+`-pro` SKU exists on OpenRouter's roster alone.
+
+**Why scoped rather than applied everywhere.** A preset is an observation about ONE
+provider's roster, not a portable fact about the model. Whether OpenAI's own API
+accepts `reasoning.mode=pro` on `gpt-5.6-sol` is UNVERIFIED — plausible, since
+OpenRouter passes parameters through, but plausible is not measured. Injecting it on
+`oai@` would be a guess, and a wrong guess is a 400 on every ultracode turn.
+
+**Trigger conditions** (either is sufficient):
+
+1. models-index records a `routeVariant` preset (or an equivalent per-vendor preset
+   field) on a non-OpenRouter vendor row for the same base model. The client change is
+   then zero — `lookupVariantPresets(model, provider)` already returns it.
+2. A live run proves the parameter is accepted on another host, at which point the
+   fact belongs in the catalog first (see `TASK_pro_preset_vendor_coverage.md` in the
+   models-index repo), NOT in a claudish-side exception list.
+
+**Do not** work around this by dropping the provider argument or adding a per-provider
+allowlist in the CLI. That reintroduces exactly the hardcoded roster this design
+removed, and `feedback_backend_repo_boundary` puts the data gap in the backend's repo.
+
+**Effort**: none in claudish if trigger 1 lands. The gate already reads whatever the
+catalog says.
+
+Reference: `TASK_pro_preset_vendor_coverage.md` (models-index repo).
+
+---
+
+## `--effort-override` accepts only the seven canonical levels
+
+Status: shipped, deliberately narrow.
+
+`--effort-override <level>` pins reasoning effort verbatim and skips
+`clampToAdvertisedEffort()`. It is NOT `--effort` — that name belongs to Claude Code
+and claudish forwards it untouched in `claudeArgs` (pinned by
+`cli-passthrough.test.ts`). The two compose: `--effort` says what to ask for,
+`--effort-override` says do not clamp what I asked for.
+
+It accepts only `none|minimal|low|medium|high|xhigh|max`, because the value flows
+through the `EffortLevel`-typed pipeline in `base-api-format.ts`. A provider-specific
+value outside that set has an existing escape hatch that needs no new flag:
+`--model-params reasoning_effort=<value>`, which lands on the payload after every
+adapter has finished.
+
+**Trigger condition**: a provider ships a native effort vocabulary that is neither one
+of the seven nor reachable by a single `--model-params` key — e.g. an effort knob whose
+parameter NAME differs per dialect AND whose values are provider-specific. Only then
+does a dialect-aware native-value path earn its complexity.
+
+**Do not** widen `EffortLevel` itself to accommodate one provider. It is the canonical
+vocabulary Claude Code emits, and the clamp table is what maps it onto each provider.

--- a/packages/cli/src/adapters/base-api-format.ts
+++ b/packages/cli/src/adapters/base-api-format.ts
@@ -421,6 +421,15 @@ export abstract class BaseAPIFormat implements APIFormat, ModelDialect {
     requested: EffortLevel,
     reasoning: ReasoningCapability
   ): EffortLevel | undefined {
+    // `--effort` pins the level VERBATIM — skip the clamp entirely. This is an
+    // escape hatch, and it can produce a 400: the clamp is what normally keeps
+    // a level the model does not advertise off the wire. Asking for it anyway
+    // is the user's explicit choice.
+    // `--effort` pins the level VERBATIM — skip the clamp entirely. This is an
+    // escape hatch, and it can produce a 400: the clamp is what normally keeps
+    // a level the model does not advertise off the wire. Asking for it anyway
+    // is the user's explicit choice.
+    if (this.pinnedEffort) return this.pinnedEffort;
     const advertised = (reasoning.efforts ?? []).filter(isEffortLevel);
     if (advertised.length === 0) {
       return isEffortLevel(reasoning.defaultEffort) ? reasoning.defaultEffort : undefined;
@@ -479,6 +488,26 @@ export abstract class BaseAPIFormat implements APIFormat, ModelDialect {
   }
 
   /**
+   * `--effort <level>`: a user-pinned effort that bypasses BOTH the request's
+   * own signal and the per-model catalog clamp.
+   *
+   * Safe as instance state because every ComposedHandler owns its dialect —
+   * `resolveModelDialect()` builds a fresh object per call and never caches —
+   * so a pin set for one model cannot leak into another.
+   *
+   * Only the seven canonical levels are accepted. A provider-specific value
+   * that is not one of them cannot flow through the `EffortLevel`-typed
+   * pipeline at all; `--model-params reasoning_effort=<value>` is the tool for
+   * that, and it lands on the payload after every adapter has finished.
+   */
+  protected pinnedEffort?: EffortLevel;
+
+  /** Install the `--effort` override for this handler. undefined clears it. */
+  setEffortOverride(level: EffortLevel | undefined): void {
+    this.pinnedEffort = level;
+  }
+
+  /**
    * Normalize Claude Code's effort signal to a canonical {@link EffortLevel}
    * (or undefined when the request carries no effort hint).
    *
@@ -492,6 +521,9 @@ export abstract class BaseAPIFormat implements APIFormat, ModelDialect {
    * accepted value set (or strips, when the provider has no reasoning knob).
    */
   protected resolveEffortLevel(originalRequest: any): EffortLevel | undefined {
+    // `--effort` wins over anything the request carries. Checked first so the
+    // legacy budget_tokens fallback below cannot override an explicit pin.
+    if (this.pinnedEffort) return this.pinnedEffort;
     const lvl = originalRequest?.output_config?.effort;
     if (typeof lvl === "string") {
       const lower = lvl.toLowerCase();

--- a/packages/cli/src/adapters/effort-override.test.ts
+++ b/packages/cli/src/adapters/effort-override.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type DiskCacheV2, writeAllModelsCache } from "../providers/all-models-cache.js";
+import { GLMModelDialect } from "./glm-model-dialect.js";
+import { type ReasoningCapability, lookupModelReasoning } from "./model-catalog.js";
+
+const MODEL_ID = "glm-effort-override-test";
+
+class CatalogBackedGLMFormat extends GLMModelDialect {
+  constructor(
+    modelId: string,
+    private readonly cachePath: string
+  ) {
+    super(modelId);
+  }
+
+  protected override lookupReasoningCapability(): ReasoningCapability | undefined {
+    return lookupModelReasoning(this.getModelId(), this.cachePath);
+  }
+}
+
+let tempDir = "";
+let cachePath = "";
+let format: CatalogBackedGLMFormat;
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "claudish-effort-override-"));
+  cachePath = join(tempDir, "all-models.json");
+  const entries: DiskCacheV2["entries"] = [
+    {
+      modelId: MODEL_ID,
+      aliases: [],
+      sources: {},
+      reasoning: {
+        supported: true,
+        control: "effort",
+        efforts: ["medium", "high"],
+        defaultEffort: "medium",
+      },
+    },
+  ];
+  writeAllModelsCache({ entries }, cachePath);
+  format = new CatalogBackedGLMFormat(MODEL_ID, cachePath);
+});
+
+afterEach(() => {
+  try {
+    rmSync(tempDir, { recursive: true, force: true });
+  } catch {}
+  tempDir = "";
+  cachePath = "";
+});
+
+function payloadFor(effort: string): Record<string, unknown> {
+  return format.prepareRequest({}, { output_config: { effort } });
+}
+
+describe("BaseAPIFormat --effort override", () => {
+  test("without an override, effort outside the advertised catalog set is clamped", () => {
+    const payload = payloadFor("max");
+
+    expect(payload.thinking).toEqual({ type: "enabled" });
+    expect(payload.reasoning_effort).toBe("high");
+  });
+
+  test("setEffortOverride(max) skips the clamp for the same model and catalog entry", () => {
+    expect(payloadFor("max").reasoning_effort).toBe("high");
+
+    format.setEffortOverride("max");
+
+    expect(payloadFor("max").reasoning_effort).toBe("max");
+  });
+
+  test("the override beats the request's own output_config.effort", () => {
+    format.setEffortOverride("max");
+
+    expect(payloadFor("low").reasoning_effort).toBe("max");
+  });
+
+  test("setEffortOverride(undefined) restores catalog-clamped behavior", () => {
+    format.setEffortOverride("max");
+    expect(payloadFor("max").reasoning_effort).toBe("max");
+
+    format.setEffortOverride(undefined);
+
+    expect(payloadFor("max").reasoning_effort).toBe("high");
+  });
+});

--- a/packages/cli/src/adapters/model-catalog.ts
+++ b/packages/cli/src/adapters/model-catalog.ts
@@ -143,6 +143,49 @@ export function lookupFamilyDefaultVariant(
 }
 
 /**
+ * Every catalog variant whose preset expands `baseModelId`, optionally narrowed
+ * to one serving provider.
+ *
+ * The inverse of {@link lookupModelRouteVariant}: that answers "which model is
+ * this variant a preset OF?", this answers "which presets exist FOR this
+ * model?".
+ *
+ * This is the sanctioned replacement for a name regex that asks "does this
+ * model support capability X?". The catalog records BOTH halves of the fact —
+ * which base model a preset applies to (`baseModelId`) and what the preset
+ * actually sets (`preset`, in `--model-params` `k=v` syntax) — so the caller
+ * carries neither a model list nor a hardcoded payload. Feed `preset` to
+ * `parseModelParams()` to get the params the provider would have applied.
+ *
+ * Returns [] for a cold cache or a model with no variants. Callers MUST treat
+ * that as "no information" and keep their existing behaviour; absence is never
+ * an error and must never block a request.
+ *
+ * @param provider Only return variants recorded on this serving provider. A
+ *   preset is an observation about ONE provider's roster, not a portable fact
+ *   about the model — the same parameter may not exist on another host — so a
+ *   caller that cannot verify the parameter independently should pass the
+ *   provider it is actually routing to.
+ */
+export function lookupVariantPresets(
+  baseModelId: string,
+  provider?: string,
+  cachePath?: string
+): { modelId: string; preset: string; provider?: string }[] {
+  const cache = readAllModelsCache(cachePath);
+  if (!cache) return [];
+  const found: { modelId: string; preset: string; provider?: string }[] = [];
+  for (const entry of cache.entries) {
+    const rv = entry.routeVariant;
+    if (!rv?.preset) continue;
+    if (rv.baseModelId !== baseModelId) continue;
+    if (provider !== undefined && rv.provider !== provider) continue;
+    found.push({ modelId: entry.modelId, preset: rv.preset, provider: rv.provider });
+  }
+  return found;
+}
+
+/**
  * Coarse capability flags straight from the catalog. Each is undefined when the
  * catalog has no opinion — never defaulted to false, because "unknown" and "no"
  * lead to different behaviour (dropping tools from a request that needs them is

--- a/packages/cli/src/adapters/model-catalog.ts
+++ b/packages/cli/src/adapters/model-catalog.ts
@@ -174,11 +174,17 @@ export function lookupVariantPresets(
 ): { modelId: string; preset: string; provider?: string }[] {
   const cache = readAllModelsCache(cachePath);
   if (!cache) return [];
+  // Same key rule as findCacheEntry — the caller passes a BARE name, and on the
+  // OpenRouter route a bare name still carries the vendor prefix
+  // ("openai/gpt-5.6-sol") because OpenRouter's API requires it. Comparing raw
+  // strings here matched nothing on precisely the provider whose presets the
+  // catalog records, i.e. the feature was dead where it was meant to work.
+  const wanted = stripVendorPrefix(baseModelId.toLowerCase());
   const found: { modelId: string; preset: string; provider?: string }[] = [];
   for (const entry of cache.entries) {
     const rv = entry.routeVariant;
-    if (!rv?.preset) continue;
-    if (rv.baseModelId !== baseModelId) continue;
+    if (!rv?.preset || !rv.baseModelId) continue;
+    if (stripVendorPrefix(rv.baseModelId.toLowerCase()) !== wanted) continue;
     if (provider !== undefined && rv.provider !== provider) continue;
     found.push({ modelId: entry.modelId, preset: rv.preset, provider: rv.provider });
   }
@@ -295,6 +301,19 @@ function isSubscriptionPlan(provider: string, cachePath?: string): boolean {
  * on modelId or aliases. Shared by lookupModel / lookupModelForProvider.
  * Throws if `modelId` contains "@" — callers must strip the provider prefix.
  */
+/**
+ * The catalog's matching key for a model id: lowercased, vendor prefix dropped.
+ *
+ * `openai/gpt-5.6-sol` and `gpt-5.6-sol` are the SAME model — the prefix is
+ * aggregator routing vocabulary, and OpenRouter's route keeps it on the bare
+ * name (see the vendor-prefix note in proxy-server's getOpenRouterHandler).
+ * Every catalog lookup must apply this rule or it silently misses exactly the
+ * models reached through an aggregator.
+ */
+function stripVendorPrefix(lowerId: string): string {
+  return lowerId.includes("/") ? lowerId.substring(lowerId.lastIndexOf("/") + 1) : lowerId;
+}
+
 function findCacheEntry(modelId: string, cachePath?: string): SlimModelEntry | undefined {
   if (modelId.includes("@")) {
     throw new Error(
@@ -306,8 +325,7 @@ function findCacheEntry(modelId: string, cachePath?: string): SlimModelEntry | u
   if (!cache || cache.entries.length === 0) return undefined;
 
   const lower = modelId.toLowerCase();
-  // Vendor-prefixed IDs like "x-ai/grok-beta" — match on segment after "/"
-  const unprefixed = lower.includes("/") ? lower.substring(lower.lastIndexOf("/") + 1) : lower;
+  const unprefixed = stripVendorPrefix(lower);
 
   for (const entry of cache.entries) {
     const entryId = entry.modelId.toLowerCase();

--- a/packages/cli/src/adapters/variant-presets.test.ts
+++ b/packages/cli/src/adapters/variant-presets.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { writeAllModelsCache } from "../providers/all-models-cache.js";
+import { lookupVariantPresets } from "./model-catalog.js";
+
+const BASE_MODEL_ID = "gpt-5.6-sol";
+const VARIANT_MODEL_ID = "gpt-5.6-sol-pro";
+const PROVIDER = "openrouter";
+const PRESET = "reasoning.mode=pro";
+
+let tempDir = "";
+let cachePath = "";
+
+beforeEach(() => {
+  tempDir = mkdtempSync(join(tmpdir(), "claudish-variant-presets-"));
+  cachePath = join(tempDir, "all-models.json");
+  writeAllModelsCache(
+    {
+      entries: [
+        {
+          modelId: VARIANT_MODEL_ID,
+          aliases: [],
+          sources: {},
+          routeVariant: {
+            kind: "provider-preset",
+            baseModelId: BASE_MODEL_ID,
+            provider: PROVIDER,
+            preset: PRESET,
+          },
+        },
+      ],
+    },
+    cachePath
+  );
+});
+
+afterEach(() => {
+  try {
+    rmSync(tempDir, { recursive: true, force: true });
+  } catch {}
+  tempDir = "";
+  cachePath = "";
+});
+
+describe("lookupVariantPresets", () => {
+  test("normalizes vendor-prefixed model ids without weakening provider scoping", () => {
+    const expected = [{ modelId: VARIANT_MODEL_ID, preset: PRESET, provider: PROVIDER }];
+
+    expect(lookupVariantPresets(BASE_MODEL_ID, PROVIDER, cachePath)).toEqual(expected);
+
+    // The OpenRouter route passes the vendor-prefixed form; a raw compare made
+    // the feature inert on precisely the route whose presets the catalog records.
+    expect(lookupVariantPresets("openai/gpt-5.6-sol", PROVIDER, cachePath)).toEqual(expected);
+    expect(lookupVariantPresets("OpenAI/GPT-5.6-Sol", PROVIDER, cachePath)).toEqual(expected);
+
+    expect(lookupVariantPresets("openai/gpt-5.6-sol", "openai", cachePath)).toEqual([]);
+    expect(lookupVariantPresets("openai/gpt-5.6-terra", PROVIDER, cachePath)).toEqual([]);
+  });
+});

--- a/packages/cli/src/auth/credentials/api-key-credential.test.ts
+++ b/packages/cli/src/auth/credentials/api-key-credential.test.ts
@@ -12,15 +12,18 @@ const HERMETIC_CONFIG = join(
 );
 
 let savedEnv: string | undefined;
+let savedDisableKeychain: string | undefined;
 let savedDisableOp: string | undefined;
 let savedConfigOverride: string | null;
 
 beforeEach(() => {
   savedEnv = process.env[ENV_VAR];
+  savedDisableKeychain = process.env.CLAUDISH_DISABLE_KEYCHAIN;
   savedDisableOp = process.env.CLAUDISH_DISABLE_OP;
   savedConfigOverride = getConfigFileOverride();
 
   delete process.env[ENV_VAR];
+  process.env.CLAUDISH_DISABLE_KEYCHAIN = "1";
   process.env.CLAUDISH_DISABLE_OP = "1";
   // Keep getApiKey() away from both the real global config and any project
   // overlay. A missing override file resolves as an empty config.
@@ -31,6 +34,8 @@ beforeEach(() => {
 afterEach(() => {
   if (savedEnv === undefined) delete process.env[ENV_VAR];
   else process.env[ENV_VAR] = savedEnv;
+  if (savedDisableKeychain === undefined) delete process.env.CLAUDISH_DISABLE_KEYCHAIN;
+  else process.env.CLAUDISH_DISABLE_KEYCHAIN = savedDisableKeychain;
   if (savedDisableOp === undefined) delete process.env.CLAUDISH_DISABLE_OP;
   else process.env.CLAUDISH_DISABLE_OP = savedDisableOp;
   setConfigFileOverride(savedConfigOverride);

--- a/packages/cli/src/auth/credentials/authority.test.ts
+++ b/packages/cli/src/auth/credentials/authority.test.ts
@@ -7,27 +7,32 @@ import type { CredentialProvider, RequestAuth, RequestAuthContext } from "./type
 
 // ── Hermetic op-source gate (mock-free) ─────────────────────────────────────
 //
-// The credential layer's last resolution step is 1Password (op://). On a machine
-// that actually HAS an op source in config, the real SDK would be consulted
-// whenever a provider's env/config/oauth all miss — flaky and non-hermetic (the
-// SDK can be denied / time out).
+// The credential layer resolves env → aliases → config → keychain →
+// 1Password (op://). On a machine with either external source enabled, real
+// credentials could satisfy an intended miss; the SDK can also be denied or
+// time out.
 //
 // We do NOT mock op-source.js: Bun's mock.module is process-global, so a stub
 // here bleeds into sibling files that test the REAL op-source (op-source.test.ts)
 // when both run in one `bun test` process. Instead we use the production escape
-// hatch CLAUDISH_DISABLE_OP=1, which makes hasOpSources() return false WITHOUT
-// touching the SDK. With it set, ApiKeyCredentialProvider.isAvailable()
-// short-circuits before the op path — exactly the env/config-only resolution the
-// tests need, hermetically, with no module mock to leak.
+// hatches CLAUDISH_DISABLE_KEYCHAIN=1 and CLAUDISH_DISABLE_OP=1. The latter
+// makes hasOpSources() return false WITHOUT touching the SDK. Together they
+// preserve the env/config-only resolution these tests need, hermetically, with
+// no module mock to leak.
+let savedDisableKeychain: string | undefined;
 let savedDisableOp: string | undefined;
 
 beforeAll(() => {
+  savedDisableKeychain = process.env.CLAUDISH_DISABLE_KEYCHAIN;
   savedDisableOp = process.env.CLAUDISH_DISABLE_OP;
+  process.env.CLAUDISH_DISABLE_KEYCHAIN = "1";
   process.env.CLAUDISH_DISABLE_OP = "1";
   __resetSniffForTests(); // hasOpSources() memoizes — re-sniff with the flag on.
 });
 
 afterAll(() => {
+  if (savedDisableKeychain === undefined) delete process.env.CLAUDISH_DISABLE_KEYCHAIN;
+  else process.env.CLAUDISH_DISABLE_KEYCHAIN = savedDisableKeychain;
   if (savedDisableOp === undefined) delete process.env.CLAUDISH_DISABLE_OP;
   else process.env.CLAUDISH_DISABLE_OP = savedDisableOp;
   __resetSniffForTests(); // drop the disabled-state sniff for later files.

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -10,6 +10,7 @@ import {
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { EFFORT_LEVELS, isEffortLevel } from "./adapters/base-api-format.js";
 import { ENV } from "./config.js";
 import { buildLegacyHint, resolveDefaultProvider } from "./default-provider.js";
 import {
@@ -29,6 +30,7 @@ import {
   normalizePricingDisplay,
   searchModels,
 } from "./model-loader.js";
+import { parseModelParams } from "./model-params.js";
 import { compareByReleaseDateDesc } from "./model-selector.js";
 import {
   type ModelResult as PrintableModelResult,
@@ -46,6 +48,7 @@ import {
   isLocalProviderEnabled,
   loadConfig,
   loadLocalConfig,
+  readProOnUltracode,
 } from "./profile-config.js";
 import { API_KEY_MAP } from "./providers/api-key-map.js";
 import { type KeyProvenance, resolveApiKeyProvenance } from "./providers/api-key-provenance.js";
@@ -413,6 +416,49 @@ export async function parseArgs(args: string[]): Promise<ClaudishConfig> {
         process.exit(1);
       }
       config.classifierProvider = cpArg;
+    } else if (arg === "--model-params") {
+      // Extra request params deep-merged into the outbound payload AFTER the
+      // adapter has shaped it, so these win over every adapter default.
+      // Repeatable: later occurrences merge over earlier ones.
+      const mpArg = args[++i];
+      if (!mpArg) {
+        console.error("--model-params requires k=v[,k=v...] (e.g. reasoning.mode=pro)");
+        process.exit(1);
+      }
+      try {
+        config.modelParams = parseModelParams(mpArg, config.modelParams ?? {});
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+    } else if (arg === "--effort-override") {
+      // NOT `--effort`. That name belongs to Claude Code and claudish forwards
+      // it verbatim in claudeArgs (pinned by cli-passthrough.test.ts); claiming
+      // it here would silently stop the child ever seeing it.
+      //
+      // The two are complementary. `--effort` tells Claude Code what to ASK
+      // for, which arrives as output_config.effort and is then clamped to the
+      // levels the model advertises. This pins the level VERBATIM and skips
+      // that clamp. An escape hatch: the clamp is what keeps an unadvertised
+      // level off the wire, so pinning past it can be rejected upstream.
+      const effArg = args[++i];
+      if (!effArg) {
+        console.error(`--effort-override requires a level (${EFFORT_LEVELS.join(", ")})`);
+        process.exit(1);
+      }
+      if (!isEffortLevel(effArg)) {
+        console.error(
+          `--effort-override "${effArg}" is not a canonical level (${EFFORT_LEVELS.join(", ")}). ` +
+            "For a provider-specific value, use --model-params (e.g. --model-params reasoning_effort=<value>)."
+        );
+        process.exit(1);
+      }
+      config.effortOverride = effArg;
+    } else if (arg === "--pro-on-ultracode") {
+      config.proOnUltracode = true;
+    } else if (arg === "--no-pro-on-ultracode") {
+      // Escape hatch when it is enabled via config/env: off for this run.
+      config.proOnUltracode = false;
     } else if (arg === "--op-env" || arg.startsWith("--op-env=")) {
       // The actual 1Password Environment read happens early in index.ts
       // (highest priority). Here we only consume the flag + its value so it
@@ -773,6 +819,18 @@ export async function parseArgs(args: string[]): Promise<ClaudishConfig> {
       }
     }
   } catch {}
+
+  // proOnUltracode precedence: CLI flag > CLAUDISH_PRO_ON_ULTRACODE env >
+  // project ./.claudish.json > global config.json > false. Opt-in, default OFF
+  // — a pro preset burns quota faster, so it must never turn itself on.
+  if (config.proOnUltracode === undefined) {
+    const envVal = process.env.CLAUDISH_PRO_ON_ULTRACODE;
+    if (envVal !== undefined) {
+      config.proOnUltracode = envVal === "1" || envVal.toLowerCase() === "true";
+    } else {
+      config.proOnUltracode = readProOnUltracode() === true;
+    }
+  }
 
   return config as ClaudishConfig;
 }
@@ -2102,6 +2160,10 @@ ${h("OPTIONS")}
   ${green("--free")}                   Show only FREE models in the interactive selector
   ${green("--monitor")}                Monitor mode - proxy to REAL Anthropic API and log traffic
   ${green("--advisor")} ${yellow('"m1,m2[:collector]"')}  Multi-model advisor replacement (implies --monitor)
+  ${green("--model-params")} ${yellow('"k=v,..."')}  Extra request params merged into the payload (e.g. reasoning.mode=pro)
+  ${green("--effort-override")} ${yellow("<level>")}  Pin reasoning effort verbatim, skipping the per-model clamp
+  ${green("--pro-on-ultracode")}       Apply the model's catalog preset while in ultracode (opt-in)
+  ${green("--no-pro-on-ultracode")}    Force that off for this run (when enabled in config/env)
   ${green("-y, --auto-approve")}       Skip permission prompts (--dangerously-skip-permissions)
   ${green("--no-auto-approve")}        Explicitly enable permission prompts (default)
   ${green("--dangerous")}              Pass --dangerouslyDisableSandbox to Claude Code

--- a/packages/cli/src/handlers/composed-handler.ts
+++ b/packages/cli/src/handlers/composed-handler.ts
@@ -21,7 +21,7 @@
  */
 
 import type { Context } from "hono";
-import type { BaseAPIFormat } from "../adapters/base-api-format.js";
+import type { BaseAPIFormat, EffortLevel } from "../adapters/base-api-format.js";
 import type { ProviderTransport } from "../providers/transport/types.js";
 import type { ModelHandler } from "./types.js";
 // Alias for readability within this file
@@ -35,12 +35,15 @@ import type { BehaviorEngine, BehaviorSession } from "../behavior/index.js";
 import { getBehaviorEngine } from "../behavior/index.js";
 import { getLogLevel, log, logStderr, logStructured, truncateContent } from "../logger.js";
 import { GeminiThoughtSignatureMiddleware, MiddlewareManager } from "../middleware/index.js";
+import { deepMergeParams } from "../model-params.js";
 import { isTerminal429 } from "../providers/transport/openai.js";
 import {
   type OpenAIImageBlock,
   type VisionProxyAuthHeaders,
   describeImages,
 } from "../services/vision-proxy.js";
+import { type SessionEventRegistry, extractSessionId } from "../session-events/index.js";
+import { applyProInjection } from "../session-events/pro-injection.js";
 import { recordStats } from "../stats.js";
 import { classifyError, reportError } from "../telemetry.js";
 import { transformOpenAIToClaude } from "../transform.js";
@@ -108,6 +111,34 @@ export interface ComposedHandlerOptions {
   forceForeignModel?: boolean;
   /** How this handler was invoked (for stats). */
   invocationMode?: "profile" | "explicit-model" | "auto-route" | "env-var" | "model-map";
+  /**
+   * `--effort <level>`: pin the reasoning effort verbatim, skipping the
+   * per-model catalog clamp. Installed on this handler's dialect(s) at
+   * construction; undefined leaves the clamped mapping untouched.
+   */
+  effortOverride?: EffortLevel;
+  /**
+   * `--model-params k=v[,...]`: extra request params deep-merged into the
+   * outbound payload at step 5a — AFTER every adapter has shaped it, so these
+   * win over adapter defaults AND over the step 5a-pre preset injection.
+   */
+  modelParams?: Record<string, unknown>;
+  /**
+   * `--pro-on-ultracode`: apply this model's catalog provider-preset while the
+   * Claude Code session is in ultracode. Opt-in; when falsy the session-event
+   * layer is never consulted and does no filesystem work.
+   */
+  proOnUltracode?: boolean;
+  /**
+   * Test seam for the session-event registry. Defaults to the process-wide
+   * singleton. Only tests should pass this.
+   */
+  sessionEventRegistry?: SessionEventRegistry;
+  /**
+   * Test seam for the model-catalog cache path used by preset resolution.
+   * Defaults to ~/.claudish/all-models.json. Only tests should pass this.
+   */
+  catalogCachePath?: string;
 }
 
 export class ComposedHandler implements ModelHandler {
@@ -203,6 +234,23 @@ export class ComposedHandler implements ModelHandler {
     // process-wide; per-request state lives on the session created in handle(),
     // because this handler is cached per model and can serve overlapping requests.
     this.behaviorEngine = getBehaviorEngine();
+
+    // `--effort`: install the pin on EVERY dialect this handler can route
+    // through. getAdapter() picks explicitAdapter or resolvedDialect at request
+    // time and modelAdapter runs in addition to it, so pinning only one leaves
+    // the flag working on some models and silently not on others. Safe to
+    // mutate: resolveModelDialect() returns a fresh instance per handler, and
+    // an explicit adapter is built per handler by its profile.
+    if (options.effortOverride) {
+      for (const dialect of new Set(
+        [this.explicitAdapter, this.resolvedDialect, this.modelAdapter].filter(Boolean)
+      )) {
+        (dialect as BaseAPIFormat).setEffortOverride(options.effortOverride);
+      }
+      log(
+        `[ComposedHandler] --effort ${options.effortOverride} pinned for ${this.targetModel} (catalog clamp skipped)`
+      );
+    }
 
     // Initialize token tracker — model adapter knows the real context window
     this.tokenTracker = new TokenTracker(port, {
@@ -433,6 +481,38 @@ export class ComposedHandler implements ModelHandler {
       this.modelAdapter.prepareRequest(requestPayload, claudeRequest);
     }
     const toolNameMap = adapter.getToolNameMap();
+
+    // 5a-pre. Ultracode → catalog provider-preset injection (opt-in).
+    //
+    // Runs BEFORE the 5a --model-params merge, and that order IS the
+    // precedence rule: an explicit user `--model-params reasoning.mode=x` wins
+    // only because the merge lands last. Swap these two blocks and the
+    // injection silently overrides what the user asked for.
+    //
+    // Both blocks sit after step 5 (prepareRequest) and before 5c
+    // (transformPayload) on purpose: after, so they beat every adapter default;
+    // before, so they write into the payload itself rather than into a
+    // provider envelope that 5c may wrap around it.
+    if (this.options.proOnUltracode) {
+      applyProInjection(requestPayload, {
+        enabled: true,
+        sessionId: extractSessionId(claudeRequest?.metadata),
+        bareModelName: this.bareModelName,
+        provider: this.provider.name,
+        targetModel: this.targetModel,
+        outputConfig: claudeRequest?.output_config,
+        registry: this.options.sessionEventRegistry,
+        cachePath: this.options.catalogCachePath,
+      });
+    }
+
+    // 5a. --model-params: the user's last word on the payload.
+    if (this.options.modelParams) {
+      deepMergeParams(requestPayload, this.options.modelParams);
+      log(
+        `[ComposedHandler] Merged --model-params (${Object.keys(this.options.modelParams).join(", ")}) for ${this.targetModel}`
+      );
+    }
 
     // 5b. Refresh auth / health check (must happen before transformPayload, which may use auth state)
     if (this.provider.refreshAuth) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -973,6 +973,9 @@ async function runCli() {
           // is its first element, so the proxy can match the two.
           modelChain: cliConfig.monitor ? undefined : cliConfig.modelChain,
           classifier: resolveClassifierConfig(cliConfig, process.env),
+          effortOverride: cliConfig.effortOverride,
+          modelParams: cliConfig.modelParams,
+          proOnUltracode: cliConfig.proOnUltracode,
         }
       )
     );

--- a/packages/cli/src/model-params.test.ts
+++ b/packages/cli/src/model-params.test.ts
@@ -1,0 +1,103 @@
+/**
+ * --model-params parsing + deep-merge behavior.
+ *
+ * Pins the flag's parsing contract: comma-split k=v items, JSON coercion of
+ * values, dot-notation nesting, repeat-merge (later flags win), values that
+ * contain '=' after the first, and the deep-merge rules used at the
+ * ComposedHandler choke point (objects merge recursively, scalars/arrays
+ * replace, user params win over adapter defaults).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { deepMergeParams, parseModelParams } from "./model-params.js";
+
+describe("parseModelParams — JSON coercion", () => {
+  test("numbers, booleans, and null coerce", () => {
+    expect(parseModelParams("temperature=0.2")).toEqual({ temperature: 0.2 });
+    expect(parseModelParams("max_tokens=4096")).toEqual({ max_tokens: 4096 });
+    expect(parseModelParams("penalty=-1.5")).toEqual({ penalty: -1.5 });
+    expect(parseModelParams("stream=false")).toEqual({ stream: false });
+    expect(parseModelParams("enable_thinking=true")).toEqual({ enable_thinking: true });
+    expect(parseModelParams("stop=null")).toEqual({ stop: null });
+  });
+
+  test("quoted strings unquote", () => {
+    expect(parseModelParams('mode="pro"')).toEqual({ mode: "pro" });
+    // Quoting forces string type for a value that would otherwise coerce
+    expect(parseModelParams('version="1.5"')).toEqual({ version: "1.5" });
+  });
+
+  test("non-JSON values stay raw strings", () => {
+    expect(parseModelParams("effort=xhigh")).toEqual({ effort: "xhigh" });
+  });
+
+  test("value may contain '=' after the first", () => {
+    expect(parseModelParams("extra_query=a=b&c=d")).toEqual({ extra_query: "a=b&c=d" });
+  });
+});
+
+describe("parseModelParams — dot-notation nesting", () => {
+  test("deep paths nest recursively", () => {
+    expect(parseModelParams("a.b.c=1")).toEqual({ a: { b: { c: 1 } } });
+  });
+
+  test("sibling dot-paths in one flag combine instead of clobbering", () => {
+    expect(parseModelParams("reasoning.mode=pro,reasoning.effort=max")).toEqual({
+      reasoning: { mode: "pro", effort: "max" },
+    });
+  });
+});
+
+describe("parseModelParams — repeat-merge", () => {
+  test("later occurrences win on overlap and add nested siblings", () => {
+    let params = parseModelParams("temperature=0.2,reasoning.mode=fast");
+    params = parseModelParams("reasoning.mode=pro,reasoning.summary=auto", params);
+    expect(params).toEqual({
+      temperature: 0.2,
+      reasoning: { mode: "pro", summary: "auto" },
+    });
+  });
+});
+
+describe("parseModelParams — malformed input", () => {
+  test("missing '=', empty key, and empty dot segment all throw", () => {
+    expect(() => parseModelParams("temperature")).toThrow(/must be key=value/);
+    expect(() => parseModelParams("=0.2")).toThrow(/must be key=value/);
+    expect(() => parseModelParams("reasoning..mode=pro")).toThrow(/empty dot segment/);
+  });
+
+  test("empty items (stray commas) are skipped", () => {
+    expect(parseModelParams("temperature=0.2,,")).toEqual({ temperature: 0.2 });
+  });
+});
+
+describe("deepMergeParams — choke-point merge rules", () => {
+  test("nested keys merge over an existing object: overlap wins, siblings survive, new keys add", () => {
+    // The adapter (e.g. CodexAPIFormat) already built reasoning:{effort,summary};
+    // user params must win on overlap (effort), keep siblings (summary), and add (mode).
+    const payload: Record<string, any> = {
+      model: "gpt-5.6-sol",
+      reasoning: { effort: "medium", summary: "auto" },
+    };
+    deepMergeParams(payload, { reasoning: { mode: "pro", effort: "max" }, temperature: 0.2 });
+    expect(payload).toEqual({
+      model: "gpt-5.6-sol",
+      reasoning: { effort: "max", summary: "auto", mode: "pro" },
+      temperature: 0.2,
+    });
+  });
+
+  test("scalars and arrays replace; a source object replaces a target scalar", () => {
+    const payload: Record<string, any> = { stop: ["a", "b"], top_p: 0.9, reasoning: "on" };
+    deepMergeParams(payload, { stop: ["c"], top_p: 0.5, reasoning: { mode: "pro" } });
+    expect(payload).toEqual({ stop: ["c"], top_p: 0.5, reasoning: { mode: "pro" } });
+  });
+
+  test("source objects are cloned — later payload mutation can't corrupt the shared params map", () => {
+    const params = { reasoning: { mode: "pro" } };
+    const payload: Record<string, any> = {};
+    deepMergeParams(payload, params);
+    payload.reasoning.mode = "mutated";
+    expect(params.reasoning.mode).toBe("pro");
+  });
+});

--- a/packages/cli/src/model-params.ts
+++ b/packages/cli/src/model-params.ts
@@ -1,0 +1,90 @@
+/**
+ * --model-params parsing and payload merging.
+ *
+ * `--model-params k=v[,k=v...]` injects arbitrary extra request parameters into
+ * the outbound provider payload (deep-merged AFTER the adapter's
+ * buildPayload/prepareRequest, so user params win over adapter defaults).
+ *
+ * Parsing rules:
+ * - Items split on commas; each item is `key=value` (the value may contain `=`
+ *   after the first).
+ * - Values are JSON-coerced when they parse as JSON (numbers, true/false,
+ *   null, quoted strings); otherwise kept as raw strings.
+ * - Dot-notation keys create nested objects: `reasoning.mode=pro` →
+ *   `{ reasoning: { mode: "pro" } }`.
+ * - The flag may repeat; later occurrences merge over earlier ones (pass the
+ *   accumulated map back in as `into`).
+ */
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Deep-merge `source` into `target` (mutates and returns `target`).
+ * Objects merge recursively; scalars and arrays replace. Object values copied
+ * FROM `source` are cloned so later in-place payload mutations can't write
+ * back into a shared params map (the same map is reused on every request).
+ */
+export function deepMergeParams(
+  target: Record<string, any>,
+  source: Record<string, unknown>
+): Record<string, any> {
+  for (const [key, value] of Object.entries(source)) {
+    if (isPlainObject(value) && isPlainObject(target[key])) {
+      deepMergeParams(target[key], value);
+    } else if (isPlainObject(value)) {
+      target[key] = deepMergeParams({}, value);
+    } else {
+      target[key] = value;
+    }
+  }
+  return target;
+}
+
+/** JSON-coerce a raw value: numbers/booleans/null/quoted strings parse; everything else stays a raw string. */
+function coerceValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+/**
+ * Parse one `--model-params` flag value into (or on top of) `into`.
+ * Throws on malformed items (missing `=`, empty key/segment) — the CLI layer
+ * catches and exits with the message.
+ */
+export function parseModelParams(
+  spec: string,
+  into: Record<string, unknown> = {}
+): Record<string, unknown> {
+  for (const item of spec.split(",")) {
+    const trimmed = item.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq <= 0) {
+      throw new Error(`--model-params item "${trimmed}" must be key=value`);
+    }
+    const key = trimmed.slice(0, eq).trim();
+    const raw = trimmed.slice(eq + 1);
+    const path = key.split(".");
+    if (path.some((seg) => seg.length === 0)) {
+      throw new Error(`--model-params key "${key}" has an empty dot segment`);
+    }
+
+    // Build the nested single-entry object for this item, then deep-merge so
+    // repeated keys / sibling dot-paths combine instead of clobbering.
+    const nested: Record<string, unknown> = {};
+    let cursor = nested;
+    for (const seg of path.slice(0, -1)) {
+      const child: Record<string, unknown> = {};
+      cursor[seg] = child;
+      cursor = child;
+    }
+    cursor[path[path.length - 1]] = coerceValue(raw);
+    deepMergeParams(into, nested);
+  }
+  return into;
+}

--- a/packages/cli/src/probe/probe-results-printer.ts
+++ b/packages/cli/src/probe/probe-results-printer.ts
@@ -21,6 +21,7 @@ import {
   isFailureState,
   isReadyState,
 } from "../providers/probe-live.js";
+import { pinProbeModelSpec } from "../providers/probe-runner.js";
 import { bgHex, cliAnsi } from "../theme/ansi.js";
 import { getThemeMode } from "../theme/theme-mode.js";
 import {
@@ -664,7 +665,12 @@ function buildDirectRowData(result: ModelResult): RowData[] {
     {
       num: "1",
       provider: result.nativeProvider,
-      spec: `${result.nativeProvider}@${result.model}`,
+      // `result.model` is the RAW user input, so it already carries the prefix
+      // whenever the user typed one — `--probe openrouter@gpt-5.6-sol` rendered
+      // as "openrouter@openrouter@gpt-5.6-sol". pinProbeModelSpec owns the
+      // prefixing rule (it also keeps native-anthropic bare, which a plain
+      // template would break); reuse it rather than repeat a second guard here.
+      spec: pinProbeModelSpec({ provider: result.nativeProvider, modelSpec: result.model }),
       status,
       errorDetail,
       barsTiming,

--- a/packages/cli/src/profile-config-scoped.test.ts
+++ b/packages/cli/src/profile-config-scoped.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readProOnUltracode } from "./profile-config.js";
+
+// Hermetic via the ScopedConfigPaths seam (homedir() can't be re-pointed at
+// runtime in Bun) — same approach as onepassword-config.test.ts.
+test("readProOnUltracode: project .claudish.json beats global config.json", () => {
+  const dir = mkdtempSync(join(tmpdir(), "claudish-scoped-"));
+  try {
+    const globalPath = join(dir, "config.json");
+    const projectPath = join(dir, ".claudish.json");
+    writeFileSync(globalPath, JSON.stringify({ proOnUltracode: false }));
+    writeFileSync(projectPath, JSON.stringify({ proOnUltracode: true }));
+    expect(readProOnUltracode({ global: () => globalPath, project: () => projectPath })).toBe(true);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/src/profile-config.ts
+++ b/packages/cli/src/profile-config.ts
@@ -232,6 +232,16 @@ export interface ClaudishProfileConfig {
    * `loadConfig` runs on lightweight startup paths and stays Zod-free.
    */
   behavior?: Record<string, unknown>;
+
+  /**
+   * Apply a model's catalog provider-preset (e.g. `reasoning.mode=pro`) while
+   * the Claude Code session is in ultracode. Opt-in and default OFF — a pro
+   * preset burns quota faster, so it must never turn itself on.
+   * Precedence: --pro-on-ultracode flag > CLAUDISH_PRO_ON_ULTRACODE env >
+   * project `.claudish.json` > this field > false. The scoped read is
+   * `readProOnUltracode()`, NOT this allowlist — see its doc comment.
+   */
+  proOnUltracode?: boolean;
 }
 
 /**
@@ -345,6 +355,12 @@ export function loadConfig(): ClaudishProfileConfig {
     if (config.behavior !== undefined) {
       merged.behavior = config.behavior;
     }
+    // Same trap as keychain/onepasswordEnvironments above: omitted from this
+    // allowlist, the field survives on disk until the first global save and is
+    // then silently dropped — quietly turning the feature off with no error.
+    if (config.proOnUltracode !== undefined) {
+      merged.proOnUltracode = config.proOnUltracode;
+    }
     return merged;
   } catch (error) {
     console.error(`Warning: Failed to load config, using defaults: ${error}`);
@@ -420,6 +436,52 @@ export function getLocalConfigPath(): string {
  */
 export function localConfigExists(): boolean {
   return existsSync(getLocalConfigPath());
+}
+
+/**
+ * The two config scopes `readProOnUltracode` consults, as thunks.
+ *
+ * A seam rather than direct calls because `homedir()` cannot be re-pointed at
+ * runtime in Bun — the same approach as onepassword-config.test.ts.
+ */
+export interface ScopedConfigPaths {
+  global: () => string;
+  project: () => string;
+}
+
+const defaultScopedConfigPaths: ScopedConfigPaths = {
+  // activeConfigFile(), NOT the raw CONFIG_FILE constant: `--config <file>` /
+  // CLAUDISH_CONFIG must redirect this read like every other config reader,
+  // and `bun run test:safe` relies on that to stay off the real machine file.
+  global: () => activeConfigFile(),
+  project: () => getLocalConfigPath(),
+};
+
+/**
+ * Read `proOnUltracode` from the project file, else the global file.
+ *
+ * Deliberately a RAW per-file read rather than `loadConfig()`. `loadConfig`
+ * merges only the global scope through its allowlist, so a project
+ * `.claudish.json` that sets ONLY this key would be invisible to it. That is
+ * the whole point of this function, not an oversight.
+ *
+ * Returns undefined when neither scope states a boolean — the caller then
+ * applies its own default (false).
+ */
+export function readProOnUltracode(
+  paths: ScopedConfigPaths = defaultScopedConfigPaths
+): boolean | undefined {
+  for (const pathFn of [paths.project, paths.global]) {
+    try {
+      const path = pathFn();
+      if (!existsSync(path)) continue;
+      const parsed = JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+      if (typeof parsed?.proOnUltracode === "boolean") return parsed.proOnUltracode;
+    } catch {
+      // Garbled/unreadable file → skip this scope rather than fail the run.
+    }
+  }
+  return undefined;
 }
 
 /**

--- a/packages/cli/src/providers/custom-endpoints-loader.test.ts
+++ b/packages/cli/src/providers/custom-endpoints-loader.test.ts
@@ -445,10 +445,12 @@ describe("custom-endpoints-loader", () => {
     const OP_ENV_VAR = "CUSTOM_OP_EP_KEY";
     const ORIGINAL_VAR = process.env[VAR];
     const ORIGINAL_OP_ENV = process.env[OP_ENV_VAR];
+    const ORIGINAL_DISABLE_KEYCHAIN = process.env.CLAUDISH_DISABLE_KEYCHAIN;
     const ORIGINAL_DISABLE_OP = process.env.CLAUDISH_DISABLE_OP;
 
     beforeEach(() => {
-      // Keep the authority's async op:// step off the real 1Password SDK/config.
+      // Keep credential misses off the host keychain and real 1Password SDK/config.
+      process.env.CLAUDISH_DISABLE_KEYCHAIN = "1";
       process.env.CLAUDISH_DISABLE_OP = "1";
       __resetSniffForTests();
       delete process.env[VAR];
@@ -461,6 +463,11 @@ describe("custom-endpoints-loader", () => {
       else process.env[VAR] = ORIGINAL_VAR;
       if (ORIGINAL_OP_ENV === undefined) delete process.env[OP_ENV_VAR];
       else process.env[OP_ENV_VAR] = ORIGINAL_OP_ENV;
+      if (ORIGINAL_DISABLE_KEYCHAIN === undefined) {
+        delete process.env.CLAUDISH_DISABLE_KEYCHAIN;
+      } else {
+        process.env.CLAUDISH_DISABLE_KEYCHAIN = ORIGINAL_DISABLE_KEYCHAIN;
+      }
       if (ORIGINAL_DISABLE_OP === undefined) delete process.env.CLAUDISH_DISABLE_OP;
       else process.env.CLAUDISH_DISABLE_OP = ORIGINAL_DISABLE_OP;
       __resetSniffForTests();

--- a/packages/cli/src/providers/provider-profiles.ts
+++ b/packages/cli/src/providers/provider-profiles.ts
@@ -64,8 +64,19 @@ export interface ProfileContext {
   targetModel: string;
   /** The listening port of the proxy server */
   port: number;
-  /** Shared ComposedHandler options from the outer scope */
-  sharedOpts: Pick<ComposedHandlerOptions, "isInteractive" | "invocationMode">;
+  /**
+   * Shared ComposedHandler options from the outer scope.
+   *
+   * Every profile spreads this verbatim, so widening this Pick is how a new
+   * handler option reaches all ~25 profile and custom-endpoint construction
+   * sites at once. An option added to ComposedHandlerOptions but NOT listed
+   * here is dropped by the spread with no error — the feature then works on
+   * the direct proxy-server routes and silently not on any profile.
+   */
+  sharedOpts: Pick<
+    ComposedHandlerOptions,
+    "isInteractive" | "invocationMode" | "effortOverride" | "modelParams" | "proOnUltracode"
+  >;
 }
 
 /**

--- a/packages/cli/src/providers/routing-rules.test.ts
+++ b/packages/cli/src/providers/routing-rules.test.ts
@@ -501,9 +501,11 @@ describe("route()", () => {
   // test module's top-level credential probe can prewarm real credentials.
   // Invalidate before and after each test to isolate host and fake keys.
   beforeEach(() => {
-    // Disable 1Password for routing tests so route()'s credential resolution
-    // never pulls a real op:// key from the host config (which would make a
-    // "no credentials → no-route" assertion fail). Mock-free env flag → no bleed.
+    // Credential resolution is env → aliases → config → keychain → op://.
+    // These tests predate the keychain source and originally disabled only
+    // op://, leaving host keychain entries able to satisfy "no credentials"
+    // assertions. Disable both external stores with the mock-free env flags.
+    process.env.CLAUDISH_DISABLE_KEYCHAIN = "1";
     process.env.CLAUDISH_DISABLE_OP = "1";
     __resetSniffForTests();
     credentials.invalidate();
@@ -515,6 +517,7 @@ describe("route()", () => {
   });
 
   afterEach(() => {
+    delete process.env.CLAUDISH_DISABLE_KEYCHAIN;
     delete process.env.CLAUDISH_DISABLE_OP;
     __resetSniffForTests();
     // Restore env vars (preserves the host's actual config for other tests).
@@ -772,6 +775,7 @@ describe("route() with defaultProvider", () => {
   // test module's top-level credential probe can prewarm real credentials.
   // Invalidate before and after each test to isolate host and fake keys.
   beforeEach(() => {
+    process.env.CLAUDISH_DISABLE_KEYCHAIN = "1";
     process.env.CLAUDISH_DISABLE_OP = "1";
     __resetSniffForTests();
     credentials.invalidate();
@@ -782,6 +786,7 @@ describe("route() with defaultProvider", () => {
   });
 
   afterEach(() => {
+    delete process.env.CLAUDISH_DISABLE_KEYCHAIN;
     delete process.env.CLAUDISH_DISABLE_OP;
     __resetSniffForTests();
     for (const key of ENV_KEYS_TO_CLEAR) {

--- a/packages/cli/src/proxy-server.ts
+++ b/packages/cli/src/proxy-server.ts
@@ -2,6 +2,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { type Context, Hono } from "hono";
 import { cors } from "hono/cors";
+import { isEffortLevel } from "./adapters/base-api-format.js";
 import { LocalModelAdapter } from "./adapters/local-adapter.js";
 import { OpenRouterAPIFormat } from "./adapters/openrouter-api-format.js";
 import { credentials } from "./auth/credentials/authority.js";
@@ -117,6 +118,22 @@ export interface ProxyServerOptions {
    * disabled by default. See classifier-passthrough.ts.
    */
   classifier?: { enabled: boolean; model: string };
+  /**
+   * `--effort <level>`: pin the reasoning effort verbatim, skipping the
+   * per-model catalog clamp. Undefined leaves the clamped mapping untouched.
+   */
+  effortOverride?: string;
+  /**
+   * `--model-params k=v[,...]`: extra request params deep-merged into every
+   * outbound payload after the adapter has shaped it.
+   */
+  modelParams?: Record<string, unknown>;
+  /**
+   * `--pro-on-ultracode`: apply a model's catalog provider-preset while the
+   * session is in ultracode. Opt-in; when false the session-event layer does
+   * no filesystem work at all.
+   */
+  proOnUltracode?: boolean;
 }
 
 /**
@@ -239,6 +256,25 @@ export async function createProxyServer(
     options.advisorModels,
     options.advisorCollector
   );
+  /**
+   * Request-shaping options that must reach EVERY ComposedHandler, whatever
+   * route built it. Defined once and spread at each construction site (and
+   * into `ProfileContext.sharedOpts`) because a handler that misses them makes
+   * the flags work on some models and silently not on others.
+   */
+  const requestShapingOpts: Pick<
+    ComposedHandlerOptions,
+    "effortOverride" | "modelParams" | "proOnUltracode"
+  > = {
+    // Narrowed HERE, not at the CLI: createProxyServer is also entered from
+    // `serve` and `team`, so the boundary must validate whoever calls it.
+    // A non-canonical value is dropped rather than passed through — it could
+    // not reach the wire anyway, and `--model-params` is its escape hatch.
+    effortOverride: isEffortLevel(options.effortOverride) ? options.effortOverride : undefined,
+    modelParams: options.modelParams,
+    proOnUltracode: options.proOnUltracode,
+  };
+
   const openRouterHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> OpenRouter Handler
   const localProviderHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> Local Provider Handler
   const remoteProviderHandlers = new Map<string, ModelHandler>(); // Map from Target Model ID -> Gemini/OpenAI Handler
@@ -268,6 +304,7 @@ export async function createProxyServer(
           adapter: orAdapter,
           isInteractive: options.isInteractive,
           invocationMode,
+          ...requestShapingOpts,
         })
       );
     }
@@ -294,6 +331,7 @@ export async function createProxyServer(
         new ComposedHandler(poeTransport, modelId, modelId, port, {
           isInteractive: options.isInteractive,
           invocationMode,
+          ...requestShapingOpts,
         })
       );
     }
@@ -327,6 +365,7 @@ export async function createProxyServer(
         summarizeTools: options.summarizeTools,
         isInteractive: options.isInteractive,
         invocationMode,
+        ...requestShapingOpts,
       });
       localProviderHandlers.set(targetModel, handler);
       log(
@@ -352,6 +391,7 @@ export async function createProxyServer(
           summarizeTools: options.summarizeTools,
           isInteractive: options.isInteractive,
           invocationMode,
+          ...requestShapingOpts,
         }
       );
       localProviderHandlers.set(targetModel, handler);
@@ -464,7 +504,7 @@ export async function createProxyServer(
         apiKey,
         targetModel,
         port,
-        sharedOpts: { isInteractive: options.isInteractive, invocationMode },
+        sharedOpts: { isInteractive: options.isInteractive, invocationMode, ...requestShapingOpts },
       });
       if (!handler) {
         return null; // Profile returned null (missing config) or unknown provider

--- a/packages/cli/src/session-events/event-translator.test.ts
+++ b/packages/cli/src/session-events/event-translator.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { translateLine } from "./event-translator.js";
+import {
+  FIXTURE_EFFORT_HIGH_DEFAULT_STDOUT,
+  FIXTURE_EFFORT_ULTRACODE_STDOUT,
+  FIXTURE_ULTRA_EFFORT_ENTER,
+  FIXTURE_ULTRA_EFFORT_EXIT,
+} from "./test-fixtures.js";
+
+describe("translateLine", () => {
+  test("real ultra_effort_enter attachment → ultra_effort_enter event", () => {
+    expect(translateLine(FIXTURE_ULTRA_EFFORT_ENTER)).toEqual({
+      kind: "ultra_effort_enter",
+      at: "2026-07-13T13:31:08.930Z",
+    });
+  });
+
+  test("real ultra_effort_exit attachment → ultra_effort_exit event", () => {
+    expect(translateLine(FIXTURE_ULTRA_EFFORT_EXIT)).toEqual({
+      kind: "ultra_effort_exit",
+      at: "2026-07-13T13:31:32.054Z",
+    });
+  });
+
+  test("real '/effort ultracode' stdout line → effort_changed (session scope)", () => {
+    expect(translateLine(FIXTURE_EFFORT_ULTRACODE_STDOUT)).toEqual({
+      kind: "effort_changed",
+      level: "ultracode",
+      scope: "session",
+      at: "2026-07-13T13:31:05.055Z",
+    });
+  });
+
+  test("real '/effort high' saved-as-default stdout line → effort_changed (default scope)", () => {
+    expect(translateLine(FIXTURE_EFFORT_HIGH_DEFAULT_STDOUT)).toEqual({
+      kind: "effort_changed",
+      level: "high",
+      scope: "default",
+      at: "2026-07-13T13:31:26.234Z",
+    });
+  });
+
+  test("malformed line → null; unrecognized attachment type → unknown passthrough", () => {
+    expect(translateLine("not json {")).toBeNull();
+    expect(translateLine('"just a string"')).toBeNull();
+    // Derived from the real enter line — only the attachment type differs
+    // (forward-compat: future harness events must flow through as `unknown`).
+    const future = FIXTURE_ULTRA_EFFORT_ENTER.replace("ultra_effort_enter", "model_switch");
+    expect(translateLine(future)).toMatchObject({
+      kind: "unknown",
+      attachmentType: "model_switch",
+    });
+  });
+});

--- a/packages/cli/src/session-events/event-translator.ts
+++ b/packages/cli/src/session-events/event-translator.ts
@@ -1,0 +1,53 @@
+/**
+ * Transcript line → HarnessEvent translation.
+ *
+ * Pure and total: never throws. Lines that aren't recognizable harness
+ * events return null; recognizable-but-unmapped attachment types return
+ * `{ kind: "unknown" }` so future event types flow through the bus without
+ * a translator change.
+ */
+
+import type { EffortScope, HarnessEvent } from "./types.js";
+
+/**
+ * Matches the `/effort` local-command stdout Claude Code echoes into the
+ * transcript, e.g. "Set effort level to ultracode (this session only): …"
+ * or "Set effort level to high (saved as your default for new sessions): …".
+ */
+const EFFORT_STDOUT_RE = /Set effort level to (\S+) \((this session only|saved as your default)/;
+
+/** Translate one raw transcript line into a HarnessEvent, or null if not one. */
+export function translateLine(line: string): HarnessEvent | null {
+  let record: any;
+  try {
+    record = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (record === null || typeof record !== "object") return null;
+  const at = typeof record.timestamp === "string" ? record.timestamp : undefined;
+
+  if (record.type === "attachment") {
+    const attachmentType = record.attachment?.type;
+    if (attachmentType === "ultra_effort_enter") return { kind: "ultra_effort_enter", at };
+    if (attachmentType === "ultra_effort_exit") return { kind: "ultra_effort_exit", at };
+    return {
+      kind: "unknown",
+      attachmentType: typeof attachmentType === "string" ? attachmentType : undefined,
+      at,
+    };
+  }
+
+  if (record.type === "user") {
+    const content = record.message?.content;
+    if (typeof content === "string" && content.includes("<local-command-stdout>")) {
+      const match = content.match(EFFORT_STDOUT_RE);
+      if (match) {
+        const scope: EffortScope = match[2] === "this session only" ? "session" : "default";
+        return { kind: "effort_changed", level: match[1], scope, at };
+      }
+    }
+  }
+
+  return null;
+}

--- a/packages/cli/src/session-events/index.ts
+++ b/packages/cli/src/session-events/index.ts
@@ -1,0 +1,232 @@
+/**
+ * SessionEventRegistry — the harness session-event layer's public surface.
+ *
+ * Keyed by Claude Code session_id (extracted from body.metadata.user_id).
+ * Each session gets a TranscriptTailer over its transcript file
+ * (<claudeHome>/projects/<slug>/<sid>.jsonl); translated events fold into
+ * per-session state via the pure reducer and fan out to subscribers.
+ *
+ * Failure posture: no public method ever throws. Unknown session state is
+ * `undefined` — callers must treat that as "no injection". Zero filesystem
+ * cost unless a caller opts in (proOnUltracode gates every call site).
+ */
+
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { log } from "../logger.js";
+import { translateLine } from "./event-translator.js";
+import { initialState, reduceEvent } from "./session-state.js";
+import { TranscriptTailer } from "./transcript-tailer.js";
+import type { HarnessEvent, SessionEventState } from "./types.js";
+
+export type SessionEventSubscriber = (sessionId: string, event: HarnessEvent) => void;
+
+export interface SessionEventRegistryOptions {
+  /** Claude Code home dir (default ~/.claude). Test seam — homedir() can't be re-pointed in Bun. */
+  claudeHome?: string;
+  /** Tailer poll interval in ms (default 250). Test seam. */
+  pollIntervalMs?: number;
+}
+
+/** How long a transcript-not-found result is cached before retrying. */
+const MISS_TTL_MS = 5_000;
+/** After this many misses, stop looking for the session's transcript. */
+const MAX_MISSES = 5;
+/** Sessions idle longer than this are swept (lossless — re-ensure re-backfills). */
+const IDLE_SWEEP_MS = 30 * 60 * 1000;
+
+interface SessionEntry {
+  state: SessionEventState;
+  tailer: TranscriptTailer;
+  lastActivity: number;
+}
+
+/**
+ * Extract the Claude Code session_id from request metadata. Claude Code embeds
+ * it in `metadata.user_id` (e.g. "user_<hash>_account_<uuid>_session_<uuid>").
+ * Returns undefined for any unrecognized shape — which callers must treat as
+ * "unknown session" (no injection).
+ */
+export function extractSessionId(metadata: unknown): string | undefined {
+  const userId = (metadata as { user_id?: unknown } | null | undefined)?.user_id;
+  if (typeof userId !== "string") return undefined;
+  // Real captured shape (RequestMeta trace, 2026-07-13): user_id is a
+  // JSON-ENCODED STRING — {"device_id":"…","account_uuid":"","session_id":"<uuid>"}.
+  // The suffix-regex below does NOT match it ("session_" is followed by `id":"`),
+  // so JSON parsing must come first.
+  try {
+    const parsed = JSON.parse(userId) as { session_id?: unknown };
+    if (typeof parsed?.session_id === "string" && parsed.session_id) {
+      return parsed.session_id;
+    }
+  } catch {
+    // not JSON — fall through to the plain user_…_session_<uuid> suffix format
+  }
+  const match = userId.match(
+    /session_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i
+  );
+  return match?.[1];
+}
+
+/** Claude Code's project-dir slug: every non-alphanumeric char becomes "-". */
+export function slugFromCwd(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9]/g, "-");
+}
+
+export class SessionEventRegistry {
+  private sessions = new Map<string, SessionEntry>();
+  private misses = new Map<string, { lastTry: number; count: number }>();
+  private subscribers: SessionEventSubscriber[] = [];
+  private claudeHome: string;
+  private pollIntervalMs?: number;
+
+  constructor(opts: SessionEventRegistryOptions = {}) {
+    this.claudeHome = opts.claudeHome ?? join(homedir(), ".claude");
+    this.pollIntervalMs = opts.pollIntervalMs;
+  }
+
+  /** Locate the session transcript and start tailing it. Safe to call per request. */
+  ensureSession(sessionId: string): void {
+    try {
+      this.sweepIdle();
+      const existing = this.sessions.get(sessionId);
+      if (existing) {
+        existing.lastActivity = Date.now();
+        return;
+      }
+
+      const miss = this.misses.get(sessionId);
+      if (miss) {
+        if (miss.count >= MAX_MISSES) return; // gave up (logged once below)
+        if (Date.now() - miss.lastTry < MISS_TTL_MS) return;
+      }
+
+      const filePath = this.locateTranscript(sessionId);
+      if (!filePath) {
+        const count = (miss?.count ?? 0) + 1;
+        this.misses.set(sessionId, { lastTry: Date.now(), count });
+        if (count === MAX_MISSES) {
+          log(
+            `[SessionEvents] transcript for session ${sessionId} not found after ${MAX_MISSES} attempts — giving up`
+          );
+        }
+        return;
+      }
+      this.misses.delete(sessionId);
+
+      const entry: SessionEntry = {
+        state: initialState({ defaultEffort: this.readSettingsEffortLevel() }),
+        tailer: new TranscriptTailer(filePath, (line) => this.onLine(sessionId, line), {
+          pollIntervalMs: this.pollIntervalMs,
+          onError: (err) => log(`[SessionEvents] tailer for ${sessionId} stopped: ${err}`),
+        }),
+        lastActivity: Date.now(),
+      };
+      this.sessions.set(sessionId, entry);
+      entry.tailer.start(); // backfills from byte 0 → full state even on late attach
+      log(`[SessionEvents] tailing ${filePath}`);
+    } catch (err) {
+      // The event layer must never break request handling.
+      log(`[SessionEvents] ensureSession(${sessionId}) failed: ${err}`);
+    }
+  }
+
+  /** Synchronous drain — closes the enter-event→request timing window. */
+  sync(sessionId: string): void {
+    try {
+      const entry = this.sessions.get(sessionId);
+      if (entry) {
+        entry.lastActivity = Date.now();
+        entry.tailer.syncNow();
+      }
+    } catch (err) {
+      log(`[SessionEvents] sync(${sessionId}) failed: ${err}`);
+    }
+  }
+
+  /** Current folded state. `undefined` = unknown session = no injection. */
+  getState(sessionId: string): SessionEventState | undefined {
+    return this.sessions.get(sessionId)?.state;
+  }
+
+  /** Subscribe to translated events (the bus). Returns an unsubscribe fn. */
+  subscribe(fn: SessionEventSubscriber): () => void {
+    this.subscribers.push(fn);
+    return () => {
+      this.subscribers = this.subscribers.filter((s) => s !== fn);
+    };
+  }
+
+  /** Dispose every tailer (proxy shutdown). */
+  disposeAll(): void {
+    for (const entry of this.sessions.values()) {
+      entry.tailer.dispose();
+    }
+    this.sessions.clear();
+    this.misses.clear();
+  }
+
+  // ─── Internal ────────────────────────────────────────────────────────
+
+  private onLine(sessionId: string, line: string): void {
+    const event = translateLine(line);
+    if (!event) return;
+    const entry = this.sessions.get(sessionId);
+    if (!entry) return;
+    entry.state = reduceEvent(entry.state, event);
+    log(
+      `[SessionEvents] ${sessionId}: ${event.kind}${event.kind === "effort_changed" ? ` level=${event.level} scope=${event.scope}` : ""} → ultracodeActive=${entry.state.ultracodeActive}`
+    );
+    for (const fn of this.subscribers) {
+      try {
+        fn(sessionId, event);
+      } catch {
+        // Subscriber errors must not poison the fold loop.
+      }
+    }
+  }
+
+  /**
+   * <claudeHome>/projects/<slugFromCwd(cwd)>/<sid>.jsonl, with a glob fallback
+   * across projects/* — the filename is unique per session, only the directory
+   * lookup can mismatch (e.g. Claude Code launched from a different cwd).
+   */
+  private locateTranscript(sessionId: string): string | undefined {
+    const projectsDir = join(this.claudeHome, "projects");
+    const primary = join(projectsDir, slugFromCwd(process.cwd()), `${sessionId}.jsonl`);
+    if (existsSync(primary)) return primary;
+    try {
+      for (const dir of readdirSync(projectsDir)) {
+        const candidate = join(projectsDir, dir, `${sessionId}.jsonl`);
+        if (existsSync(candidate)) return candidate;
+      }
+    } catch {
+      // projects dir missing/unreadable → treated as not found
+    }
+    return undefined;
+  }
+
+  /** Seed for new sessions: persisted default from <claudeHome>/settings.json. */
+  private readSettingsEffortLevel(): string | undefined {
+    try {
+      const settings = JSON.parse(readFileSync(join(this.claudeHome, "settings.json"), "utf-8"));
+      return typeof settings.effortLevel === "string" ? settings.effortLevel : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private sweepIdle(): void {
+    const now = Date.now();
+    for (const [sid, entry] of this.sessions) {
+      if (now - entry.lastActivity > IDLE_SWEEP_MS) {
+        entry.tailer.dispose();
+        this.sessions.delete(sid);
+      }
+    }
+  }
+}
+
+/** Process-wide singleton — constructed lazily-cheap (no fs work until ensureSession). */
+export const sessionEvents = new SessionEventRegistry();

--- a/packages/cli/src/session-events/pro-injection.test.ts
+++ b/packages/cli/src/session-events/pro-injection.test.ts
@@ -1,0 +1,312 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { appendFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Context } from "hono";
+import { ComposedHandler } from "../handlers/composed-handler.js";
+import { type SlimModelEntry, writeAllModelsCache } from "../providers/all-models-cache.js";
+import type { ProviderTransport } from "../providers/transport/types.js";
+import { SessionEventRegistry } from "./index.js";
+import {
+  type ProInjectionOptions,
+  applyProInjection,
+  resolveVariantPreset,
+} from "./pro-injection.js";
+import {
+  FIXTURE_EFFORT_HIGH_DEFAULT_STDOUT,
+  FIXTURE_EFFORT_ULTRACODE_STDOUT,
+  FIXTURE_SESSION_ID,
+  FIXTURE_ULTRA_EFFORT_ENTER,
+  FIXTURE_ULTRA_EFFORT_EXIT,
+} from "./test-fixtures.js";
+
+const BASE_MODEL_ID = "gpt-5.6-sol";
+const VARIANT_MODEL_ID = "gpt-5.6-sol-pro";
+const PROVIDER = "openrouter";
+const PRESET = "reasoning.mode=pro";
+
+let home = "";
+let registry: SessionEventRegistry | undefined;
+let transcriptFile = "";
+let cachePath = "";
+
+/** Fake ~/.claude with the real captured transcript lines for FIXTURE_SESSION_ID. */
+function makeHome(...lines: string[]): void {
+  home = mkdtempSync(join(tmpdir(), "claudish-proinj-"));
+  const projectDir = join(home, "projects", "-fake-cwd");
+  mkdirSync(projectDir, { recursive: true });
+  transcriptFile = join(projectDir, `${FIXTURE_SESSION_ID}.jsonl`);
+  writeFileSync(transcriptFile, lines.map((line) => `${line}\n`).join(""));
+  cachePath = join(home, "all-models.json");
+  registry = new SessionEventRegistry({ claudeHome: home, pollIntervalMs: 60_000 });
+  registry.ensureSession(FIXTURE_SESSION_ID);
+  registry.sync(FIXTURE_SESSION_ID);
+}
+
+function variantEntry(
+  provider = PROVIDER,
+  preset = PRESET,
+  baseModelId = BASE_MODEL_ID
+): SlimModelEntry {
+  return {
+    modelId: VARIANT_MODEL_ID,
+    aliases: [],
+    sources: {},
+    routeVariant: {
+      kind: "provider-preset",
+      baseModelId,
+      provider,
+      preset,
+    },
+  };
+}
+
+function writeCatalog(entries: SlimModelEntry[] = [variantEntry()]): void {
+  writeAllModelsCache({ entries }, cachePath);
+}
+
+function makeProOptions(overrides: Partial<ProInjectionOptions> = {}): ProInjectionOptions {
+  return {
+    enabled: true,
+    sessionId: FIXTURE_SESSION_ID,
+    bareModelName: BASE_MODEL_ID,
+    provider: PROVIDER,
+    targetModel: `${PROVIDER}@${BASE_MODEL_ID}`,
+    outputConfig: { effort: "xhigh" },
+    registry,
+    cachePath,
+    ...overrides,
+  };
+}
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  registry?.disposeAll();
+  registry = undefined;
+  try {
+    rmSync(home, { recursive: true, force: true });
+  } catch {}
+  home = "";
+  transcriptFile = "";
+  cachePath = "";
+});
+
+describe("resolveVariantPreset", () => {
+  test("returns the same-provider catalog preset as parsed nested params", () => {
+    makeHome();
+    writeCatalog();
+
+    expect(resolveVariantPreset(BASE_MODEL_ID, PROVIDER, cachePath)).toEqual({
+      params: { reasoning: { mode: "pro" } },
+      variantModelId: VARIANT_MODEL_ID,
+      provider: PROVIDER,
+      preset: PRESET,
+    });
+  });
+
+  test("returns undefined when the variant belongs to a different provider", () => {
+    makeHome();
+    writeCatalog([variantEntry("openrouter")]);
+
+    expect(resolveVariantPreset(BASE_MODEL_ID, "openai", cachePath)).toBeUndefined();
+  });
+
+  test("returns undefined when the catalog model has no variant", () => {
+    makeHome();
+    writeCatalog([{ modelId: BASE_MODEL_ID, aliases: [], sources: {} }]);
+
+    expect(resolveVariantPreset(BASE_MODEL_ID, PROVIDER, cachePath)).toBeUndefined();
+  });
+
+  test("returns undefined without throwing for a cold or missing cache", () => {
+    makeHome();
+
+    expect(resolveVariantPreset(BASE_MODEL_ID, PROVIDER, cachePath)).toBeUndefined();
+  });
+
+  test("returns undefined without throwing for an unparseable preset", () => {
+    makeHome();
+    writeCatalog([variantEntry(PROVIDER, "reasoning-tier")]);
+
+    expect(resolveVariantPreset(BASE_MODEL_ID, PROVIDER, cachePath)).toBeUndefined();
+  });
+});
+
+describe("applyProInjection", () => {
+  test("ultracode enter plus matching provider deep-merges the catalog preset", () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    const payload: {
+      model: string;
+      reasoning: { effort: string; mode?: string };
+    } = {
+      model: BASE_MODEL_ID,
+      reasoning: { effort: "xhigh" },
+    };
+
+    expect(applyProInjection(payload, makeProOptions())).toBe(true);
+    expect(payload.reasoning).toEqual({ effort: "xhigh", mode: "pro" });
+  });
+
+  test("enabled false preserves the default-OFF contract and leaves the payload untouched", () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    const payload = { reasoning: { effort: "xhigh" }, marker: "unchanged" };
+
+    expect(applyProInjection(payload, makeProOptions({ enabled: false }))).toBe(false);
+    expect(payload).toEqual({ reasoning: { effort: "xhigh" }, marker: "unchanged" });
+  });
+
+  test("non-xhigh output effort blocks injection for subagent requests", () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    const payload = { marker: "unchanged" };
+
+    expect(applyProInjection(payload, makeProOptions({ outputConfig: { effort: "low" } }))).toBe(
+      false
+    );
+    expect(payload).toEqual({ marker: "unchanged" });
+  });
+
+  test("structured output_config.format blocks injection for auxiliary requests", () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    const payload = { marker: "unchanged" };
+
+    expect(
+      applyProInjection(
+        payload,
+        makeProOptions({
+          outputConfig: { effort: "xhigh", format: { type: "json_schema" } },
+        })
+      )
+    ).toBe(false);
+    expect(payload).toEqual({ marker: "unchanged" });
+  });
+
+  test("provider mismatch blocks injection and leaves the payload untouched", () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog([variantEntry("openrouter")]);
+    const payload = { marker: "unchanged" };
+
+    expect(applyProInjection(payload, makeProOptions({ provider: "openai" }))).toBe(false);
+    expect(payload).toEqual({ marker: "unchanged" });
+  });
+
+  test("ultracode exit followed by registry.sync stops injection", () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    appendFileSync(
+      transcriptFile,
+      `${FIXTURE_EFFORT_HIGH_DEFAULT_STDOUT}\n${FIXTURE_ULTRA_EFFORT_EXIT}\n`
+    );
+    registry?.sync(FIXTURE_SESSION_ID);
+    const payload = { marker: "unchanged" };
+
+    expect(applyProInjection(payload, makeProOptions())).toBe(false);
+    expect(payload).toEqual({ marker: "unchanged" });
+  });
+
+  test("undefined sessionId blocks injection and leaves the payload untouched", () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    const payload = { marker: "unchanged" };
+
+    expect(applyProInjection(payload, makeProOptions({ sessionId: undefined }))).toBe(false);
+    expect(payload).toEqual({ marker: "unchanged" });
+  });
+});
+
+// ─── ComposedHandler wiring (step 5a-pre) ────────────────────────────────────
+
+/** Fake transport; the stubbed global fetch captures the final wire payload. */
+function makeTransport(): ProviderTransport {
+  return {
+    name: PROVIDER,
+    displayName: "OpenRouter",
+    streamFormat: "openai-sse",
+    getEndpoint: () => "http://localhost/v1/chat/completions",
+    getHeaders: async () => ({}),
+  } as unknown as ProviderTransport;
+}
+
+/** Stub fetch → capture outbound body, return a canned error (skips stream parsing). */
+function stubFetchCapture(): {
+  body: () => Record<string, unknown> & { reasoning?: { mode?: unknown } };
+} {
+  let captured: Record<string, unknown> & { reasoning?: { mode?: unknown } } = {};
+  globalThis.fetch = (async (_url: unknown, init: unknown) => {
+    const body = (init as { body?: unknown } | undefined)?.body;
+    if (typeof body !== "string") throw new Error("expected a JSON request body");
+    captured = JSON.parse(body);
+    return new Response('{"error":{"message":"stub"}}', { status: 500 });
+  }) as unknown as typeof fetch;
+  return { body: () => captured };
+}
+
+function makeContext(): Context {
+  return {
+    req: { header: () => ({}) },
+    header: () => {},
+    json: (body: unknown, status?: number) =>
+      new Response(JSON.stringify(body), { status: status ?? 200 }),
+  } as unknown as Context;
+}
+
+function makeClaudePayload(): Record<string, unknown> {
+  return {
+    model: BASE_MODEL_ID,
+    max_tokens: 16,
+    messages: [{ role: "user", content: "hi" }],
+    // Ultracode main-loop turns carry effort xhigh (composite-guard signature).
+    output_config: { effort: "xhigh" },
+    metadata: { user_id: `user_e2e_account_e2e_session_${FIXTURE_SESSION_ID}` },
+  };
+}
+
+function makeHandler(options: {
+  proOnUltracode?: boolean;
+  modelParams?: Record<string, unknown>;
+}): ComposedHandler {
+  return new ComposedHandler(makeTransport(), `${PROVIDER}@${BASE_MODEL_ID}`, BASE_MODEL_ID, 8080, {
+    ...options,
+    sessionEventRegistry: registry,
+    catalogCachePath: cachePath,
+  });
+}
+
+describe("ComposedHandler step 5a-pre wiring", () => {
+  test("proOnUltracode true in an ultracode session puts reasoning.mode=pro on the wire", async () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    const wire = stubFetchCapture();
+
+    await makeHandler({ proOnUltracode: true }).handle(makeContext(), makeClaudePayload());
+
+    expect(wire.body().reasoning?.mode).toBe("pro");
+  });
+
+  test("ORDERING INVARIANT: swapping 5a-pre after 5a would override explicit --model-params", async () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    const wire = stubFetchCapture();
+
+    await makeHandler({
+      proOnUltracode: true,
+      modelParams: { reasoning: { mode: "standard" } },
+    }).handle(makeContext(), makeClaudePayload());
+
+    expect(wire.body().reasoning?.mode).toBe("standard");
+  });
+
+  test("falsy proOnUltracode leaves reasoning.mode off the wire", async () => {
+    makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
+    writeCatalog();
+    const wire = stubFetchCapture();
+
+    await makeHandler({}).handle(makeContext(), makeClaudePayload());
+
+    expect(wire.body().reasoning?.mode).toBeUndefined();
+  });
+});

--- a/packages/cli/src/session-events/pro-injection.test.ts
+++ b/packages/cli/src/session-events/pro-injection.test.ts
@@ -149,6 +149,33 @@ describe("applyProInjection", () => {
     expect(payload.reasoning).toEqual({ effort: "xhigh", mode: "pro" });
   });
 
+  test("applyProInjection ensures+syncs the session itself — production never does it", () => {
+    // Do not use makeHome() here: that shared helper eagerly ensures and syncs,
+    // masking the production lifecycle bug that reached a live run.
+    home = mkdtempSync(join(tmpdir(), "claudish-proinj-"));
+    const projectDir = join(home, "projects", "-fake-cwd");
+    mkdirSync(projectDir, { recursive: true });
+    transcriptFile = join(projectDir, `${FIXTURE_SESSION_ID}.jsonl`);
+    writeFileSync(
+      transcriptFile,
+      `${FIXTURE_EFFORT_ULTRACODE_STDOUT}\n${FIXTURE_ULTRA_EFFORT_ENTER}\n`
+    );
+    cachePath = join(home, "all-models.json");
+    registry = new SessionEventRegistry({ claudeHome: home, pollIntervalMs: 60_000 });
+    writeCatalog();
+
+    const disabledPayload = { marker: "unchanged" };
+    expect(applyProInjection(disabledPayload, makeProOptions({ enabled: false }))).toBe(false);
+    expect(disabledPayload).toEqual({ marker: "unchanged" });
+    expect(registry.getState(FIXTURE_SESSION_ID)).toBeUndefined();
+
+    const payload: { reasoning: { effort: string; mode?: string } } = {
+      reasoning: { effort: "xhigh" },
+    };
+    expect(applyProInjection(payload, makeProOptions())).toBe(true);
+    expect(payload.reasoning).toEqual({ effort: "xhigh", mode: "pro" });
+  });
+
   test("enabled false preserves the default-OFF contract and leaves the payload untouched", () => {
     makeHome(FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER);
     writeCatalog();

--- a/packages/cli/src/session-events/pro-injection.ts
+++ b/packages/cli/src/session-events/pro-injection.ts
@@ -105,6 +105,20 @@ export function applyProInjection(
     if (opts.outputConfig?.effort !== "xhigh") return false;
     if (opts.outputConfig?.format) return false;
     const registry = opts.registry ?? sessionEvents;
+    // Own the session lifecycle here rather than at the call site. getState()
+    // returns undefined until a tailer exists, so without these two lines the
+    // layer is INERT in production and every gate below is unreachable — the
+    // unit tests only passed because the harness called ensureSession itself.
+    //
+    // Both are cheap to repeat: ensureSession is idempotent (and rate-limits
+    // its own misses), sync is a no-op for an unknown session. They run only
+    // after the free gates above, so a request that could never inject does no
+    // filesystem work. sync() closes the enter-event→request race — the
+    // ultracode attachment is written to the transcript moments before the
+    // first ultracode request arrives, and poll-interval latency would
+    // otherwise lose that first turn.
+    registry.ensureSession(opts.sessionId);
+    registry.sync(opts.sessionId);
     const state = registry.getState(opts.sessionId);
     if (!state?.ultracodeActive) return false;
     // Capability gate LAST: it is the only gate that touches the filesystem.

--- a/packages/cli/src/session-events/pro-injection.ts
+++ b/packages/cli/src/session-events/pro-injection.ts
@@ -1,0 +1,122 @@
+/**
+ * Ultracode → provider-preset payload injection (v1 consumer of the
+ * session-event layer).
+ *
+ * Applied in ComposedHandler step 5a-pre, immediately BEFORE the --model-params
+ * merge — precedence is positional, so an explicit user parameter always wins
+ * over the injected one.
+ *
+ * WHAT IS INJECTED IS NOT HARDCODED. Both halves of the fact come from the slim
+ * catalog's `routeVariant`: which models a preset applies to (`baseModelId`)
+ * and what that preset sets (`preset`, e.g. `reasoning.mode=pro`). A name regex
+ * would assert a fact the catalog already knows, and would go stale the moment
+ * a vendor ships another pro SKU.
+ */
+
+import { lookupVariantPresets } from "../adapters/model-catalog.js";
+import { log } from "../logger.js";
+import { deepMergeParams, parseModelParams } from "../model-params.js";
+import { type SessionEventRegistry, sessionEvents } from "./index.js";
+
+/** A catalog preset resolved for a model, and where it was learned. */
+export interface ResolvedPreset {
+  /** The params the preset expands to, ready to deep-merge. */
+  params: Record<string, unknown>;
+  /** The variant model id the preset was read from (e.g. `gpt-5.6-sol-pro`). */
+  variantModelId: string;
+  /** The serving provider the catalog recorded the preset on. */
+  provider?: string;
+  /** The raw preset string, for the log line. */
+  preset: string;
+}
+
+/**
+ * The provider-preset this model has on `provider`, if the catalog knows one.
+ *
+ * Replaces the v1 `/gpt-5.6/` name gate. Returns undefined for a cold cache, a
+ * model with no variants, a variant recorded on a DIFFERENT provider, or a
+ * preset string that is not parseable `k=v` — every one of which means "no
+ * information", which the caller must treat as "do not inject".
+ *
+ * `provider` is required rather than optional on purpose: a preset is an
+ * observation about ONE provider's roster. `reasoning.mode=pro` is recorded
+ * against OpenRouter; whether the same parameter reaches the model on another
+ * host is unverified, and injecting it there would be a guess.
+ */
+export function resolveVariantPreset(
+  bareModelName: string,
+  provider: string,
+  cachePath?: string
+): ResolvedPreset | undefined {
+  for (const variant of lookupVariantPresets(bareModelName, provider, cachePath)) {
+    try {
+      const params = parseModelParams(variant.preset);
+      if (Object.keys(params).length === 0) continue;
+      return {
+        params,
+        variantModelId: variant.modelId,
+        provider: variant.provider,
+        preset: variant.preset,
+      };
+    } catch {
+      // Unparseable preset vocabulary (not `k=v`) → no information, try the next.
+    }
+  }
+  return undefined;
+}
+
+export interface ProInjectionOptions {
+  /** The proOnUltracode config gate (default OFF). */
+  enabled: boolean;
+  /** Claude Code session id from extractSessionId(). undefined = no injection. */
+  sessionId: string | undefined;
+  /** Bare model name (no provider prefix) — the catalog key for the preset lookup. */
+  bareModelName: string;
+  /** The serving provider actually being routed to (ProviderTransport.name). */
+  provider: string;
+  /** Full routed model string, for the log line. */
+  targetModel: string;
+  /** The incoming Claude request's output_config — the composite-guard input. */
+  outputConfig?: { effort?: unknown; format?: unknown } | null;
+  /** Test seam — defaults to the process-wide registry. */
+  registry?: SessionEventRegistry;
+  /** Test seam — catalog cache path. Defaults to ~/.claudish/all-models.json. */
+  cachePath?: string;
+}
+
+/**
+ * Merge the model's catalog provider-preset into the outbound payload when the
+ * session is in ultracode. Returns whether it injected. Never throws.
+ */
+export function applyProInjection(
+  requestPayload: Record<string, any>,
+  opts: ProInjectionOptions
+): boolean {
+  try {
+    if (!opts.enabled || !opts.sessionId) return false;
+    // Composite wire guard (2026-07-15): subagent requests carry the SAME
+    // session_id as the main loop (empirically verified — Anthropic exposes no
+    // hierarchy metadata, GH#12430), so session state alone over-applies.
+    // Ultracode main-loop turns are signed by output_config.effort === "xhigh";
+    // subagents send their own configured effort, and auxiliary calls (titling)
+    // carry output_config.format (structured output). Residual known gap: a
+    // subagent explicitly configured `effort: xhigh` during an ultracode
+    // session still gets the preset — narrow and semantically defensible.
+    if (opts.outputConfig?.effort !== "xhigh") return false;
+    if (opts.outputConfig?.format) return false;
+    const registry = opts.registry ?? sessionEvents;
+    const state = registry.getState(opts.sessionId);
+    if (!state?.ultracodeActive) return false;
+    // Capability gate LAST: it is the only gate that touches the filesystem.
+    const resolved = resolveVariantPreset(opts.bareModelName, opts.provider, opts.cachePath);
+    if (!resolved) return false;
+    deepMergeParams(requestPayload, resolved.params);
+    log(
+      `[SessionEvents] ultracode active → preset ${resolved.preset} for ${opts.targetModel} ` +
+        `(catalog variant ${resolved.variantModelId} @ ${resolved.provider}, session ${opts.sessionId})`
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/cli/src/session-events/registry.test.ts
+++ b/packages/cli/src/session-events/registry.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SessionEventRegistry } from "./index.js";
+import { FIXTURE_SESSION_ID, FIXTURE_ULTRA_EFFORT_ENTER } from "./test-fixtures.js";
+
+let home: string;
+let registry: SessionEventRegistry | undefined;
+
+afterEach(() => {
+  registry?.disposeAll();
+  registry = undefined;
+  try {
+    rmSync(home, { recursive: true, force: true });
+  } catch {}
+});
+
+describe("SessionEventRegistry", () => {
+  test("finds the transcript via the projects/* glob fallback and seeds from settings.json", () => {
+    home = mkdtempSync(join(tmpdir(), "claudish-sev-"));
+    // Deliberately NOT slugFromCwd(process.cwd()) — forces the glob fallback.
+    const projectDir = join(home, "projects", "-some-other-cwd");
+    mkdirSync(projectDir, { recursive: true });
+    writeFileSync(
+      join(projectDir, `${FIXTURE_SESSION_ID}.jsonl`),
+      `${FIXTURE_ULTRA_EFFORT_ENTER}\n`
+    );
+    writeFileSync(join(home, "settings.json"), JSON.stringify({ effortLevel: "high" }));
+
+    registry = new SessionEventRegistry({ claudeHome: home, pollIntervalMs: 60_000 });
+    registry.ensureSession(FIXTURE_SESSION_ID);
+    registry.sync(FIXTURE_SESSION_ID);
+
+    const state = registry.getState(FIXTURE_SESSION_ID);
+    expect(state?.ultracodeActive).toBe(true);
+    expect(state?.defaultEffort).toBe("high"); // seeded from settings.json effortLevel
+    expect(state?.seededFrom).toBe("settings");
+  });
+
+  test("unknown session → getState undefined (no injection), ensureSession never throws", () => {
+    home = mkdtempSync(join(tmpdir(), "claudish-sev-"));
+    registry = new SessionEventRegistry({ claudeHome: home });
+    const sid = "00000000-0000-0000-0000-000000000000";
+    registry.ensureSession(sid); // no projects dir at all — records a miss
+    registry.sync(sid);
+    expect(registry.getState(sid)).toBeUndefined();
+  });
+});
+
+describe("extractSessionId — real captured shape", () => {
+  // Verbatim user_id value from the [RequestMeta] trace in
+  // logs/claudish_2026-07-13_13-30-48.log (real Claude Code session).
+  const REAL_USER_ID =
+    '{"device_id":"073c3e365d9be8e8227e5e8c550ec03388f7643998e13abf2c306e6d2ace43c2","account_uuid":"","session_id":"4365c8f1-eb14-42b5-9d60-e69ad47e5fb3"}';
+
+  test("parses the JSON-encoded user_id Claude Code actually sends", async () => {
+    const { extractSessionId } = await import("./index.js");
+    expect(extractSessionId({ user_id: REAL_USER_ID })).toBe(
+      "4365c8f1-eb14-42b5-9d60-e69ad47e5fb3"
+    );
+  });
+});

--- a/packages/cli/src/session-events/session-state.test.ts
+++ b/packages/cli/src/session-events/session-state.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test";
+import { translateLine } from "./event-translator.js";
+import { initialState, reduceEvent } from "./session-state.js";
+import {
+  FIXTURE_EFFORT_HIGH_DEFAULT_STDOUT,
+  FIXTURE_EFFORT_ULTRACODE_STDOUT,
+  FIXTURE_ULTRA_EFFORT_ENTER,
+  FIXTURE_ULTRA_EFFORT_EXIT,
+} from "./test-fixtures.js";
+
+// Events derived from the real captured transcript lines.
+const enterEvent = translateLine(FIXTURE_ULTRA_EFFORT_ENTER)!;
+const exitEvent = translateLine(FIXTURE_ULTRA_EFFORT_EXIT)!;
+const ultracodeChanged = translateLine(FIXTURE_EFFORT_ULTRACODE_STDOUT)!;
+const highDefaultChanged = translateLine(FIXTURE_EFFORT_HIGH_DEFAULT_STDOUT)!;
+
+describe("session-state reducer", () => {
+  test("ultra_effort_enter sets ultracodeActive", () => {
+    const state = reduceEvent(initialState(), enterEvent);
+    expect(state.ultracodeActive).toBe(true);
+    expect(state.lastEventAt).toBe("2026-07-13T13:31:08.930Z");
+  });
+
+  test("ultra_effort_exit clears ultracodeActive", () => {
+    const state = reduceEvent(reduceEvent(initialState(), enterEvent), exitEvent);
+    expect(state.ultracodeActive).toBe(false);
+  });
+
+  test("effort_changed(ultracode) pre-arms ultracodeActive; any other level clears it", () => {
+    const armed = reduceEvent(initialState(), ultracodeChanged);
+    expect(armed.ultracodeActive).toBe(true);
+    expect(armed.effort).toBe("ultracode");
+    const cleared = reduceEvent(armed, highDefaultChanged);
+    expect(cleared.ultracodeActive).toBe(false);
+    expect(cleared.effort).toBe("high");
+  });
+
+  test("default-scope change updates defaultEffort; settings seed populates initial state", () => {
+    const seeded = initialState({ defaultEffort: "medium" });
+    expect(seeded).toMatchObject({
+      ultracodeActive: false,
+      effort: "medium",
+      defaultEffort: "medium",
+      seededFrom: "settings",
+    });
+    const state = reduceEvent(seeded, highDefaultChanged);
+    expect(state.defaultEffort).toBe("high");
+    expect(state.effortScope).toBe("default");
+  });
+});

--- a/packages/cli/src/session-events/session-state.ts
+++ b/packages/cli/src/session-events/session-state.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-session state reducer — pure, never throws.
+ *
+ * File order is authoritative (events fold in the order they appear in the
+ * transcript); timestamps are informational only.
+ */
+
+import type { HarnessEvent, SessionEventState } from "./types.js";
+
+/** Fresh state, optionally seeded from ~/.claude/settings.json `effortLevel`. */
+export function initialState(seed?: { defaultEffort?: string }): SessionEventState {
+  if (seed?.defaultEffort) {
+    return {
+      ultracodeActive: false,
+      effort: seed.defaultEffort,
+      defaultEffort: seed.defaultEffort,
+      seededFrom: "settings",
+    };
+  }
+  return { ultracodeActive: false, seededFrom: "none" };
+}
+
+/** Fold one event into state. Unknown events only touch lastEventAt. */
+export function reduceEvent(state: SessionEventState, event: HarnessEvent): SessionEventState {
+  const next: SessionEventState = { ...state, lastEventAt: event.at ?? state.lastEventAt };
+  switch (event.kind) {
+    case "ultra_effort_enter":
+      next.ultracodeActive = true;
+      return next;
+    case "ultra_effort_exit":
+      next.ultracodeActive = false;
+      return next;
+    case "effort_changed":
+      next.effort = event.level;
+      next.effortScope = event.scope;
+      // Pre-arm on `/effort ultracode` (the stdout line lands ~8ms before the
+      // ultra_effort_enter attachment — belt-and-braces for that window);
+      // any other level clears it.
+      next.ultracodeActive = event.level === "ultracode";
+      if (event.scope === "default") next.defaultEffort = event.level;
+      return next;
+    default:
+      return next;
+  }
+}

--- a/packages/cli/src/session-events/test-fixtures.ts
+++ b/packages/cli/src/session-events/test-fixtures.ts
@@ -1,0 +1,23 @@
+/**
+ * Session-event test fixtures — DERIVED FROM A REAL CAPTURED TRANSCRIPT
+ * (repo rule: no hand-crafted fixtures).
+ *
+ * Source: ~/.claude/projects/-Users-jack-mag-claudish-packages-cli/
+ *         4365c8f1-eb14-42b5-9d60-e69ad47e5fb3.jsonl (Claude Code 2.1.207,
+ *         captured 2026-07-13). Lines copied verbatim.
+ */
+
+/** Real user line: `/effort ultracode` local-command stdout (scope: session only). */
+export const FIXTURE_EFFORT_ULTRACODE_STDOUT = `{"parentUuid":"e24c5a75-8635-42ea-8365-585fa61dfda6","isSidechain":false,"promptId":"01f92171-1609-4cd4-8f02-648c74ee4dd2","type":"user","message":{"role":"user","content":"<local-command-stdout>Set effort level to ultracode (this session only): xhigh + dynamic workflow orchestration</local-command-stdout>"},"uuid":"ed1a6a25-4bf7-4ed2-b383-2aa63a91b01e","timestamp":"2026-07-13T13:31:05.055Z","userType":"external","entrypoint":"cli","cwd":"/Users/jack/mag/claudish/packages/cli","sessionId":"4365c8f1-eb14-42b5-9d60-e69ad47e5fb3","version":"2.1.207","gitBranch":"main"}`;
+
+/** Real attachment line: ultracode mode entered. */
+export const FIXTURE_ULTRA_EFFORT_ENTER = `{"parentUuid":"7091946b-1c08-4474-ab83-adef45cf09dc","isSidechain":false,"attachment":{"type":"ultra_effort_enter","reminderType":"full"},"type":"attachment","uuid":"5bc1a151-0908-4d6f-807e-cd5280dfc550","timestamp":"2026-07-13T13:31:08.930Z","userType":"external","entrypoint":"cli","cwd":"/Users/jack/mag/claudish/packages/cli","sessionId":"4365c8f1-eb14-42b5-9d60-e69ad47e5fb3","version":"2.1.207","gitBranch":"main"}`;
+
+/** Real user line: `/effort high` local-command stdout (scope: saved as default). */
+export const FIXTURE_EFFORT_HIGH_DEFAULT_STDOUT = `{"parentUuid":"06896b8a-b70d-4792-9d14-369df7af2aee","isSidechain":false,"promptId":"271dfb8d-8713-46d6-8e51-fdd88fcea3f4","type":"user","message":{"role":"user","content":"<local-command-stdout>Set effort level to high (saved as your default for new sessions): Comprehensive implementation with extensive testing and documentation</local-command-stdout>"},"uuid":"94a76c05-a155-47bd-9514-b9d54c2de80f","timestamp":"2026-07-13T13:31:26.234Z","userType":"external","entrypoint":"cli","cwd":"/Users/jack/mag/claudish/packages/cli","sessionId":"4365c8f1-eb14-42b5-9d60-e69ad47e5fb3","version":"2.1.207","gitBranch":"main"}`;
+
+/** Real attachment line: ultracode mode exited. */
+export const FIXTURE_ULTRA_EFFORT_EXIT = `{"parentUuid":"400eb219-eae9-4ac1-bcc1-24bbb95f59ad","isSidechain":false,"attachment":{"type":"ultra_effort_exit"},"type":"attachment","uuid":"5418c102-e293-4f70-865e-b7445a2cd0f2","timestamp":"2026-07-13T13:31:32.054Z","userType":"external","entrypoint":"cli","cwd":"/Users/jack/mag/claudish/packages/cli","sessionId":"4365c8f1-eb14-42b5-9d60-e69ad47e5fb3","version":"2.1.207","gitBranch":"main"}`;
+
+/** The session id embedded in every fixture line above. */
+export const FIXTURE_SESSION_ID = "4365c8f1-eb14-42b5-9d60-e69ad47e5fb3";

--- a/packages/cli/src/session-events/transcript-tailer.test.ts
+++ b/packages/cli/src/session-events/transcript-tailer.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  FIXTURE_EFFORT_ULTRACODE_STDOUT,
+  FIXTURE_ULTRA_EFFORT_ENTER,
+  FIXTURE_ULTRA_EFFORT_EXIT,
+} from "./test-fixtures.js";
+import { TranscriptTailer } from "./transcript-tailer.js";
+
+/** Wait until a predicate returns true, checking every `intervalMs` ms.
+ *  Rejects if the predicate hasn't returned true within `timeoutMs`. */
+function waitUntil(predicate: () => boolean, timeoutMs = 5000, intervalMs = 50): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      if (predicate()) return resolve();
+      if (Date.now() >= deadline) return reject(new Error("waitUntil timed out"));
+      setTimeout(check, intervalMs);
+    };
+    check();
+  });
+}
+
+let dir: string;
+let tailer: TranscriptTailer | undefined;
+
+function makeTranscript(content: string): string {
+  dir = mkdtempSync(join(tmpdir(), "claudish-tailer-"));
+  const file = join(dir, "session.jsonl");
+  writeFileSync(file, content);
+  return file;
+}
+
+afterEach(() => {
+  tailer?.dispose();
+  tailer = undefined;
+  try {
+    rmSync(dir, { recursive: true, force: true });
+  } catch {}
+});
+
+describe("TranscriptTailer", () => {
+  test("start() backfills all existing lines from byte 0", () => {
+    const file = makeTranscript(
+      `${FIXTURE_EFFORT_ULTRACODE_STDOUT}\n${FIXTURE_ULTRA_EFFORT_ENTER}\n`
+    );
+    const lines: string[] = [];
+    tailer = new TranscriptTailer(file, (l) => lines.push(l), { pollIntervalMs: 20 });
+    tailer.start();
+    // The backfill tick is synchronous — no waiting needed.
+    expect(lines).toEqual([FIXTURE_EFFORT_ULTRACODE_STDOUT, FIXTURE_ULTRA_EFFORT_ENTER]);
+  });
+
+  test("polling picks up lines appended after start()", async () => {
+    const file = makeTranscript(`${FIXTURE_ULTRA_EFFORT_ENTER}\n`);
+    const lines: string[] = [];
+    tailer = new TranscriptTailer(file, (l) => lines.push(l), { pollIntervalMs: 20 });
+    tailer.start();
+    appendFileSync(file, `${FIXTURE_ULTRA_EFFORT_EXIT}\n`);
+    await waitUntil(() => lines.length === 2);
+    expect(lines[1]).toBe(FIXTURE_ULTRA_EFFORT_EXIT);
+  });
+
+  test("partial line stays buffered until its newline arrives; dispose stops ticks", () => {
+    const file = makeTranscript("");
+    const lines: string[] = [];
+    tailer = new TranscriptTailer(file, (l) => lines.push(l), { pollIntervalMs: 60_000 });
+    tailer.start();
+
+    const half = Math.floor(FIXTURE_ULTRA_EFFORT_ENTER.length / 2);
+    appendFileSync(file, FIXTURE_ULTRA_EFFORT_ENTER.slice(0, half));
+    tailer.syncNow();
+    expect(lines).toEqual([]); // no newline yet → buffered, not delivered
+
+    appendFileSync(file, `${FIXTURE_ULTRA_EFFORT_ENTER.slice(half)}\n`);
+    tailer.syncNow();
+    expect(lines).toEqual([FIXTURE_ULTRA_EFFORT_ENTER]); // reassembled exactly
+
+    tailer.dispose();
+    appendFileSync(file, `${FIXTURE_ULTRA_EFFORT_EXIT}\n`);
+    tailer.syncNow();
+    expect(lines).toHaveLength(1); // disposed → syncNow is a no-op
+  });
+});

--- a/packages/cli/src/session-events/transcript-tailer.ts
+++ b/packages/cli/src/session-events/transcript-tailer.ts
@@ -1,0 +1,104 @@
+/**
+ * TranscriptTailer — incremental, poll-based JSONL file tailer.
+ *
+ * Mirrors the repo's established patterns: setTimeout+stat poll loop, and
+ * ollama-jsonl.ts's buffer split/pop incremental line parsing. No held file
+ * descriptors between ticks (open/read/close per delta), no fs.watch.
+ *
+ * Failure posture: an fs error stops the tailer (dead, via onError) — it
+ * never throws into the caller. `syncNow()` runs one immediate synchronous
+ * tick so request-time reads are deterministic.
+ */
+
+import { closeSync, openSync, readSync, statSync } from "node:fs";
+
+export interface TranscriptTailerOptions {
+  /** Poll interval in ms (default 250). */
+  pollIntervalMs?: number;
+  /** Called once when an fs error kills the tailer. */
+  onError?: (err: unknown) => void;
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 250;
+
+export class TranscriptTailer {
+  private offset = 0;
+  private buffer = "";
+  private decoder = new TextDecoder();
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(
+    private filePath: string,
+    private onLine: (line: string) => void,
+    private opts: TranscriptTailerOptions = {}
+  ) {}
+
+  /** Backfill from byte 0 (late attach reconstructs full state), then poll. */
+  start(): void {
+    if (this.disposed) return;
+    this.tick();
+    this.schedule();
+  }
+
+  /** One immediate synchronous tick — request-time drain. */
+  syncNow(): void {
+    this.tick();
+  }
+
+  /** Stop polling. Idempotent. */
+  dispose(): void {
+    this.disposed = true;
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private schedule(): void {
+    if (this.disposed) return;
+    this.timer = setTimeout(() => {
+      this.tick();
+      this.schedule();
+    }, this.opts.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS);
+    // A live poll timer must never keep the process alive.
+    this.timer.unref?.();
+  }
+
+  private tick(): void {
+    if (this.disposed) return;
+    try {
+      const size = statSync(this.filePath).size;
+      if (size < this.offset) {
+        // Truncation — reset and re-backfill from byte 0.
+        this.offset = 0;
+        this.buffer = "";
+        this.decoder = new TextDecoder();
+      }
+      if (size === this.offset) return;
+
+      const fd = openSync(this.filePath, "r");
+      let chunk: Buffer;
+      try {
+        chunk = Buffer.alloc(size - this.offset);
+        const bytesRead = readSync(fd, chunk, 0, chunk.length, this.offset);
+        this.offset += bytesRead;
+        if (bytesRead < chunk.length) chunk = chunk.subarray(0, bytesRead);
+      } finally {
+        closeSync(fd);
+      }
+
+      // stream:true keeps a multi-byte UTF-8 sequence split across ticks intact.
+      this.buffer += this.decoder.decode(chunk, { stream: true });
+      const lines = this.buffer.split("\n");
+      this.buffer = lines.pop() ?? "";
+      for (const line of lines) {
+        if (line.trim()) this.onLine(line);
+      }
+    } catch (err) {
+      // Dead tailer, never a crash — the registry's lazy re-ensure can rebuild.
+      this.dispose();
+      this.opts.onError?.(err);
+    }
+  }
+}

--- a/packages/cli/src/session-events/types.ts
+++ b/packages/cli/src/session-events/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Harness session-event layer — shared types.
+ *
+ * Claude Code records session state transitions (ultracode enter/exit, effort
+ * changes) in its session transcript (~/.claude/projects/<slug>/<sid>.jsonl)
+ * that never reach the wire. This layer tails the transcript, translates the
+ * harness-internal records into the typed events below, and folds them into
+ * per-session state that claudish consults at request time.
+ *
+ * The transcript format is Anthropic-internal and may drift between Claude
+ * Code versions — every consumer must treat unknown shapes as `unknown`
+ * (forward-compat passthrough) and unknown state as "no injection".
+ */
+
+/** Where an effort change applies: this session only, or the persisted default. */
+export type EffortScope = "session" | "default";
+
+/**
+ * A translated harness event. Future event kinds (model_switch, …) are one
+ * union member + one reducer case.
+ */
+export type HarnessEvent =
+  | { kind: "ultra_effort_enter"; at?: string }
+  | { kind: "ultra_effort_exit"; at?: string }
+  | { kind: "effort_changed"; level: string; scope: EffortScope; at?: string }
+  | { kind: "unknown"; attachmentType?: string; at?: string };
+
+/** Folded per-session state. File order is authoritative; timestamps informational. */
+export interface SessionEventState {
+  /** True between ultra_effort_enter and ultra_effort_exit (or pre-armed by effort_changed(ultracode)). */
+  ultracodeActive: boolean;
+  /** Most recent effort level seen in this session (verbatim, e.g. "high", "ultracode"). */
+  effort?: string;
+  /** Scope of the most recent effort change. */
+  effortScope?: EffortScope;
+  /** Persisted default effort (settings.json seed, updated by scope==="default" changes). */
+  defaultEffort?: string;
+  /** Where the initial state came from. */
+  seededFrom: "settings" | "none";
+  /** Timestamp of the last folded event (informational only). */
+  lastEventAt?: string;
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -82,6 +82,14 @@ export interface ClaudishConfig {
   classifierModel?: string; // --classifier-model <m> (also enables the passthrough)
   classifierProvider?: string; // --classifier-provider anthropic (enables the passthrough)
 
+  // Request-shaping overrides
+  /** --effort <level>: pin the reasoning effort verbatim, SKIPPING the per-model catalog clamp */
+  effortOverride?: string;
+  /** --model-params k=v[,k=v...]: extra request params deep-merged into the outbound payload */
+  modelParams?: Record<string, unknown>;
+  /** --pro-on-ultracode: apply the model's catalog provider-preset while in ultracode (opt-in) */
+  proOnUltracode?: boolean;
+
   // Cost tracking
   costTracking?: boolean;
   auditCosts?: boolean;


### PR DESCRIPTION
Ports `--model-params` and the session-event pro-injection layer off an orphaned
July branch, rewired against current `main`. Adds `--effort-override`. Fixes two
bugs that a live run caught after the port looked green, one probe display bug,
and a test-isolation defect that had been costing six failures on any
keychain-enabled machine.

## What's new

**`--model-params k=v[,k=v...]`** — extra request params deep-merged into the
outbound payload at step 5a, after every adapter has shaped it, so they are the
user's last word. Dot-notation nests (`reasoning.mode=pro`). Repeatable.

**`--effort-override <level>`** — pins reasoning effort verbatim and skips
`clampToAdvertisedEffort()`. Deliberately **not** `--effort`: that name belongs to
Claude Code and claudish forwards it untouched in `claudeArgs` (pinned by
`cli-passthrough.test.ts`). The two compose — `--effort` says what to ask for,
`--effort-override` says don't clamp what I asked for.

`main` centralised effort mapping since July, so this is two methods in
`base-api-format.ts`, not the eight dialect files the port anticipated.

**`--pro-on-ultracode`** (opt-in, default OFF) — applies a model's catalog
provider-preset while the session is in ultracode.

## No hardcoded model gate

The port arrived with `isProCapableModel = /gpt-5\.6/.test(name)` and a hardcoded
`{reasoning:{mode:"pro"}}` payload. That violates the CLAUDE.md "never hardcode
rosters" invariant and is why the work never merged.

Both are gone. The catalog already carries the fact under `routeVariant`:

```
gpt-5.6-sol-pro → {baseModelId: "gpt-5.6-sol", provider: "openrouter",
                   preset: "reasoning.mode=pro"}
```

`baseModelId` replaces the regex; `preset` replaces the payload. And
`parseModelParams("reasoning.mode=pro")` already returns `{reasoning:{mode:"pro"}}`,
so the `--model-params` parser doubles as the preset parser — the two features
converge rather than sitting side by side. A cold cache or an absent variant means
no injection, which is the correct default: absence never asserts a fact.

## The gate is provider-scoped, and that is load-bearing

Measured against each vendor with real requests:

| Vendor | `reasoning.mode=pro` |
|---|---|
| `openrouter` | accepted (200) |
| `openai` (`api.openai.com/v1/responses`) | accepted (200) |
| `openai-codex` (ChatGPT OAuth backend) | **400** — `` `reasoning.mode` is not supported with this model `` |

Neither OpenRouter-only nor universal. An unscoped injection would hard-400 every
ultracode turn on `cx@`, the most likely route for this family. Verified live in
both directions: on `openrouter` the injection fires and returns 200; on `cx@`,
with `--pro-on-ultracode` explicitly on and a genuine ultracode session, the layer
tails the transcript, tracks state, and **declines to inject** — 0 errors.

`openai` accepting it means the catalog under-reports reality. Filed in the
models-index repo as `TASK_pro_preset_vendor_coverage.md` rather than worked
around here.

## Two bugs that shipped green

Both were invisible to the suite and only a live interactive run exposed them.

**The layer was inert in production.** `applyProInjection()` read
`registry.getState()`, but nothing ever called `ensureSession()` — `getState()`
returns `undefined` until a tailer exists, so the injection could never fire on any
request. The tests passed because their own `makeHome()` helper called
`ensureSession()`. A test that performs setup the production path never performs
cannot fail for the right reason.

**Vendor-prefixed ids matched nothing.** On the OpenRouter route a bare name still
carries its vendor prefix (`openai/gpt-5.6-sol`) because OpenRouter requires it,
while the catalog records `gpt-5.6-sol`. A raw string compare missed on precisely
the one provider whose presets the catalog records. Both sides now share
`stripVendorPrefix()` with `findCacheEntry()`.

## Also fixed

**Probe prefix doubling** — `--probe openrouter@gpt-5.6-sol` rendered
`openrouter@openrouter@gpt-5.6-sol`. `buildDirectRowData` concatenated
`${nativeProvider}@${model}` with no guard, but `model` is raw user input.
Display-only, which is why it survived. Now reuses `pinProbeModelSpec()`, which
already owns the rule (and keeps `native-anthropic` bare).

**Six failing tests, wrongly written off as environmental.** The credential
authority resolves env → aliases → config → **keychain** → op://.
`routing-rules.test.ts` isolated the first and last only — it cleared env vars and
set `CLAUDISH_DISABLE_OP=1` but never the keychain twin. On a machine with
`keychain.enabled: true`, `route()` resolved real credentials and every "no
credentials" assertion failed.

`keychain-source.ts:91` already shipped `CLAUDISH_DISABLE_KEYCHAIN=1`, its comment
describing it as "mirroring CLAUDISH_DISABLE_OP". The pairing was never completed
because these tests predate the keychain source. Bisected by env var: `70/0` with
the flag, `64/6` without, on identical code. The gap was systemic — 8 files set one
flag without the other; fixed the four with credential-absence assertions.

No assertion weakened, no test deleted. The assertions were right; the isolation
was not.

## Verification

- `bun run typecheck` — clean, both packages
- `bun run lint` — 0 errors
- `bun run test` — **2985 pass / 14 skip / 0 fail over 2999**, first fully green run
- CI-approximating run (no credentials, `CLAUDISH_SKIP_LIVE_E2E=1`) — 2981/18/0

Every regression test here was verified to **fail when its fix is reverted**,
including the ordering invariant: swapping 5a-pre after the 5a merge makes the
injected `pro` silently override an explicit user `--model-params`.

## Known pre-existing flake

`SessionManager > G1/G2: timeout stays timeout…` is load-sensitive: 8/8 green in
isolation, but it failed 2 of 3 full-suite preflight runs under load. It spawns a
real child and waits for a 1s timeout inside a 10s budget. Untouched by this PR —
if CI goes red on that test alone, re-run it.

## Parked, with triggers

`ROADMAP.md` records why the pro-preset gate stays provider-scoped and why
`--effort-override` accepts only the seven canonical levels, each with an explicit
trigger condition for widening.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
