### PR TITLE
fix: stop text tool-call recovery dispatching mangled tool names

### DIFF
--- a/ai-docs/architecture/adapters.md
+++ b/ai-docs/architecture/adapters.md
@@ -46,6 +46,39 @@ Located in `handlers/shared/stream-parsers/`:
 - `ollama-jsonl.ts` — Ollama JSONL → Claude SSE
 - `openai-responses-sse.ts` — OpenAI Responses API → Claude SSE (Codex)
 
+## Text-based tool recovery is a fallback, and it is load-bearing on the busiest wire
+
+`openai-sse.ts` calls `extractToolCallsFromText` (`handlers/shared/tool-call-recovery.ts`)
+at finalization. That function scrapes tool calls out of assistant PROSE, for local models
+that cannot emit structured `tool_calls` at all. It is the only production caller, so this
+path is exactly the `openai-sse` roster: GLM, Kimi, Grok, DeepSeek, Qwen, OpenRouter, LiteLLM.
+
+Three properties are not obvious from the source and each one shipped as a defect
+(v7.68.0, `ai-docs/reports/grok-tool-name-mangling-20260827.md`):
+
+1. **It must not run when the model already emitted a structured call.** Recovery can only
+   ADD calls, never repair one. Ungated, a turn holding one real call plus prose mentioning
+   a function tag dispatched TWO `tool_use` blocks. The gate is `state.tools.size > 0`.
+2. **Every pattern needs the allowlist, not just the last one.** The function stacks six
+   patterns; only Pattern 5 (natural language) had a `knownTools` guard, and its `continue`
+   reads like a function-wide filter. Patterns 0–4 had none. The allowlist is now the
+   request's own advertised tool list, applied to the return value of all six.
+3. **A tool name is an identifier, and nothing else may occupy that slot.** Pattern 0 matched
+   `<function=([^>]+)>`, which accepts every character except `>`. A `<function=` opened in
+   prose swallowed everything up to the next `>`, so parameter names and ARGUMENT VALUES
+   became the tool name. `TOOL_NAME_SHAPE` (`adapters/tool-name-utils.ts`) is the one
+   definition; `hasExtractableFunctionTag` exists so the parser's text hold-back test cannot
+   drift from what the extractor accepts. Drift there withheld text that nothing later emitted.
+
+`TokenTracker.recordToolUse` re-checks the shape and buckets a failure under `malformed`.
+The map is written to `stats/*.json` and printed in the session summary, neither of which is
+redacted, so a swallowed argument value must never reach it.
+
+**Observation and dispatch are the same event.** `onToolCallObserved` is hooked inside
+`send()`, the single frame writer (`openai-sse.ts`), not at the `content_block_start` sites.
+That makes "a tool name was only mis-REPORTED" impossible: anything counted in the stats was
+also dispatched to Claude Code.
+
 ## Errors that ride an HTTP 200 stream (`stream-head-sniffer.ts`)
 
 The Codex backend (`chatgpt.com/backend-api/codex/responses`) reports capacity faults **inside** a 200 body, not via the status code:

