### PR TITLE
test: cover the probe spec column, and fix a structurally-flaky timeout test

### DIFF
--- a/packages/cli/src/channel/session-manager.test.ts
+++ b/packages/cli/src/channel/session-manager.test.ts
@@ -33,6 +33,10 @@ const __dirname = dirname(__filename);
 const FAKE_CLAUDISH_TS = join(__dirname, "test-helpers", "fake-channel-stream-json.ts");
 const SIGNAL_CHILD_TS = join(__dirname, "test-helpers", "stats-buffer-signal-child.ts");
 const TERMINAL_STATUSES: readonly SessionStatus[] = ["completed", "failed", "cancelled", "timeout"];
+// Must match KILL_GRACE_MS in session-manager.ts:210; post-SIGTERM waits must exceed it.
+const KILL_GRACE_MS = 5000;
+const POST_SIGTERM_WAIT_MS = KILL_GRACE_MS + 2000;
+const TIMEOUT_REGRESSION_TEST_MS = POST_SIGTERM_WAIT_MS * 2 + 1000;
 
 const ORIGINAL_CLAUDISH_BIN = process.env.CLAUDISH_BIN;
 let sessionsDir: string;
@@ -341,40 +345,48 @@ describe("SessionManager", () => {
     expect(manager.cancelSession("ghost-session")).toBe(false);
   });
 