--- a/ai-docs/reports/grok-tool-name-mangling-20260827.md
+++ b/ai-docs/reports/grok-tool-name-mangling-20260827.md
@@ -1,0 +1,175 @@
+# Tool names are mangled on the openai-sse wire (grok-subscription)
+
+**Date:** 2026-08-27
+**Area:** Layer 1/2 stream translation, tool-call parsing
+**Severity:** high — the malformed name was DISPATCHED, not only recorded
+**Status:** root-caused, fixed, reproduced before and after
+
+> This supersedes the first draft of this report. That draft named a leading
+> hypothesis that is wrong, ruled out a path that is in fact the cause, and left
+> the severity question open. All three are corrected below, with the runs.
+
+---
+
+## Summary
+
+A `gk@grok-4.6` run recorded a tool call whose NAME is a concatenation of a tool
+name, a parameter name, a type fragment, and an argument value:
+
+```
+web_search_query_listOpposed["macos security add-generic-password -X hex password flag"]
+```
+
+Three defects combined to produce it. All three are on `openai-sse`, the busiest
+wire in claudish.
+
+| # | Defect | Site |
+|---|---|---|
+| 1 | Text extraction ran even when the model already emitted a structured tool call | `openai-sse.ts` finalize |
+| 2 | Only Pattern 5 of six had an allowlist; Patterns 0–4 had none | `tool-call-recovery.ts` |
+| 3 | Pattern 0 captured `[^>]+`, so prose became a tool name | `tool-call-recovery.ts` |
+
+---
+
+## Environment
+
+| | |
+|---|---|
+| Model spec | `gk@grok-4.6+x-ai@grok-4.6+or@x-ai/grok-4.6` |
+| Provider | Grok-subscription (`"provider_name":"Grok-subscription"`) |
+| Wire | `openai-sse` |
+| Host | macOS (darwin 25.6.0) |
+
+---
+
+## Root cause
+
+`extractToolCallsFromText` scrapes tool calls out of assistant prose, for local
+models that cannot emit structured `tool_calls`. Its Pattern 0 read:
+
+```ts
+const qwenPattern = /<function=([^>]+)>([\s\S]*?)(?=<function=|$)/gi;
+```
+
+`[^>]+` accepts every character except `>`. There was no length bound, no
+character class, and no allowlist. A model that opened `<function=` in prose had
+every following character up to the next `>` taken as the tool name.
+
+Running the real function against candidate inputs, before the fix:
+
+```
+--- qwen style, name swallows all
+    name="web_search_query_listOpposed[\"macos security add-generic-password -X hex password flag\"]" source=xml_text args={}
+    *** EXACT MATCH TO REPORTED NAME ***
+--- arbitrary garbage name
+    name="TOTALLY_NOT_A_TOOL_$$$" source=xml_text args={"x":"1"}
+```
+
+### What the first draft got wrong
+
+**The leading hypothesis was wrong.** It proposed that the parser appends
+`function.name` deltas without respecting index boundaries. It does not append.
+The name is assigned once, inside `if (!t)`, and a later delta at the same index
+is ignored (`openai-sse.ts`, structured tool-call branch). Also cleared by
+inspection: the truncation map in `base-api-format.ts` only maps a short key to a
+longer original; `GrokModelDialect` matches `name="([^"]+)"` so its names cannot
+contain a quote; `collect-sse-message.ts` reads `block.name` without appending.
+
+**The "Ruled out" section was wrong.** The allowlist it quotes guards **Pattern 5**
+only, the natural-language pattern. Patterns 0–4 sit above it in the same
+function and had no guard. A `continue` inside one loop of a six-pattern function
+reads like a function-wide filter; it is not.
+
+---
+
+## The open question, answered: it reached the wire
+
+`onToolCallObserved` is hooked inside `send()`, the single frame writer, not at
+the `content_block_start` sites. Observation and dispatch are therefore the same
+event. Driving the real `createStreamingResponseHandler` end to end, before the fix:
+
+```
+OBSERVED (goes to stats/*.json):
+  "web_search_query_listOpposed[\"macos security add-generic-password -X hex password flag\"]"
+DISPATCHED to Claude Code (tool_use content_block_start):
+  "web_search_query_listOpposed[\"macos security add-generic-password -X hex password flag\"]"
+
+SAME SET: YES — corruption reaches the client
+```
+
+Claude Code received a `tool_use` block naming a tool that does not exist. The
+turn was lost. Severity is high, not medium.
+
+---
+
+## The three records explained
+
+The stats file held three entries (`web_search`, `WebSearch`, and the malformed
+one) for what looked like one or two real calls. `extractToolCallsFromText` ran
+unconditionally at finalization, with no check on whether structured calls had
+already arrived. One structured call plus prose mentioning a function tag, before
+the fix:
+
+```
+Model made ONE structured tool call. Recorded tool names:
+  "WebSearch"
+  "web_search"
+count = 2
+```
+
+---
+
+## Fix
+
+| # | Change | File |
+|---|---|---|
+| 1 | Skip text extraction when `state.tools.size > 0`; pass the request's advertised tool names to the extractor | `handlers/shared/stream-parsers/openai-sse.ts` |
+| 2 | New optional `knownToolNames` parameter; `keepOnlyRealTools` applied to the return of all six patterns | `handlers/shared/tool-call-recovery.ts` |
+| 3 | Pattern 0 bounded to `TOOL_NAME_SOURCE`; `hasExtractableFunctionTag` exported so the parser's hold-back test cannot drift from it | `handlers/shared/tool-call-recovery.ts` |
+| 4 | `recordToolUse` buckets a non-identifier name under `malformed` | `handlers/shared/token-tracker.ts` |
+| 5 | `TOOL_NAME_SOURCE` / `TOOL_NAME_SHAPE` as the single definition | `adapters/tool-name-utils.ts` |
+
+Fix 3 needed fix 5's shared constant for a reason worth recording: the parser's
+text hold-back test used its own loose copy of the pattern. Tightening only the
+extractor would have left text that matches the hold-back test but not the
+extractor withheld from the client and then never emitted, a silent text loss
+with no tool call to show for it.
+
+### After the fix
+
+```
+--- qwen style clean
+    name="web_search" source=xml_text args={"query_list":"[\"macos security add-generic-password -X hex password flag\"]"}
+--- qwen style, name swallows all
+    (none)
+--- arbitrary garbage name
+    (none)
+--- unclosed function tag mid-prose
+    (none)
+```
+
+The legitimate recovery path, which is the reason this code exists, still works.
+The duplicate-dispatch case now reports `count = 1`.
+
+Suite: **2986 pass, 17 skip, 0 fail** (`packages/cli`).
+
+---
+
+## Still unknown
+
+Grok's raw bytes were not recovered. The session directory
+`/Users/jack/mag/madbench/.claude/worktrees/keychain/ai-docs/sessions/team-20260827-0015`
+no longer exists, and a sweep of `/Users/jack/mag` and `~/.claude` found no
+surviving copy of the malformed name. This is the `ai-docs/sessions/` loss mode
+`CLAUDE.md` warns about: gitignored, and removed with the worktree.
+
+The mechanism is proven and reproduced. The exact text Grok emitted is not known.
+Confirming it needs a `gk@grok-4.6` run with `--debug` on a task that provokes a
+web search.
+
+---
+
+## Related
+
+The `web_search` tool itself is unimplemented: `handlers/shared/web-search-detector.ts`
+is a v1 stub that warns and passes through. Tracked separately.