-  test("G1/G2: timeout stays timeout in memory, meta, and on the wire", async () => {
-    const events: ChannelEvent[] = [];
-    const timeoutManager = makeManager({
-      onStateChange: (_sessionId, event) => events.push(event),
-    });
-    const id = timeoutManager.createSession({
-      model: "test-model",
-      timeoutSeconds: 1,
-      claudishFlags: ["--result-then-hang", "--trap-term-exit-zero"],
-    });
+  test(
+    "G1/G2: timeout stays timeout in memory, meta, and on the wire",
+    async () => {
+      const events: ChannelEvent[] = [];
+      const timeoutManager = makeManager({
+        onStateChange: (_sessionId, event) => events.push(event),
+      });
+      const id = timeoutManager.createSession({
+        model: "test-model",
+        timeoutSeconds: 1,
+        claudishFlags: ["--result-then-hang", "--trap-term-exit-zero"],
+      });
 
-    await waitForStatus(timeoutManager, id, ["running"]);
-    expect(timeoutManager.sendInput(id, "interactive turn")).toBe(true);
-    await waitForStatus(timeoutManager, id, ["waiting_for_input"]);
+      await waitForStatus(timeoutManager, id, ["running"]);
+      expect(timeoutManager.sendInput(id, "interactive turn")).toBe(true);
+      await waitForStatus(timeoutManager, id, ["waiting_for_input"]);
 
-    const metaPath = await waitForMeta(id, 4000);
-    const info = timeoutManager.getSession(id);
-    const meta = JSON.parse(readFileSync(metaPath, "utf-8")) as {
-      status: string;
-      exitCode: number | null;
-    };
-    const terminalWireEvents = events
-      .map((event) => event.type)
-      .filter((type) => TERMINAL_STATUSES.includes(type as SessionStatus));
+      // If the SIGTERM trap loses its race, SIGKILL follows only after the full
+      // grace, then exit, pipe drain, and writeArtifacts must finish. Keep these
+      // polling budgets above KILL_GRACE_MS or load makes this a fast-path-only test.
+      await waitForStatus(timeoutManager, id, ["timeout"], POST_SIGTERM_WAIT_MS);
+      const metaPath = await waitForMeta(id, POST_SIGTERM_WAIT_MS);
+      const info = timeoutManager.getSession(id);
+      const meta = JSON.parse(readFileSync(metaPath, "utf-8")) as {
+        status: string;
+        exitCode: number | null;
+      };
+      const terminalWireEvents = events
+        .map((event) => event.type)
+        .filter((type) => TERMINAL_STATUSES.includes(type as SessionStatus));
 
-    // Same test, deliberately: memory, persistent data, and the wire must all
-    // report the honest terminal reason. SEP-1686 projects timeout to failed.
-    expect(info.status).toBe("timeout");
-    expect(meta.status).toBe("timeout");
-    expect(info.exitCode).toBe(0);
-    expect(meta.exitCode).toBe(0);
-    expect(terminalWireEvents).toEqual(["timeout"]);
-    expect(events.some((event) => event.type === "timeout")).toBe(true);
-  }, 10_000);
+      // Same test, deliberately: memory, persistent data, and the wire must all
+      // report the honest terminal reason. SEP-1686 projects timeout to failed.
+      expect(info.status).toBe("timeout");
+      expect(meta.status).toBe("timeout");
+      expect(info.exitCode).toBe(0);
+      expect(meta.exitCode).toBe(0);
+      expect(terminalWireEvents).toEqual(["timeout"]);
+      expect(events.some((event) => event.type === "timeout")).toBe(true);
+    },
+    TIMEOUT_REGRESSION_TEST_MS
+  );
 
   test("G7: a promptless session reaches a usable state and accepts later input", async () => {
     const id = manager.createSession({ model: "test-model", timeoutSeconds: 5 });

--- a/packages/cli/src/probe/probe-results-printer.test.ts
+++ b/packages/cli/src/probe/probe-results-printer.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { type ModelResult, printProbeResults } from "./probe-results-printer.js";
+
+// Keep this in sync with the printer's local ANSI-stripping expression.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequences require control chars
+const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g;
+
+function renderDirectSpec(nativeProvider: string, model: string): string {
+  let output = "";
+  const originalWrite = process.stderr.write;
+  process.stderr.write = ((chunk: string | Uint8Array) => {
+    output += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  }) as typeof process.stderr.write;
+
+  try {
+    // The direct-row path reads only these fields. Keep the fixture minimal so
+    // any new dependency in the display path is explicit in this test.
+    const result = {
+      model,
+      nativeProvider,
+      routingSource: "direct",
+      chain: [],
+    } as unknown as ModelResult;
+
+    printProbeResults([result], false);
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+
+  const cells = output
+    .replace(ANSI_RE, "")
+    .split("\n")
+    .map((line) => line.split("│").map((cell) => cell.trim()))
+    .find((row) => row[1] === "1" && row[2] === nativeProvider);
+
+  expect(cells).toBeDefined();
+  return cells?.[3] ?? "";
+}
+
+describe("printProbeResults direct Model Spec", () => {
+  test("does not double an explicit provider prefix", () => {
+    const spec = renderDirectSpec("openrouter", "openrouter@gpt-5.6-sol");
+
+    expect({ spec, atCount: spec.match(/@/g)?.length ?? 0 }).toEqual({
+      spec: "openrouter@gpt-5.6-sol",
+      atCount: 1,
+    });
+  });
+
+  test("prefixes a bare model input", () => {
+    expect(renderDirectSpec("openrouter", "gpt-5.6-sol")).toBe("openrouter@gpt-5.6-sol");
+  });
+
+  test("keeps native-anthropic model inputs bare", () => {
+    const spec = renderDirectSpec("native-anthropic", "claude-opus-4-7");
+
+    // Prefixing this sets hasExplicitProvider=true and routes away from the
+    // passthrough, so native-anthropic must remain special-cased.
+    expect(spec).toBe("claude-opus-4-7");
+    expect(spec).not.toContain("@");
+  });
+
+  test("prefixes a slash-qualified vendor model input", () => {
+    expect(renderDirectSpec("openrouter", "openai/gpt-5.6-sol")).toBe(
+      "openrouter@openai/gpt-5.6-sol"
+    );
+  });
+});


### PR DESCRIPTION
Test-only follow-up to #220 / v7.67.0. Closes the two gaps that release left open.
No production code changed.

## 1. `probe/` had zero tests

The v7.67.0 fix for `--probe openrouter@gpt-5.6-sol` rendering
`openrouter@openrouter@gpt-5.6-sol` shipped with nothing guarding it. The whole
directory had no test file — the two "probe tests" live in `probe-runner.test.ts`
and never touch row rendering. That gap is exactly why a user-visible bug shipped
in the first place.

Adds `probe-results-printer.test.ts` covering the direct row's Model Spec cell:

- explicit prefix is not doubled — asserts the **count** of `@`, not just equality,
  so the intent is legible
- a bare model input still gets prefixed
- `native-anthropic` stays **bare** — prefixing it sets `hasExplicitProvider=true`
  and routes it away from the passthrough, so a naive "always prefix" fix would
  break it
- a slash-qualified vendor id (`openai/gpt-5.6-sol`) is not mistaken for a
  provider prefix

`buildDirectRowData` is not exported, so the test drives `printProbeResults` and
reads the rendered cell back rather than exporting internals just for a test.

**Perturbation-verified**: restoring the old `${nativeProvider}@${model}`
concatenation fails case 1 with the real symptom —

```
- "atCount": 1,  "spec": "openrouter@gpt-5.6-sol"
+ "atCount": 2,  "spec": "openrouter@openrouter@gpt-5.6-sol"
```

## 2. G1/G2 waited less time than the path it was waiting on

`SessionManager > G1/G2: timeout stays timeout…` was 8/8 green in isolation but
failed **2 of 3** full-suite runs under load, at ~5091ms — notably *not* at its 10s
test budget.

That is not vague flakiness. The test called `waitForMeta(id, 4000)`, while the
chain it awaits is:

1. the 1s timeout fires → `SIGTERM`
2. `SIGKILL` is armed at `KILL_GRACE_MS` = **5000** (`session-manager.ts:210`)
3. the child must exit, pipes must drain, `finalize()` runs
4. `meta.json` is written by `writeArtifacts` at the **very end** of `finalize`

So the budget sat below the grace period *alone*. Whenever the child's SIGTERM trap
lost the race, the file provably could not exist yet, and the test passed only on
the fast path. `waitForMeta`'s own default is 5000 — this call had been given
**less** than the default for the wait that needed the most slack.

Fixed by waiting for the observable `timeout` status transition before waiting for
the artifact, with both budgets derived from a mirrored `KILL_GRACE_MS` rather than
a magic number, so raising that constant cannot silently reintroduce the flake. A
comment records the reasoning, since `4000` looks arbitrary without it.

No assertion weakened, no test deleted, no production code touched. The four
expects about `info.status`, `meta.status`, `exitCode` and `terminalWireEvents` are
the point of the test and are unchanged.

## Verification

CI-approximating suite (credential-free, `CLAUDISH_SKIP_LIVE_E2E=1`), run 3×:

| run | result | G1/G2 failures |
|---|---|---|
| 1 | 2985 pass / 18 skip / 0 fail (3003) | 0 |
| 2 | 2985 pass / 18 skip / 0 fail (3003) | 0 |
| 3 | 2984 pass / 18 skip / 2 fail (3004) | 0 |

**0 occurrences of the G1/G2 failure across all three**, against 2 of 3 before.

Run 3's two failures are unrelated and documented: `glm-5-turbo … [30001.01ms]` is
the known live-API timeout under load, and the collected count shifting 3003 → 3004
shows a credential gate opened for a live test. Different tier, different cause.

Also: `session-manager.test.ts` 36/36 across 8 consecutive isolated runs, typecheck
clean, biome 0 errors.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