--- a/packages/cli/src/adapters/tool-name-utils.ts
+++ b/packages/cli/src/adapters/tool-name-utils.ts
@@ -8,6 +8,20 @@
 import { log } from "../logger.js";
 
 /**
+ * The character shape of a tool name, as a pattern fragment.
+ *
+ * Every tool Claude Code advertises is an identifier. Anything else that reaches
+ * a "tool name" slot is text some parser swallowed, and swallowed text carries
+ * argument VALUES. Kept here so the text extractor and the stats recorder hold
+ * the same line: see `handlers/shared/tool-call-recovery.ts` and
+ * `handlers/shared/token-tracker.ts`.
+ */
+export const TOOL_NAME_SOURCE = "[A-Za-z_][A-Za-z0-9_.-]{0,63}";
+
+/** Anchored form of {@link TOOL_NAME_SOURCE}. Stateless, so it is safe to share. */
+export const TOOL_NAME_SHAPE = new RegExp(`^${TOOL_NAME_SOURCE}$`);
+
+/**
  * Simple deterministic string hash that produces an 8-char hex string.
  * Used for tool name truncation to avoid collisions.
  */

--- a/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
@@ -12,6 +12,7 @@ import { log } from "../../../logger.js";
 import {
   type ToolSchema,
   extractToolCallsFromText,
+  hasExtractableFunctionTag,
   validateAndRepairToolCall,
 } from "../tool-call-recovery.js";
 import { isWebSearchToolCall, warnWebSearchUnsupported } from "../web-search-detector.js";
@@ -261,7 +262,24 @@ export function createStreamingResponseHandler(
 
             // Check for text-based tool calls before finalizing
             // Some models (like Qwen) output tool calls as text instead of structured tool_calls
-            const textToolCalls = extractToolCallsFromText(state.accumulatedText);
+            //
+            // Only when the model produced NO structured call. Recovery exists for
+            // models that cannot emit `tool_calls` at all; against a model that
+            // just did, it can only ADD calls, never repair one. Ungated, a turn
+            // holding one real call plus prose mentioning a function tag dispatched
+            // two tool_use blocks, and both were recorded.
+            const textToolCalls =
+              state.tools.size > 0
+                ? []
+                : extractToolCallsFromText(
+                    state.accumulatedText,
+                    toolSchemas?.map((t: any) => t?.name).filter((n: any): n is string => !!n)
+                  );
+            if (state.tools.size > 0 && state.accumulatedText.length > 0) {
+              log(
+                `[Streaming] Skipping text-based tool extraction: ${state.tools.size} structured tool call(s) already present`
+              );
+            }
             log(`[Streaming] Text-based tool calls found: ${textToolCalls.length}`);
             if (textToolCalls.length > 0) {
               log(
@@ -578,8 +596,11 @@ export function createStreamingResponseHandler(
                       // Only hold back for patterns we can actually parse (XML, JSON), not natural language
                       // Natural language patterns are extracted at finalization, not held back
                       const hasStructuredToolPattern =
-                        // Qwen XML-style: <function=ToolName>
-                        /<function=[^>]+>/.test(state.accumulatedText) ||
+                        // Qwen XML-style: <function=ToolName>. Same shape the
+                        // extractor accepts, so text held back here is always text
+                        // the extractor can act on. A looser test here withheld
+                        // text that nothing later emitted.
+                        hasExtractableFunctionTag(state.accumulatedText) ||
                         // JSON tool call in text: {"name": "Task", "arguments":
                         /\{\s*"(?:name|tool)"\s*:\s*"(?:Task|Read|Write|Edit|Bash|Grep|Glob)"/i.test(
                           state.accumulatedText

--- a/packages/cli/src/handlers/shared/stream-parsers/tool-name-mangling.test.ts
+++ b/packages/cli/src/handlers/shared/stream-parsers/tool-name-mangling.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "bun:test";
+
+import { createStreamingResponseHandler } from "./openai-sse.js";
+
+const ctx: any = {
+  body: (stream: any, init: any) => new Response(stream, init),
+  json: () => {
+    throw new Error("Unexpected no-body error path");
+  },
+};
+
+const adapter = {
+  getToolNameMap: () => new Map([["web_search", "WebSearch"]]),
+  processTextContent: (text: string) => ({
+    cleanedText: text,
+    extractedToolCalls: [],
+    wasTransformed: false,
+  }),
+};
+
+const toolSchemas = [
+  {
+    name: "Read",
+    input_schema: {
+      type: "object",
+      properties: { file_path: { type: "string" } },
+      required: ["file_path"],
+    },
+  },
+  {
+    name: "WebSearch",
+    input_schema: {
+      type: "object",
+      properties: { query: { type: "string" } },
+      required: ["query"],
+    },
+  },
+];
+
+const sseResponse = (frames: string[]) =>
+  new Response(
+    new ReadableStream({
+      start(controller) {
+        const encoder = new TextEncoder();
+        for (const frame of frames) controller.enqueue(encoder.encode(frame));
+        controller.close();
+      },
+    }),
+    { headers: { "content-type": "text/event-stream" } }
+  );
+
+const dataFrame = (data: unknown) => `data: ${JSON.stringify(data)}\n\n`;
+
+const textFrame = (content: string) =>
+  dataFrame({ choices: [{ delta: { content }, finish_reason: null }] });
+
+const finishFrame = (finishReason: "stop" | "tool_calls") =>
+  dataFrame({ choices: [{ delta: {}, finish_reason: finishReason }] });
+
+function toolUseStarts(wire: string): any[] {
+  const starts: any[] = [];
+  for (const frame of wire.split("\n\n")) {
+    const dataLine = frame.split("\n").find((line) => line.startsWith("data: "));
+    if (!dataLine || dataLine === "data: [DONE]") continue;
+    try {
+      const data = JSON.parse(dataLine.slice(6));
+      if (data.type === "content_block_start" && data.content_block?.type === "tool_use") {
+        starts.push(data.content_block);
+      }
+    } catch {}
+  }
+  return starts;
+}
+
+async function parseFrames(frames: string[]) {
+  const observed: string[] = [];
+  const response = createStreamingResponseHandler(
+    ctx,
+    sseResponse(frames),
+    adapter,
+    "test-model",
+    null,
+    undefined,
+    toolSchemas,
+    adapter.getToolNameMap(),
+    undefined,
+    { onToolCallObserved: (name) => observed.push(name) }
+  );
+  const wire = await response.text();
+
+  return { observed, toolUses: toolUseStarts(wire) };
+}
+
+describe("openai-sse tool-name recovery", () => {
+  it("does not dispatch malformed function-tag prose", async () => {
+    const malformed =
+      '<function=web_search_query_listOpposed["macos security add-generic-password -X hex password flag"]>';
+    const result = await parseFrames([
+      textFrame(malformed),
+      finishFrame("stop"),
+      "data: [DONE]\n\n",
+    ]);
+
+    expect(result.toolUses).toEqual([]);
+    expect(result.observed).toEqual([]);
+  });
+
+  it("does not recover a second call from prose when a structured call exists", async () => {
+    const result = await parseFrames([
+      textFrame("I will use <function=web_search> for this."),
+      dataFrame({
+        choices: [
+          {
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: "call_web_search_0",
+                  type: "function",
+                  function: { name: "web_search", arguments: '{"query":"x"}' },
+                },
+              ],
+            },
+            finish_reason: null,
+          },
+        ],
+      }),
+      finishFrame("tool_calls"),
+      "data: [DONE]\n\n",
+    ]);
+
+    expect(result.toolUses).toHaveLength(1);
+    expect(result.toolUses[0].name).toBe("WebSearch");
+    expect(result.observed).toEqual(["WebSearch"]);
+  });
+
+  it("recovers an advertised Read call and rejects an unadvertised text call", async () => {
+    const recovered = await parseFrames([
+      textFrame("<function=Read><parameter=file_path>/x"),
+      finishFrame("stop"),
+      "data: [DONE]\n\n",
+    ]);
+
+    expect(recovered.toolUses).toHaveLength(1);
+    expect(recovered.toolUses[0].name).toBe("Read");
+    expect(recovered.observed).toEqual(["Read"]);
+
+    const unadvertised = await parseFrames([
+      textFrame("<function=Unadvertised><parameter=value>x"),
+      finishFrame("stop"),
+      "data: [DONE]\n\n",
+    ]);
+    expect(unadvertised.toolUses).toEqual([]);
+    expect(unadvertised.observed).toEqual([]);
+  });
+});

--- a/packages/cli/src/handlers/shared/token-tracker.test.ts
+++ b/packages/cli/src/handlers/shared/token-tracker.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { existsSync, readFileSync, unlinkSync } from "node:fs";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { TokenTracker } from "./token-tracker.js";
@@ -12,6 +12,7 @@ interface TokenFile {
 }
 
 const createdTokenFiles = new Set<string>();
+const originalTokenFile = process.env.CLAUDISH_TOKEN_FILE;
 let nextPort = 50_000 + (process.pid % 10_000);
 
 function createTracker(contextWindow = 400_000): {
@@ -23,10 +24,11 @@ function createTracker(contextWindow = 400_000): {
 
   do {
     port = nextPort++;
-    tokenFile = join(homedir(), ".claudish", `tokens-${port}.json`);
+    tokenFile = join(tmpdir(), `claudish-token-tracker-${process.pid}-${port}.json`);
   } while (existsSync(tokenFile));
 
   createdTokenFiles.add(tokenFile);
+  process.env.CLAUDISH_TOKEN_FILE = tokenFile;
 
   return {
     tracker: new TokenTracker(port, {
@@ -47,6 +49,8 @@ afterEach(() => {
     if (existsSync(path)) unlinkSync(path);
   }
   createdTokenFiles.clear();
+  if (originalTokenFile === undefined) delete process.env.CLAUDISH_TOKEN_FILE;
+  else process.env.CLAUDISH_TOKEN_FILE = originalTokenFile;
 });
 
 describe("TokenTracker live input-token tracking", () => {
@@ -134,5 +138,26 @@ describe("TokenTracker live input-token tracking", () => {
     expect(tracker.getInputTokens()).toBe(300_000);
     expect(tracker.getLastInputTokens()).toBe(20_000);
     expect(readTokenFile(tokenFile).input_tokens).toBe(20_000);
+  });
+});
+
+describe("TokenTracker tool-name accounting", () => {
+  test("redacts malformed names without changing unknown, normal, or total counts", () => {
+    const { tracker } = createTracker();
+    const malformed = 'web_search_query_listOpposed["private argument value"]';
+
+    tracker.recordToolUse(malformed);
+    tracker.recordToolUse("   ");
+    tracker.recordToolUse("Read");
+    tracker.recordToolUse("Read");
+
+    const toolCalls = tracker.getToolCalls();
+    expect(toolCalls).toEqual([
+      { name: "Read", count: 2 },
+      { name: "malformed", count: 1 },
+      { name: "unknown", count: 1 },
+    ]);
+    expect(JSON.stringify(toolCalls)).not.toContain(malformed);
+    expect(tracker.getToolCallCount()).toBe(4);
   });
 });

--- a/packages/cli/src/handlers/shared/token-tracker.ts
+++ b/packages/cli/src/handlers/shared/token-tracker.ts
@@ -13,6 +13,7 @@
 import { mkdirSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
+import { TOOL_NAME_SHAPE } from "../../adapters/tool-name-utils.js";
 import { type PlanUsage, isPlanStale } from "../../auth/quota/types.js";
 import { log } from "../../logger.js";
 import { type ModelPricing, getModelPricing } from "./remote-provider-types.js";
@@ -109,7 +110,14 @@ export class TokenTracker {
    * transcript.
    */
   recordToolUse(name: string): void {
-    const key = name.trim() || "unknown";
+    const trimmed = name.trim();
+    // A tool name is an identifier. A name that is not one did not come from a
+    // tool: it is text a parser swallowed, and it can carry ARGUMENT VALUES.
+    // This map is written to `stats/*.json` and printed in the session summary,
+    // neither of which is a redacted surface, so the value must not land here.
+    // The call is still counted, under `malformed`, so the total keeps agreeing
+    // with the transcript.
+    const key = !trimmed ? "unknown" : TOOL_NAME_SHAPE.test(trimmed) ? trimmed : "malformed";
     this.toolCallsByName.set(key, (this.toolCallsByName.get(key) ?? 0) + 1);
   }
 

--- a/packages/cli/src/handlers/shared/tool-call-recovery.test.ts
+++ b/packages/cli/src/handlers/shared/tool-call-recovery.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+
+import { extractToolCallsFromText, hasExtractableFunctionTag } from "./tool-call-recovery.js";
+
+describe("extractToolCallsFromText tool-name validation", () => {
+  it("rejects a swallowed argument value without breaking Qwen-style recovery", () => {
+    const malformed =
+      '<function=web_search_query_listOpposed["macos security add-generic-password -X hex password flag"]>';
+
+    expect(extractToolCallsFromText(malformed)).toEqual([]);
+
+    const recovered = extractToolCallsFromText('<function=web_search><parameter=query_list>["x"]');
+    expect(recovered).toHaveLength(1);
+    expect(recovered[0]).toMatchObject({
+      name: "web_search",
+      arguments: { query_list: '["x"]' },
+    });
+  });
+
+  it("drops well-shaped unadvertised names only when an allowlist is supplied", () => {
+    const text = "<function=Unadvertised><parameter=value>x";
+
+    expect(extractToolCallsFromText(text, ["Read"])).toEqual([]);
+    expect(extractToolCallsFromText(text)).toEqual([
+      {
+        name: "Unadvertised",
+        arguments: { value: "x" },
+        source: "xml_text",
+      },
+    ]);
+  });
+
+  it("canonicalizes an advertised tool name case-insensitively", () => {
+    expect(extractToolCallsFromText("<function=read>", ["Read"])).toEqual([
+      {
+        name: "Read",
+        arguments: {},
+        source: "xml_text",
+      },
+    ]);
+  });
+
+  it("rejects tool names longer than 64 characters", () => {
+    const tooLong = `A${"a".repeat(64)}`;
+
+    expect(extractToolCallsFromText(`<function=${tooLong}>`)).toEqual([]);
+  });
+
+  it("detects exactly the function tags that Pattern 0 can extract", () => {
+    const valid = "<function=Read>";
+    const invalid = "<function=not a name!>";
+
+    expect(hasExtractableFunctionTag(valid)).toBe(true);
+    expect(extractToolCallsFromText(valid)).toHaveLength(1);
+    expect(hasExtractableFunctionTag(invalid)).toBe(false);
+    expect(extractToolCallsFromText(invalid)).toEqual([]);
+  });
+});

--- a/packages/cli/src/handlers/shared/tool-call-recovery.ts
+++ b/packages/cli/src/handlers/shared/tool-call-recovery.ts
@@ -8,6 +8,7 @@
  * 3. Retry prompt generation with error feedback
  */
 
+import { TOOL_NAME_SHAPE, TOOL_NAME_SOURCE } from "../../adapters/tool-name-utils.js";
 import { log } from "../../logger.js";
 
 export interface ExtractedToolCall {
@@ -27,15 +28,88 @@ export interface ToolSchema {
 }
 
 /**
+ * A tool name is an identifier, so the extractors must never accept anything else.
+ *
+ * Pattern 0 below used to capture `[^>]+`, which accepts every character except
+ * `>`. A model that opened `<function=` in prose and closed it 80 characters
+ * later had all 80 characters taken as the tool name — parameter names, type
+ * fragments and ARGUMENT VALUES included. One such name reached a client:
+ * `web_search_query_listOpposed["macos security add-generic-password …"]`.
+ * See `ai-docs/reports/grok-tool-name-mangling-20260827.md`.
+ */
+const FUNCTION_TAG_SOURCE = `<function=(${TOOL_NAME_SOURCE})>([\\s\\S]*?)(?=<function=|$)`;
+
+/** Unanchored, no `g` flag, so it holds no `lastIndex` and is safe to share. */
+const FUNCTION_TAG_PRESENT = new RegExp(`<function=${TOOL_NAME_SOURCE}>`);
+
+/**
+ * Does this text hold a `<function=NAME>` tag Pattern 0 can actually extract?
+ *
+ * Exported so the openai-sse hold-back test uses the SAME shape the extractor
+ * uses. When the two drifted, text matching the loose hold-back test but not the
+ * extractor was withheld from the client and then never emitted at all: a silent
+ * text loss with no tool call to show for it. Called once per streamed chunk, so
+ * the pattern is built once at module load rather than per call.
+ */
+export function hasExtractableFunctionTag(text: string): boolean {
+  return FUNCTION_TAG_PRESENT.test(text);
+}
+
+/**
+ * Drop extracted calls that are not real tools.
+ *
+ * Two gates. The shape gate rejects a name that is not an identifier, which is
+ * how a swallowed argument value is caught. The allowlist gate rejects a
+ * well-shaped name the client never advertised, which is how a hallucinated tool
+ * is caught. The allowlist is the request's own tool list, so it is exact rather
+ * than a hardcoded roster.
+ */
+function keepOnlyRealTools(
+  extracted: ExtractedToolCall[],
+  knownToolNames?: string[]
+): ExtractedToolCall[] {
+  const kept: ExtractedToolCall[] = [];
+  for (const call of extracted) {
+    if (!TOOL_NAME_SHAPE.test(call.name)) {
+      log(
+        `[ToolRecovery] Dropped extracted call: name is not an identifier: ${JSON.stringify(
+          call.name.slice(0, 120)
+        )}`
+      );
+      continue;
+    }
+    if (!knownToolNames || knownToolNames.length === 0) {
+      kept.push(call);
+      continue;
+    }
+    const canonical = knownToolNames.find((t) => t.toLowerCase() === call.name.toLowerCase());
+    if (!canonical) {
+      log(`[ToolRecovery] Dropped extracted call for unadvertised tool: ${call.name}`);
+      continue;
+    }
+    kept.push(canonical === call.name ? call : { ...call, name: canonical });
+  }
+  return kept;
+}
+
+/**
  * Extract tool calls from text content
  * Many local models output tool calls as JSON in their text rather than using structured tool_calls
+ *
+ * `knownToolNames` is the tool list the client advertised on THIS request. Pass
+ * it whenever it is in hand: every pattern below is then held to it, not just
+ * the natural-language one.
  */
-export function extractToolCallsFromText(text: string): ExtractedToolCall[] {
+export function extractToolCallsFromText(
+  text: string,
+  knownToolNames?: string[]
+): ExtractedToolCall[] {
   const extracted: ExtractedToolCall[] = [];
 
   // Pattern 0: Qwen-style function calls <function=NAME><parameter=PARAM>VALUE
   // Example: <function=SlashCommand><parameter=command>/ls -la
-  const qwenPattern = /<function=([^>]+)>([\s\S]*?)(?=<function=|$)/gi;
+  // Fresh instance per call: a `g` regex carries `lastIndex` across calls.
+  const qwenPattern = new RegExp(FUNCTION_TAG_SOURCE, "gi");
   let match: RegExpExecArray | null;
   // biome-ignore lint/suspicious/noAssignInExpressions: canonical RegExp.exec() iteration idiom
   while ((match = qwenPattern.exec(text)) !== null) {
@@ -177,18 +251,24 @@ export function extractToolCallsFromText(text: string): ExtractedToolCall[] {
   // Matches: "I'll use the Task tool with subagent_type=Explore"
   // Matches: "I will use the Read tool to read /path/to/file"
   // Matches: "Let me use the Bash tool to run ls -la"
-  const knownTools = [
-    "Task",
-    "Read",
-    "Write",
-    "Edit",
-    "Bash",
-    "Grep",
-    "Glob",
-    "WebFetch",
-    "WebSearch",
-    "ToolSearch",
-  ];
+  // The caller's own tool list is exact; this roster is the fallback for callers
+  // that have none in hand. Natural-language extraction is the loosest pattern
+  // here, so it keeps its own guard even though `keepOnlyRealTools` runs after.
+  const knownTools =
+    knownToolNames && knownToolNames.length > 0
+      ? knownToolNames
+      : [
+          "Task",
+          "Read",
+          "Write",
+          "Edit",
+          "Bash",
+          "Grep",
+          "Glob",
+          "WebFetch",
+          "WebSearch",
+          "ToolSearch",
+        ];
   const nlPatterns = [
     // "I'll use the X tool with param=value" - ends with period, colon, newline, or end
     /(?:I(?:'ll| will| am going to)|Let me|Going to)\s+use\s+(?:the\s+)?(\w+)\s+tool\s+(?:with\s+)?(.+?)(?:[.:\n]|$)/gi,
@@ -315,7 +395,7 @@ export function extractToolCallsFromText(text: string): ExtractedToolCall[] {
     }
   }
 
-  return extracted;
+  return keepOnlyRealTools(extracted, knownToolNames);
 }
 
 /**


### PR DESCRIPTION
## The bug

A `gk@grok-4.6` run dispatched a tool call whose NAME was a concatenation of a tool name, a parameter name and an argument value:

```
web_search_query_listOpposed["macos security add-generic-password -X hex password flag"]
```

Claude Code received a `tool_use` block naming a tool that does not exist. The turn was lost.

## Root cause

Three defects on `openai-sse`, the wire that carries GLM, Kimi, Grok, DeepSeek, Qwen, OpenRouter and LiteLLM.

| # | Defect |
|---|---|
| 1 | Pattern 0 of `extractToolCallsFromText` matched `<function=([^>]+)>`. `[^>]+` accepts every character except `>`, so a `<function=` opened in prose took everything up to the next `>` as the tool name. |
| 2 | Only Pattern 5 of six had an allowlist. Its `continue` reads like a function-wide filter; Patterns 0–4 had no guard. |
| 3 | `openai-sse` ran text extraction unconditionally at finalization, so a turn with one real structured call plus prose mentioning a function tag dispatched TWO `tool_use` blocks. |

`onToolCallObserved` is hooked inside `send()`, the single frame writer, so observation and dispatch are the same event. The malformed name reached the client, not only `stats/*.json`.

## Fix

- `TOOL_NAME_SOURCE` / `TOOL_NAME_SHAPE` in `adapters/tool-name-utils.ts` as the one definition of what a tool name may look like.
- Pattern 0 bounded to that shape. `hasExtractableFunctionTag` exported so the parser's text hold-back test cannot drift from what the extractor accepts; drift there withheld text that nothing later emitted.
- `extractToolCallsFromText` takes the request's advertised tool names and holds every pattern to them, via one filter on the return value rather than a guard at each of six push sites.
- `openai-sse` skips extraction when `state.tools.size > 0`.
- `recordToolUse` buckets a non-identifier name under `malformed`, so a swallowed argument value cannot reach `stats/*.json` or the session summary. Neither is a redacted surface.

## Behavior change worth a look

The `state.tools.size > 0` gate drops text-extracted calls in a turn that also carried a structured call. If a model emits genuine parallel tool use half-structured and half in prose, that second call is now lost instead of dispatched. Judged correct: recovery exists for models that cannot emit `tool_calls` at all, and a lost call costs a retry while a phantom call wastes a turn and can carry garbage.

## Verification

Regression tests were verified by reverting all four source files to `HEAD` and re-running:

```
(fail) TokenTracker tool-name accounting > redacts malformed names without changing unknown, normal, or total counts
(fail) openai-sse tool-name recovery > does not dispatch malformed function-tag prose
(fail) openai-sse tool-name recovery > does not recover a second call from prose when a structured call exists
(fail) openai-sse tool-name recovery > recovers an advertised Read call and rejects an unadvertised text call

 7 pass
 5 fail
 1 error
```

The failure diffs are the bug itself: `Received length: 2` for the duplicate dispatch, and `Unadvertised` reaching the wire.

With the fix in place: **2995 pass, 17 skip, 0 fail**. Typecheck clean, build clean.

## Notes

- `token-tracker.test.ts` existing tests now write to `tmpdir()` via `CLAUDISH_TOKEN_FILE` instead of the real `~/.claudish/`. Beyond the minimum, kept because it stops the suite touching real user state, which is what `test:safe` exists to protect.
- Grok's raw bytes were never recovered; the session directory was gitignored and removed with its worktree. The mechanism is proven and reproduced, but the exact text Grok emitted is unknown.

Report: `ai-docs/reports/grok-tool-name-mangling-20260827.md`
Rationale: `ai-docs/architecture/adapters.md`

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
