### PR TITLE
docs: archive the advisor build evidence, park three follow-ups, add a handoff

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -451,7 +451,99 @@ routing function as the runtime.
 **Effort**: medium to large.
 
 Reference: `ai-docs/architecture/advisor.md` ("Panel routing and billing");
-`ai-docs/sessions/dev-feature-advisor-any-model-20260909-0001/scope-decisions.md` (gitignored).
+`ai-docs/reports/advisor-scope-decisions-20260910.md`.
+
+---
+
+## `--advisor`: a reasoning-only panel reply is recorded as a stub
+
+Status: not started. Recorded as a known limitation of the any-model advisor work.
+
+`extractChatCompletionText` (`packages/cli/src/handlers/native-handler-advisor.ts:2179-2187`)
+reads only `choices[0].message.content`, as a string or as an array of text parts. If a
+reasoning model answers HTTP 200 with its text in a reasoning field and `content` null or empty,
+the check at `:2152` records `origin: "stub"` with "HTTP 200 but the response carried no advice
+text". The main model then receives a failure, not advice, for a call that was billed.
+
+This is visible, not silent: the failure text names the model, the call raises one warning, and
+the `advisor_call` record says `stub`.
+
+**Why parked.** Two questions come first. The field that carries reasoning differs between
+providers, so the shape must come from a real captured response, never a guessed one (fixtures
+come from real debug logs). And reasoning without a final answer is the model's working, not its
+conclusion; whether it counts as advice is a product decision.
+
+**Trigger condition**: a real run shows a panel model returning reasoning with empty content, or
+a user reports stub advice from a reasoning model.
+
+**Must still hold after the change:** a reply with no text at all stays `stub`; if reasoning is
+accepted as advice, the `advisor_call` record says so, so a reader can tell it apart from an
+answer.
+
+**Effort**: small.
+
+Reference: `ai-docs/reports/advisor-build-report-20260911.md` ("Known limitations").
+
+---
+
+## `openai-sse` parser: one `catch` drops every per-chunk error without a log line
+
+Status: not started. Found during the any-model advisor work; not specific to the advisor.
+
+In `packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts`, the `try` at `:534` opens
+with `JSON.parse(dataStr)` and closes at `:896` with `} catch (e) {}`. It covers the parse and
+all chunk handling after it: usage, text deltas, reasoning, and tool calls. Any exception in
+those 360 lines is dropped, and the loop moves to the next line. A malformed chunk, or a bug in
+tool-call handling, can drop a tool call while the turn still ends with `end_turn`.
+
+The raw chunk is logged verbatim at `:528` under `--debug`, so the input survives. The fact that
+it was dropped does not. `openai-sse` is the default stream format for every adapter that does
+not override it (`packages/cli/src/adapters/base-api-format.ts:605`), so the effect reaches most
+foreign providers. During the advisor work this cost a full investigation of the SSE log
+truncation defect.
+
+The catches at `:267` and `:270` are different: they guard `enqueue` and `close` on a stream
+that can already be closed, and are correct.
+
+**Why parked.** Out of scope for the advisor work, and the file is shared by every OpenAI-shaped
+provider, so a change needs its own test run across the stream-format fixtures.
+
+**Trigger condition**: the next edit to `openai-sse.ts`, or any report of a tool call that
+vanished or a turn that ended early on an OpenAI-shaped provider.
+
+**Must still hold after the change:** one bad chunk still does not end the stream; the error is
+logged with enough context to find the chunk in a debug log; the replayed fixtures in
+`format-translation.test.ts` stay green.
+
+**Effort**: small for a log line; medium if the `try` is narrowed to the parse.
+
+---
+
+## Local `bun run test` skips the macOS bridge suite
+
+Status: not started. Local only; CI is not affected.
+
+`package.json:23` runs `bun run --cwd packages/cli test && bun run --cwd packages/macos-bridge
+test`. On `bun` 1.4.0 the two `displayWidth` Unicode-oracle tests in
+`packages/cli/src/tui/viz/color.test.ts` fail, the CLI suite exits non-zero, and `&&` stops
+before the bridge suite starts. A local `bun run test` therefore reports nothing about the
+bridge.
+
+CI pins `bun` 1.3.10 (`.github/workflows/test.yml:58`), where the CLI suite is green and the
+bridge suite runs: run `34544453952` on the `v9.3.0` merge printed `Ran 3257 tests across 211
+files`, then `Ran 20 tests across 1 file`.
+
+**Why parked.** Nothing is unguarded in CI today. The risk arrives when the CI pin moves to a
+`bun` version where the two tests fail: CI then goes red and, the same way, stops running the
+bridge suite.
+
+**Trigger condition**: the CI `bun` pin is raised, or someone relies on a local run to check a
+bridge change.
+
+**Must still hold after the change:** the root `test` script still fails when either suite
+fails; both suites report even when the first one fails.
+
+**Effort**: small.
 
 ---
 

--- a/ai-docs/architecture/advisor.md
+++ b/ai-docs/architecture/advisor.md
@@ -8,7 +8,10 @@ caught, and which failures are silent.
 
 Baseline for the work: claudish 9.0.6 (`1eed9e5`), Claude Code 2.1.263. Sources: the session
 `ai-docs/sessions/dev-feature-advisor-any-model-20260909-0001/` (gitignored, so it will not
-survive; everything load-bearing from it is copied here).
+survive; everything load-bearing from it is copied here). Three of its records are archived
+verbatim in `ai-docs/reports/`: the build report (`advisor-build-report-20260911.md`), the
+mutation proofs behind each guard (`advisor-mutation-proofs-20260911.md`), and the scope
+decisions (`advisor-scope-decisions-20260910.md`).
 
 ```
 claudish --advisor "gpt-5.6-sol" -p "task"                          # A: no main model, Claude Code's own

--- a/ai-docs/reports/advisor-build-report-20260911.md
+++ b/ai-docs/reports/advisor-build-report-20260911.md
@@ -1,0 +1,183 @@
+# Advisor build report (archived)
+
+Archived on 2026-09-11 from the gitignored build session
+`ai-docs/sessions/dev-feature-advisor-any-model-20260909-0001/report.md`, which
+`git worktree remove` deletes. Everything below the rule is verbatim.
+
+Read it as a record of the build, not as a description of later code:
+
+- It describes branch `worktree-advisor-support`, released as `v9.3.0` (merge `ee2c995`).
+- Its session-relative paths (`validation/phase7-*`, `reviews/`, `tests/`) no longer exist.
+  Two of them were archived next to this file:
+  `tests/mutation-proofs.md` is `advisor-mutation-proofs-20260911.md`, and the scope record is
+  `advisor-scope-decisions-20260910.md`. The raw real-run logs were not archived.
+- Its "macOS bridge suite does not run" note is true only for a local run on `bun` 1.4.0.
+  CI pins `bun` 1.3.10, where the CLI suite is green and the bridge suite runs
+  (run `34544453952`: `Ran 20 tests across 1 file`).
+- Rationale: `ai-docs/architecture/advisor.md`. Lessons: `advisor-any-model-verification-20260911.md`.
+
+---
+
+# Advisor for any main-model configuration — build report
+
+**Branch:** `worktree-advisor-support` · **Base:** `ad326c3` · **Plan:**
+`docs/plans/2026-09-09-claudish-advisor-any-model.md` (magus repo)
+**Depth:** full · **Automation:** autonomous
+
+## What the plan asked for, and what is true now
+
+`claudish --advisor "<models>"` had to work whatever main model was chosen.
+
+| Configuration | Plan said | Verified now |
+|---|---|---|
+| No `--model` | "works today" | **Was false.** Claude Code offered no advisor tool at all, on this branch AND on the released build. Now works: 3 calls, all `upstream`. |
+| Bare Anthropic name | did not work | Works: 2 calls, `upstream`, advisor beta flag stripped. |
+| Foreign model | did not work | Works: 2 calls, `upstream`, real advice while the main loop ran on Grok. |
+| Panel plus collector | — | Works: per-member records, collector `upstream`, a failed member named in `failedModels`. |
+| `--advisor` absent | no advisor traffic | Verified: no tool, no swap, no records, no log file. |
+
+## The root cause the plan did not know
+
+Claude Code builds its advisor tool spec only when an advisor MODEL is
+configured, and it has no default. Claudish set the experimental env var, which
+bypasses only the RANK checks, and never supplied a model. So the tool was never
+offered, in any configuration, before or after the plan's changes. A control run
+on the RELEASED build behaved identically.
+
+The beta header `advisor-tool-2026-03-01` is sent regardless, which is why the
+advisor looked active when it was not.
+
+Claudish now passes `--advisor sonnet` to the child, and leaves the user's own
+`advisorModel` alone when they have one.
+
+## What was built
+
+| Area | Change |
+|---|---|
+| Capture | Advisor tool-use ids are captured by tool NAME, not the `toolu_` prefix. Foreign parsers mint `call_*` / `tool_*`; the old regexes recorded nothing, so the advisor silently did nothing on every foreign provider. SSE events are reassembled across chunk boundaries, and non-stream JSON is scanned too. |
+| Dispatch | `--advisor` no longer implies `--monitor`. A decorator wraps the handler `getHandlerForRequest` returns, swaps Claude Code's server advisor tool for a function tool BEFORE the inner handler converts the request (foreign converters drop server tools), tees the response to scan it without touching the client's bytes, and rewrites advisor tool_results. |
+| Launch | A no-`--model` advisor session keeps the four launch behaviours monitor used to provide: no picker, no required-model exit, no `ANTHROPIC_MODEL=unknown`, native auth preserved. `--monitor` itself is untouched. |
+| Provenance | Every panel call writes an `advisor_call` record with an explicit `origin` (`upstream`, `stub`, `absent`), the stub path, route host, status and byte count; every rewrite writes `advisor_rewrite` with `resultOrigin` and `failedModels`. Records go to the always-on log, not only under debug. |
+| Failure visibility | Failures reach the model as text naming the model and reason, carry `is_error` on the Anthropic wire, and raise one warning each. Provider error text is sanitised by credential value and by shape first. |
+| Startup | A notice names each panel model's host and that it bills per token, the main model and its provider, whether the advisor env var was set by claudish or inherited, and the uncached per-call cost. Predictable failures refuse before a port is bound. |
+
+## Defects found and fixed along the way
+
+Each was found by review or by a real run, not by the original plan.
+
+1. The OpenRouter panel request passed `resolveModelNameSync` its arguments in
+   the wrong order and sent the returned object as the model id. Every
+   OpenRouter panel member failed.
+2. A retried request re-ran and re-billed the whole panel, in a window up to
+   90 seconds.
+3. Startup refused a Google model the runtime could serve, and accepted a
+   placeholder token the runtime rejects. Both halves came from two credential
+   lookups; there is now one.
+4. The advisor log file was written unscrubbed while the debug mirror was
+   scrubbed.
+5. The Anthropic collector had no timeout.
+6. Subscription-prefixed specs became invalid OpenRouter ids
+   (`openai-codex/gpt-5.6-sol`); they now resolve through live catalog data, or
+   are refused by name.
+7. An in-flight entry could be evicted, after which the log claimed `upstream`
+   while the model received an error.
+8. The OpenAI route sent `max_tokens`; that endpoint requires
+   `max_completion_tokens`, so the plan's own example model returned 400.
+9. A bare name could resolve to another provider's id
+   (`accounts/fireworks/models/kimi-k3`).
+10. **Found by a real run:** the unanswered-advisor detection matched the phrase
+    "No such tool available: advisor" in ANY tool_result text, so a model
+    running `rg "advisor"` in Bash minted a fake advisor record and a false
+    user-visible warning. Text the model wrote is untrusted input.
+11. **Found by a real run:** the panel was handed a transcript containing the
+    harness's own tool error and answered about it. The panel is now asked the
+    advisor's own question, with that one tool_result neutralised by id.
+12. **Found by a red test:** claudish's SSE debug logger truncated payloads at
+    300 characters, so fixtures extracted from a debug log were unparseable
+    mid-JSON. Since the project's documented test workflow extracts fixtures
+    from debug logs, every such fixture was at risk. The logger now writes
+    payloads verbatim, and the extractor refuses to write a corrupt fixture.
+13. **Pre-existing, found by an experiment:** a nested claudish inherits
+    claudish's own placeholder `ANTHROPIC_AUTH_TOKEN`, and the native-auth path
+    forwarded it, so Anthropic answered 401. Reproduced on the released build.
+    Only exact placeholder values are scrubbed.
+
+## Test results
+
+| Suite | Result |
+|---|---|
+| Full suite, this branch | 3239 pass / 14 skip / 2 fail, 3255 tests across 211 files |
+| Full suite, clean base `ad326c3` | 3156 pass / 14 skip / 4 fail plus 1 error |
+| `typecheck` | exit 0, no errors |
+| `lint` | exit 0, no errors |
+
+Both failures are the `displayWidth` Unicode-oracle tests in
+`tui/viz/color.test.ts`, which also fail on the clean base. No live-network
+flake and no contention failure appeared in the final run, and **no new failure
+is attributable to this work**. The macOS bridge suite does not run, because the
+root script chains the two suites with `&&` and the base is already red.
+
+New advisor tests, all green: capture 5, failures 5, panel prompt 5,
+decorator 9, routing and state 13, startup 23, runner 19, SSE log payload 3,
+plus the existing 40.
+
+Mutation proofs: 30 bugs were reintroduced one at a time, each in a file backed
+up by copy and restored byte for byte afterwards, running only the test that
+should catch it. **25 were caught.** `tests/mutation-proofs.md` records every
+planted edit and the failing test names.
+
+Two results are worth stating plainly rather than averaging away:
+
+- The first "exactly once" test passed with its own guard deleted, because
+  swapping an already-swapped body changes nothing. A replacement test was
+  written that observes a side effect which doubles, and the mutation is caught
+  by that test only. Without mutation testing the guard would have looked
+  covered while guarding nothing.
+- Four fixes had no test at all: the OpenRouter id resolution, the OpenAI token
+  parameter, the collector alias, and the SSE log cap. Each of those bugs was
+  found by a REAL RUN rather than by a failing test, which is how a fix arrives
+  without a guard. Tests were then written for all four, and the four mutations
+  re-run: every one is now caught. One caveat is recorded rather than smoothed
+  over — two of the three SSE-log tests derive their expectations from the
+  exported constant, so they would follow it if it changed; the literal
+  5000-character test is the real regression guard.
+
+Across all rounds: 34 mutations attempted, 29 caught on the first attempt, and
+the 5 that were not are each explained in `tests/mutation-proofs.md` — one
+because its test was too weak (replaced, then caught) and four because the fix
+had no test yet (written, then caught).
+
+## Evidence
+
+- Real runs: `validation/phase7-*` (before the advisor model, including a
+  released-build control), `validation/phase7b-*` and `phase7c-*` (after),
+  `validation/authexp-*` (the placeholder experiment). Each has the pane output,
+  the claudish debug log and the origin records.
+- Code review: four models, `reviews/code-review/`, 0 CRITICAL, all HIGH
+  findings dispositioned in `consolidated.md`.
+- Design review: two rounds, `reviews/plan-review*/`. The first rejected the
+  design over the `toolu_` prefix defect; the second over breaking configuration
+  A at launch.
+- Tests: `tests/mutation-proofs.md` records the planted bug behind each guard.
+
+## Behaviour changes a user may notice
+
+- `--advisor` no longer forces the main loop onto the native handler. A profile
+  mapping now applies to an advisor launch, where it used to be overridden. This
+  follows the plan's requirement that the advisor must not change main-model
+  routing; the startup notice names the provider that serves the main model.
+- Panel calls are billed per token at the named host and never use a
+  subscription. This was always true and is now stated at startup.
+- A configuration that cannot work is refused before a port is bound, instead of
+  failing mid-session.
+
+## Known limitations and follow-ups
+
+- Panel calls do not use claudish's subscription-aware routing. Parked in
+  `ROADMAP.md`.
+- A panel model that returns HTTP 200 with reasoning but no content is recorded
+  as a stub. Reasoning-only response shapes are not unwrapped.
+- The collector's synthesis quality is out of scope; one observed run produced a
+  degenerate synthesis from a thin transcript.
+- The swallowing `catch` around SSE `JSON.parse` hides parse errors; flagged,
+  not changed.

--- a/ai-docs/reports/advisor-followups-handoff-20260911.md
+++ b/ai-docs/reports/advisor-followups-handoff-20260911.md
@@ -1,0 +1,100 @@
+# Handoff: four follow-ups from the any-model advisor work
+
+## Context
+- Repo: MadAppGang/claudish. `--advisor` for any main model shipped in v9.3.0 (merge ee2c995).
+- Prerequisite: this file, the roadmap entries and the archives (commit fe0bd29 and the commit
+  that adds this file) are on main.
+- Read first: CLAUDE.md (the Invariants section is binding), ai-docs/architecture/advisor.md,
+  ai-docs/architecture/adapters.md.
+- Evidence from the original build, in ai-docs/reports/: advisor-build-report-20260911.md,
+  advisor-mutation-proofs-20260911.md, advisor-scope-decisions-20260910.md,
+  advisor-any-model-verification-20260911.md.
+- Each item has a ROADMAP.md entry with the full rationale. This file is the work order.
+
+## Working rules
+1. Work in a new worktree from current main (/dev:worktree). Never use git stash in a worktree.
+2. Before any edit, run `bun run test`. Record the counts and the names of the failing tests.
+   On bun 1.4.0, the two displayWidth tests in packages/cli/src/tui/viz/color.test.ts fail.
+   Any other failure after your change is a regression.
+3. Tests: Codex writes them, a subagent runs them, you check the result with a real claudish run.
+4. Run claudish in a dedicated session (/terminal:run or a channel session), not in the main Bash tool.
+5. Fixtures come from real debug logs (`claudish --debug` writes to logs/). Never hand-craft one.
+6. Every new guard needs a mutation proof: copy the source file aside, plant the bug, run only
+   the guarding test, show that it fails, restore by copy (never git), check with cmp.
+   Record the proof in ai-docs/reports/.
+7. "Done" needs pasted output from a fresh run. Anything that must survive goes in a tracked
+   directory, never ai-docs/sessions/.
+
+## Order
+4, 3, 2, 1: smallest and safest first. Items 4 and 3 are independent. Item 2 needs a real
+capture first. Item 1 is the only large one.
+
+## Item 4: local `bun run test` skips the macOS bridge suite (small)
+Roadmap: "Local `bun run test` skips the macOS bridge suite".
+Problem: package.json:23 joins the two suites with &&. On bun 1.4.0 the CLI suite is red, so the
+bridge suite never runs locally. CI pins bun 1.3.10 (.github/workflows/test.yml:58, :97), is
+green, and runs both suites.
+Do: make the root test script run both suites every time and exit non-zero if either failed.
+Write it as a small Bun + TypeScript script, not shell logic.
+Done when: on bun 1.4.0, `bun run test` prints both "Ran N tests across M files" lines (the
+bridge line is "20 tests across 1 file") and exits 1; the PR's CI run is green and shows both.
+Out of scope: the displayWidth failures (a bun-version drift, separate task).
+
+## Item 3: the openai-sse parser drops per-chunk errors (small to medium)
+Roadmap: "`openai-sse` parser: one `catch` drops every per-chunk error without a log line".
+Problem: packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts. The try opens at :534
+with JSON.parse(dataStr) and closes at :896 with `} catch (e) {}`. An exception anywhere in those
+360 lines (usage, text, reasoning, tool calls) disappears. A tool call can vanish while the turn
+ends with end_turn. The catches at :267 and :270 are correct; leave them.
+Do: log the error in that catch, with enough context to find the chunk in a debug log (the raw
+chunk is already logged at :528). Optionally narrow the try to the parse. One bad chunk must
+still not end the stream.
+Done when: a test takes a real fixture from packages/cli/src/test-fixtures/sse-responses/,
+corrupts one data line, and asserts that the error is logged and the stream continues; removing
+the log call makes that test fail; format-translation.test.ts stays green.
+Trap: this is the default stream format for every adapter that does not override it
+(packages/cli/src/adapters/base-api-format.ts:605). Run all stream-parser tests, not one file.
+
+## Item 2: a reasoning-only panel reply is recorded as a stub (small)
+Roadmap: "`--advisor`: a reasoning-only panel reply is recorded as a stub".
+Problem: extractChatCompletionText (packages/cli/src/handlers/native-handler-advisor.ts:2179-2187)
+reads only choices[0].message.content. A reply whose text is only in a reasoning field reaches
+the check at :2152 and becomes origin: "stub".
+Decide first, with the user: does reasoning without a final answer count as advice? If no, only
+improve the failure reason. If yes, continue.
+Do: run a reasoning model as a panel member with `claudish --debug`, capture a real
+reasoning-only response, build the fixture from that log, and read the field that response uses.
+Done when: the fixture test passes; a reply with no text at all is still a stub; the
+advisor_call record shows when reasoning was accepted as advice; a mutation proof exists; one
+real run with that panel model shows origin "upstream" in the advisor log.
+
+## Item 1: panel calls skip subscription-aware routing (medium to large)
+Roadmap: "Route `--advisor` panel calls through subscription-aware routing".
+Problem: advisorRouteFor (packages/cli/src/handlers/native-handler-advisor.ts) calls each panel
+model with a raw metered key: OPENAI_API_KEY to api.openai.com, GEMINI_API_KEY, ANTHROPIC_API_KEY
+for a Claude collector, OPENROUTER_API_KEY for the rest. It never calls route(). Example:
+preflight routes gpt-5.6-sol to the Codex subscription (cx@) and grok-4.6 to the Grok
+subscription (gk@), but as panel members both bill per token.
+Read first: advisor.md, section "Panel routing and billing".
+Must still hold: origin records separate "upstream" from "stub" per model; billing is decided by
+the credential that signed (RequestAuth.arm === "oauth"), never by the provider name; the startup
+refusal and notice read the same single routing function as the runtime.
+Traps, each one silent:
+- The default collector is haiku, a bare Claude name. It must never reach route(). Check
+  nativeRouteFor() first, or the routing chain falls back to OpenRouter.
+- openai-codex bills by the signing credential. It is in CREDENTIAL_DECIDED_PROVIDERS and must
+  never also be in SUBSCRIPTION_PROVIDERS.
+- An absent arm means metered. "The composite returned an artifact" does not mean subscription.
+- Never hardcode rosters or pricing. Resolve them live.
+Done when: a real run of
+  claudish --model grok-4.6 --advisor "gpt-5.6-sol,grok-4.6" -p "<task>"
+writes, for each panel member, an advisor_call record with origin "upstream" and the
+subscription route host (add a billing field to the record, which it does not have today); the
+startup notice no longer says "billed per token" for those members; a member with no
+subscription still bills metered and says so; preflight and the startup notice agree for every
+member.
+
+## When finished
+Mark each ROADMAP.md item DONE with its evidence (follow the format of the entry
+"Regression test: a Responses stream that dies mid tool-call"), update advisor.md for items 1
+and 2, and record the mutation proofs in ai-docs/reports/.

--- a/ai-docs/reports/advisor-mutation-proofs-20260911.md
+++ b/ai-docs/reports/advisor-mutation-proofs-20260911.md
@@ -1,0 +1,246 @@
+# Advisor mutation proofs (archived)
+
+Archived on 2026-09-11 from the gitignored build session
+`ai-docs/sessions/dev-feature-advisor-any-model-20260909-0001/tests/mutation-proofs.md`, which
+`git worktree remove` deletes. Everything below the rule is verbatim.
+
+Each row plants one bug, runs only the test that must catch it, and records the result. A row
+marked NOT PROVEN is a guard that did not exist at that time; the "Gap-closure" section at the
+end re-plants those bugs after tests were added.
+
+Read it as a record of the build, not as a description of later code:
+
+- Line numbers and the `git status` blocks describe the working tree during the build. The
+  cited commits (`f599ce2`, `64bab36`, `4468665`) exist in history.
+- Paths under `/Users/jack/.claude/jobs/` were temporary backup copies on the build machine.
+  They no longer exist.
+- The released code is `v9.3.0` (merge `ee2c995`). The build report is
+  `advisor-build-report-20260911.md`.
+
+---
+
+# Mutation proofs
+
+Method: back up the source file by copy, apply one targeted bug with `perl -pi`,
+confirm with `git diff --stat` that exactly one line changed, run ONLY the
+guarding test file, restore by copy (never git), confirm the restore with `cmp`.
+Run by the orchestrator. Source at the time: `claude-runner.ts` identical to
+commit `4468665`.
+
+## `packages/cli/src/claude-runner-advisor.test.ts` (Codex, commit f599ce2 + 64bab36)
+
+Unmutated: 11 pass, 0 fail.
+
+| Id | Mutation in `claude-runner.ts` | Result | Failing tests |
+|---|---|---|---|
+| M3 | `isAdvisorNativeSession`: drop `&& !config.model` | 9 pass, 2 fail | `is false when a Claude model is set`; `is false when a non-Claude model is set` |
+| M1 | `resolveAdvisorToolEnv`: set `"2"` instead of `"1"` | 9 pass, 2 fail | `sets the advisor variable to 1 when advisor is on and the parent variable is absent`; `uses a value accepted by Claude Code's strict boolean parser` |
+| M2 | `resolveAdvisorToolEnv`: delete the inherited-value check | 9 pass, 2 fail | `preserves an inherited value of 0`; `preserves an inherited value of true` |
+| M4 | `resolveAdvisorToolEnv`: advisor off still adds the variable | 10 pass, 1 fail | `does not add the advisor variable when advisor is off` |
+
+Every mutation restored; final `git diff --stat` on source and test file: empty.
+
+## Advisor guard mutation proofs, 14 mutations (2026-09-10)
+
+Same method: back up by `cp` to `/Users/jack/.claude/jobs/be9663df/tmp/mut-<basename>.orig`,
+run one `perl -pi` edit, confirm with `diff` against the backup that the file
+changed, run ONLY the guarding test file, restore by `cp`, check with `cmp`. No
+test file was touched. Paths are relative to `packages/cli/src/`.
+
+Unmutated baselines: `handlers/advisor-routing-and-state.test.ts` 7 pass,
+`handlers/advisor-decorator.test.ts` 8 pass, `claude-runner-advisor.test.ts` 19 pass,
+`advisor-startup.test.ts` 18 pass. All 0 fail.
+
+| Id | File | Mutation (perl edit) | Result | Failing tests | Verdict |
+|---|---|---|---|---|---|
+| 1 | `handlers/native-handler-advisor.ts` | `s/resolveModelNameSync\(rawModelId, "openrouter"\)\.resolvedId\)/resolveModelNameSync(rawModelId, "openrouter") as any)/` | 6 pass, 1 fail | `routes OpenAI, Google, OpenRouter, and Anthropic models with provider credentials` (the `typeof openrouter.wireModel` check on `grok-4.6`: expected "string", received "object") | PROVEN |
+| 2 | `handlers/native-handler-advisor.ts` | `s/const keys = own === NO_SESSION_BUCKET \? \[NO_SESSION_BUCKET\] : \[own, NO_SESSION_BUCKET\];/const keys = [...pendingBySession.keys()];/` (lookup searches every bucket) | 5 pass, 2 fail | `isolates calls by session and retains consumed entries`; `adopts a no-session call into the first known session` | PROVEN |
+| 3 | `handlers/native-handler-advisor.ts` | `s/^(\s*)call\.consumedAt \?\?= clock\(\);/$1call.consumedAt ??= clock();\n$1pendingBySession.get(call.sessionKey)?.delete(toolUseId);/` | 5 pass, 2 fail | `isolates calls by session and retains consumed entries`; `adopts a no-session call into the first known session` | PROVEN |
+| 4 | `handlers/native-handler-advisor.ts` | `s/\(block as any\)\.is_error = true;/(block as any).is_error = false;/` | 6 pass, 1 fail | `propagates an AdvisorToolResult error flag and text` | PROVEN |
+| 5 | `handlers/advisor-decorator.ts` | `s/if \(c\.get\("advisorHandled"\) === true\) return this\.inner\.handle\(c, payload\);//` | 8 pass, 0 fail | none | NOT PROVEN |
+| 6 | `handlers/advisor-decorator.ts` | `s/ADVISOR_ABSENT_WARN_AFTER = 3;/ADVISOR_ABSENT_WARN_AFTER = 2;/` | 5 pass, 3 fail | `warns once after three consecutive tool-carrying requests without advisor`; `does not count or reset requests with no tools array`; `resets the consecutive count when advisor is offered and remains one-shot after warning` | PROVEN |
+| 7 | `handlers/advisor-decorator.ts` | `s/if \(!Array\.isArray\(tools\) \|\| tools\.length === 0\) return;/if (!Array.isArray(tools) \|\| tools.length === 0) { consecutiveAbsent = 0; return; }/` | 7 pass, 1 fail | `does not count or reset requests with no tools array` | PROVEN |
+| 8 | `handlers/advisor-decorator.ts` | `s/return new Response\(passthrough, \{/return new Response("", {/` | 7 pass, 1 fail | `returns byte-identical SSE response data to the client (BC7)` | PROVEN |
+| 9 | `handlers/advisor-decorator.ts` | `s/const swapped = swapAdvisorToolInBody\(payload\);/const swapped = null as any;/` | 6 pass, 2 fail | `replaces the server advisor tool and preserves every other tool in order`; `processes a request only once when an already wrapped handler is wrapped again` | PROVEN |
+| 10 | `claude-runner.ts` | `s/return value === (CLAUDISH_PLACEHOLDER_(API_KEY\|AUTH_TOKEN));/return value?.includes($1) ?? false;/` (both lines of `isClaudishPlaceholderCredential`) | 17 pass, 2 fail | `leaves values that merely contain placeholder text untouched`; `recognizes only the exact placeholder for the matching variable name` | PROVEN |
+| 11 | `claude-runner.ts` | `s/for \(const name of \["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_API_KEY"\] as const\)/for (const name of ["ANTHROPIC_API_KEY"] as const)/` | 17 pass, 2 fail | `removes the exact auth-token placeholder and reports it`; `leaves unrelated environment variables untouched` | PROVEN |
+| 12 | `advisor-startup.ts` | `s/return v === "1" \|\| v === "true" \|\| v === "yes" \|\| v === "on";/return v.length > 0;/` (in `isClaudeCodeBoolTrue`) | 15 pass, 3 fail | `does not refuse for the disable variable when the child value is "2"` / `"false"` / `"0"` | PROVEN |
+| 13 | `advisor-startup.ts` | `s/if \(!facts\.collectorDefaulted\) \{/if (true) {/` | 17 pass, 1 fail | `drops an unavailable default collector and explains concatenation` | PROVEN |
+| 14 | `advisor-startup.ts` | `s/if \(includesMain\.length > 0\) \{/if (true) {/` | 17 pass, 1 fail | `mentions the main model only when it is also a panel member` | PROVEN |
+
+Why 5 is NOT PROVEN: the exactly-once test (`processes a request only once when an
+already wrapped handler is wrapped again`) asserts only that the final `tools` array
+holds one function `advisor` and no `advisor_20260301`. A second pass of
+`swapAdvisorToolInBody` over an already-swapped body finds no server tool and
+changes nothing, so double processing leaves that array the same. The duplicate
+presence-monitor observation, the duplicate `swap_applied` log record and the
+double response tee all go unasserted. Mutation 9 fails this test only because it
+removes the swap entirely. The test was not strengthened here.
+
+Final `git diff --stat packages/`: empty output (exit 0). `cmp` of all four source
+files against their `.orig` copies: identical.
+
+## Orchestrator spot checks (re-run independently)
+
+| Id | Control (unmutated) | Mutated | Restored |
+|---|---|---|---|
+| 8 | `advisor-decorator.test.ts` 8 pass, 0 fail | 7 pass, 1 fail: `returns byte-identical SSE response data to the client (BC7)` | `cmp` identical; `git diff --stat` empty |
+| 1 | `advisor-routing-and-state.test.ts` 7 pass, 0 fail | 6 pass, 1 fail: `advisorRouteFor > routes OpenAI, Google, OpenRouter, and Anthropic models with provider credentials` | `cmp` identical; `git diff --stat` empty |
+
+## New-guard mutation proofs
+
+Round 2, run 2026-09-11 against the working tree of `worktree-advisor-support`.
+Protocol: one mutation at a time via `perl -pi -e`, applied + tested + restored in a
+single command, each file backed up by `cp` to
+`/Users/jack/.claude/jobs/be9663df/tmp/mut2-<basename>.orig` first. No test file was
+edited. `diff -q` confirmed every edit landed; `cmp` confirmed every restore.
+
+| Id | Source file | perl edit | Result | Failing tests | Verdict |
+|---|---|---|---|---|---|
+| 1 | `handlers/native-handler-advisor.ts` | `s/^function rememberAdvisorToolUseId\(id: string, sessionId\?: string\): void \{$/function rememberAdvisorToolUseId(id: string, sessionId?: string): void {\n  if (!id.startsWith("toolu_")) return;/` | `advisor-capture.test.ts` 1 pass, 4 fail | `records the parser-produced non-Anthropic advisor tool-use id`; `records the same id when parser output is split into 16-byte chunks`; `… into 64-byte chunks`; `records the same id when a chunk boundary lands on a newline inside an SSE event` | **PROVEN** |
+| 2 | `handlers/native-handler-advisor.ts` | `s/^    this\.buf \+= chunkText;$/    this.buf = chunkText;/` | `advisor-capture.test.ts` 3 pass, 2 fail | `records the same id when parser output is split into 16-byte chunks`; `… into 64-byte chunks` | **PROVEN** |
+| 3 | `handlers/native-handler-advisor.ts` | `s/^    if \(typeof text !== "string" \|\| text\.trim\(\)\.length === 0\) \{$/    if (typeof text !== "string") {/` | `advisor-failures.test.ts` 4 pass, 1 fail | `treats an HTTP 200 response with an empty answer as a failure` | **PROVEN** |
+| 4 | `handlers/native-handler-advisor.ts` | `s/^    reason: sanitizeAdvisorReason\(reason, secrets\),$/    reason,/` | `advisor-failures.test.ts` 4 pass, 1 fail | `redacts credential-shaped provider text while preserving the reason` | **PROVEN** |
+| 5 | `handlers/native-handler-advisor.ts` | `s/^    origin: "stub",$/    origin: observed?.status === 400 ? "upstream" : "stub",/` | `advisor-failures.test.ts` 1 pass, 4 fail | `turns an HTTP 400 panel response into a named stub failure`; `preserves successful advice and reports a failed peer without a collector`; `raises exactly one warning for a failed call and names every failed model`; `redacts credential-shaped provider text while preserving the reason` | **PROVEN** |
+| 6 | `handlers/native-handler-advisor.ts` | `s/^      if \(block\.type === "tool_result" && block\.tool_use_id === toolUseId\) \{$/      if (block.type === "tool_result" && JSON.stringify(block.content ?? "").includes("No such tool available")) {/` | `advisor-panel-prompt.test.ts` 4 pass, 1 fail | `preserves another tool result verbatim even when it quotes the plumbing error` | **PROVEN** |
+| 7 | `handlers/native-handler-advisor.ts` | ``s/^    `\$\{body\}\\n\\n` \+$/    "" +/`` | `advisor-panel-prompt.test.ts` 4 pass, 1 fail | `turns an empty advisor input into usable panel instructions` | **PROVEN** (see note) |
+| 8 | `handlers/native-handler-advisor.ts` | `s{^  return entry\.sources\["openrouter-api"\]\?\.externalId \?\? null;$}{  const fromOr = …; if (fromOr) return fromOr; for (const s of Object.values(entry.sources) as any[]) { const id = s?.externalId; if (typeof id === "string" && id.includes("/")) return id; } return null;}` | all four advisor guard files: 22 pass, 0 fail | none | **NOT PROVEN** |
+| 9 | `handlers/native-handler-advisor.ts` | `s/^  if \(route\.kind !== "openai"\) return "max_tokens";$/  return "max_tokens";/` | all four advisor guard files: 22 pass, 0 fail | none | **NOT PROVEN** |
+| 10 | `handlers/advisor-decorator.ts` | `s{^    if \(c\.get\("advisorHandled"\) === true\) return this\.inner\.handle\(c, payload\);$}{    // mutation: already-wrapped guard removed}` | `advisor-decorator.test.ts` 8 pass, 1 fail | `withAdvisorSwap > observes advisor presence only once per request through nested wrappers` | **PROVEN** |
+| 11 | `advisor-startup.ts` | `s/^      callable: false,$/      callable: true,/` | `advisor-startup.test.ts` 18 pass, 0 fail | none | **NOT PROVEN** |
+| 12 | `handlers/shared/stream-parsers/openai-sse.ts` | `s/^export const SSE_LOG_MAX_CHARS = 1_000_000;$/export const SSE_LOG_MAX_CHARS = 300;/` | `format-translation.test.ts` 97 pass, 0 fail | none | **NOT PROVEN** |
+
+### Notes on the individual results
+
+**7 — the question IS guarded, but not by the test that names it.**
+`states the advisor question in the messages sent to the panel` asserts only that
+`JSON.stringify(prepared)` contains the question string. The advisor `tool_use` block is
+copied through unchanged and still carries `input.question`, so that assertion holds even
+when the appended final user turn is emptied. The mutation was caught instead by
+`turns an empty advisor input into usable panel instructions`, which asserts on the
+content of the final turn itself. The behaviour is guarded; the guard is the empty-input
+test, not the question test.
+
+**5 — origin is a load-bearing field across the whole failure surface.**
+The mutation was scoped to HTTP 400 alone and still took out four of the five tests: the
+warning aggregation, the peer-failure reporting and the redaction test all read `origin`
+to decide what counts as a failure. That is the intended coupling, not over-reach.
+
+**8 — the Fireworks-id bug is not re-detectable by the current tests.**
+`advisorRouteFor` is exercised only for `grok-4.6`, whose live catalog entry does carry an
+`openrouter-api` external id, so the reintroduced "any slashed external id" fallback is
+never reached. Reproducing the shipped bug needs a model the catalog knows but OpenRouter
+does not serve (the `kimi-k3` case the comment at `openRouterIdOf` documents), with a
+fixture catalog entry whose only slashed id belongs to another vendor. Coverage gap.
+
+**9 — the token-parameter spelling has no test at all.**
+`grep -rn "max_completion_tokens\|advisorTokenParamFor" packages/cli/src --include="*.test.ts"`
+returns nothing. Forcing the deprecated `max_tokens` on the openai route — exactly the
+400 the doc comment cites twice from runs phase7b-B and phase7b-C — is invisible to the
+suite. Coverage gap.
+
+**10 — the new nested-wrapper test is the one that catches it.**
+The older test `processes a request only once when an already wrapped handler is wrapped
+again` still PASSED under the mutation: it observes the inner handler's call count, and a
+double-wrapped handler still reaches the inner handler once per outer call. Only
+`observes advisor presence only once per request through nested wrappers`, which shares a
+single presence monitor between two wrappers and counts observations, fails. Without that
+test the `advisorHandled` guard is unguarded.
+
+**11 — `unresolvedAlias` short-circuits nothing the tests look at.**
+No test file in `packages/cli/src` references `advisorModelStatus` or `unresolvedAlias`
+(`grep -rln` over the tree returns only source files). The startup tests drive refusals
+through missing credentials only, so flipping the alias branch to `callable: true` changes
+no assertion. Coverage gap.
+
+**12 — the SSE log truncation is exercised by no test.**
+`SSE_LOG_MAX_CHARS` / `formatRawSseLogPayload` are referenced only by `openai-sse.ts` and
+`openai-responses-sse.ts`. `format-translation.test.ts` mentions `extract-sse-from-log.ts`
+in a header comment only; it replays checked-in `.sse` fixtures and never writes or reads a
+debug log. The 300-char cap can be reintroduced with a fully green suite — the corruption
+would resurface only as a wrong `stop_reason` in a future fixture extraction, which is
+precisely the failure mode the constant's doc comment describes. This is the widest of the
+four gaps: the regression it protects against is silent by construction.
+
+### Final state
+
+```
+$ git status --porcelain packages/
+ M packages/cli/src/advisor-startup.ts
+AM packages/cli/src/handlers/advisor-capture.test.ts
+M  packages/cli/src/handlers/advisor-decorator.test.ts
+A  packages/cli/src/handlers/advisor-failures.test.ts
+ M packages/cli/src/handlers/native-handler-advisor.ts
+ M packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
+ M packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+ M packages/cli/src/index.ts
+ M packages/cli/src/test-fixtures/extract-sse-from-log.ts
+ M packages/cli/src/test-fixtures/sse-responses/grok-4.6-openai-advisor-turn1.sse
+?? packages/cli/src/handlers/advisor-panel-prompt.test.ts
+```
+
+Byte-identical to the status recorded before the first mutation. All four backups verified
+against their live files with `cmp` after the last run:
+`native-handler-advisor.ts`, `advisor-decorator.ts`, `advisor-startup.ts`,
+`openai-sse.ts` — all identical. No mutation left behind, no test file touched.
+
+## Gap-closure mutation proofs
+
+Re-run of the four bugs that were NOT caught the last time they were planted. Tests have since
+been added for each; this round re-plants the same bugs to prove those tests are real guards.
+Every bug below was an observed production failure, not a hypothetical.
+
+| # | Bug | Source file | Exact perl edit | Result | Failing test(s) | Verdict |
+|---|-----|-------------|-----------------|--------|-----------------|---------|
+| 1 | OpenRouter wire id falls back to any external id containing a slash (the old behaviour that put `accounts/fireworks/models/kimi-k3` on the wire to OpenRouter) | `packages/cli/src/handlers/native-handler-advisor.ts` (`openRouterIdOf`) | `perl -pi -e 's{return entry\.sources\["openrouter-api"\]\?\.externalId \?\? null;}{return entry.sources["openrouter-api"]?.externalId ?? ((Object.values(entry.sources ?? {}) as any[]).map((s) => s?.externalId).find((id) => typeof id === "string" && id.includes("/")) ?? null);}'` | 12 pass / **1 fail** | `OpenRouter advisor wire-model resolution > refuses a known model that only publishes another vendor's external id` | **PROVEN** |
+| 2 | `max_tokens` sent on the direct OpenAI route (`HTTP 400: Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.`) | `packages/cli/src/handlers/native-handler-advisor.ts` (`advisorTokenParamFor`) | `perl -pi -e 's{if \(route\.kind !== "openai"\) return "max_tokens";}{if (true \|\| route.kind !== "openai") return "max_tokens";}'` | 12 pass / **1 fail** | `advisor request token parameter routing > uses max_completion_tokens on the direct OpenAI route` | **PROVEN** |
+| 3 | An unresolved collector alias is treated as callable (claudish would POST the claudish alias verbatim and take a silent 401/404) | `packages/cli/src/advisor-startup.ts` (`advisorModelStatus`) | `perl -pi -e 's!if \(route\.unresolvedAlias\) \{!if (false && route.unresolvedAlias) {!'` | 20 pass / **3 fail** | `decideAdvisorStartup > unresolved collector aliases > keeps an unresolved alias uncallable even when its credential is present`; `... > refuses an unresolved collector named by the user`; `... > drops an unresolved default collector and explains concatenation` | **PROVEN** |
+| 4 | The 300-character truncation of the logged raw SSE payload returns (cut mid-JSON, so extracted fixtures fail `JSON.parse` and the corruption only ever surfaces as a wrong `stop_reason`) | `packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts` (`SSE_LOG_MAX_CHARS`) | `perl -pi -e 's!export const SSE_LOG_MAX_CHARS = 1_000_000;!export const SSE_LOG_MAX_CHARS = 300;!'` | 2 pass / **1 fail** | `formatRawSseLogPayload > preserves a realistic payload well beyond the former 300-character cap` | **PROVEN** |
+
+Guard files (unchanged by this round):
+`packages/cli/src/handlers/advisor-routing-and-state.test.ts` (#1, #2),
+`packages/cli/src/advisor-startup.test.ts` (#3),
+`packages/cli/src/handlers/shared/stream-parsers/sse-log-payload.test.ts` (#4).
+
+Note on #4: the other two tests in `sse-log-payload.test.ts` derive their expectations from the
+exported `SSE_LOG_MAX_CHARS`, so they follow the constant wherever it is set and cannot catch a
+shrunken cap. The guard is the first test, which pins a literal 5,000-character payload against
+the former 300-character cap. That test alone carries the proof, and it does fail.
+
+Protocol notes: each mutation was applied, tested and restored inside a single command; `diff -q`
+confirmed the edit landed before every test run, and `cmp` confirmed the restore after it. No test
+file was edited, and no `git stash` / `checkout` / `restore` / `reset` was used at any point (this
+tree carries uncommitted work). Mutation 3's first attempt aborted on a perl delimiter error
+(`s{...}{...}` with an unbalanced `{` in the replacement) — the `&&` short-circuited before `diff`,
+so the file was never mutated on that attempt; it was re-run with `!` delimiters.
+
+### Final state
+
+```
+$ git status --porcelain packages/
+ M packages/cli/src/advisor-startup.test.ts
+ M packages/cli/src/advisor-startup.ts
+AM packages/cli/src/handlers/advisor-capture.test.ts
+M  packages/cli/src/handlers/advisor-decorator.test.ts
+A  packages/cli/src/handlers/advisor-failures.test.ts
+ M packages/cli/src/handlers/advisor-routing-and-state.test.ts
+ M packages/cli/src/handlers/native-handler-advisor.ts
+ M packages/cli/src/handlers/shared/stream-parsers/openai-responses-sse.ts
+ M packages/cli/src/handlers/shared/stream-parsers/openai-sse.ts
+ M packages/cli/src/index.ts
+ M packages/cli/src/test-fixtures/extract-sse-from-log.ts
+ M packages/cli/src/test-fixtures/sse-responses/grok-4.6-openai-advisor-turn1.sse
+?? packages/cli/src/handlers/advisor-panel-prompt.test.ts
+?? packages/cli/src/handlers/shared/stream-parsers/sse-log-payload.test.ts
+```
+
+Byte-identical to the status recorded before the first mutation of this round. Each backup was
+verified against its live file with `cmp` after the last run:
+
+```
+IDENTICAL native-handler-advisor.ts
+IDENTICAL advisor-startup.ts
+IDENTICAL openai-sse.ts
+```
+
+No mutation left behind, no test file touched.

--- a/ai-docs/reports/advisor-scope-decisions-20260910.md
+++ b/ai-docs/reports/advisor-scope-decisions-20260910.md
@@ -1,0 +1,78 @@
+# Advisor scope decisions (archived)
+
+Archived on 2026-09-11 from the gitignored build session
+`ai-docs/sessions/dev-feature-advisor-any-model-20260909-0001/scope-decisions.md`, which
+`git worktree remove` deletes. Everything below the rule is verbatim.
+
+This is the decision record from the middle of the build, written after a read-only trace of how
+panel credentials resolve. It decides which credential and routing problems the build fixed and
+which it parked.
+
+Read it as a record of the build, not as a description of later code:
+
+- Line numbers describe the code at that time, not `v9.3.0`.
+- Which items were fixed before release is in the "Defects found and fixed" section of
+  `advisor-build-report-20260911.md`.
+- `research/panel-credentials.md`, which it cites, stayed in the session directory and was not
+  archived.
+- The one item it parked, subscription-aware panel routing, is tracked in `ROADMAP.md` under
+  "Route `--advisor` panel calls through subscription-aware routing".
+
+---
+
+# Scope decisions after the panel-credentials trace
+
+Source: `research/panel-credentials.md` (read-only trace), plus the orchestrator's
+own read of `providers/catalog-client.ts:314` and
+`handlers/native-handler-advisor.ts:640`.
+
+## Observed
+
+- `resolveModelNameSync(userInput, targetProvider): ModelResolutionResult`
+  (`catalog-client.ts:314`). The advisor calls it as
+  `resolveModelNameSync("openrouter", rawModelId) ?? rawModelId`
+  (`native-handler-advisor.ts:640`): arguments swapped, and the result is an
+  object that is never nullish. The OpenRouter request body therefore carries an
+  object as `model`. The body is typed `any`, so the type checker misses it.
+  Every OpenRouter panel member is affected.
+
+## Reported by the trace (from code, not yet observed at runtime)
+
+- Panel keys resolve lazily in `resolveAdvisorKeys` (`native-handler.ts:33-65`):
+  openrouter and openai through the credential authority (env, config, keychain,
+  1Password); google by hand, skipping the keychain; the Anthropic collector key
+  is only the inbound `x-api-key` header (`native-handler.ts:150`).
+- Bare `gpt-5.6-sol` parses to provider `openai` and calls api.openai.com with
+  the metered `OPENAI_API_KEY`, never the Codex login. `gemini-3.8-flash` parses
+  to `google`. `grok-4.6` parses to `x-ai` and goes to OpenRouter. No panel call
+  uses a subscription; even `cx@` and `gk@` specs go to OpenRouter.
+- Under OAuth (configuration A) the Anthropic collector gets no key, receives a
+  401, and silently falls back to concatenation.
+- `cli.ts:2201` help text says `--advisor` "works with any --model". False until
+  P4 lands.
+
+## Decisions
+
+| Item | Decision | Reason |
+|---|---|---|
+| OpenRouter model-id bug | IN | Breaks R3 for every OpenRouter panel member. |
+| Google key skips the keychain | IN | Silent empty key; R3/R5. |
+| Anthropic collector key | IN: inbound `x-api-key`, else `ANTHROPIC_API_KEY` from the credential authority; never the OAuth bearer. No key: startup refusal. | R3/R5; decided open question 3. |
+| Single source for "which endpoint/credential a panel model uses" | IN: one exported pure function in `native-handler-advisor.ts`, used by `buildAdvisorRequest` AND by the startup refusal/notice. | A duplicated copy of the branching is how drift starts. |
+| Billing disclosure | IN: the startup notice names each panel model's endpoint and says it bills per token; the panel does not use subscriptions. | CLAUDE.md billing invariants; N2. |
+| Panel through subscription-aware routing (`cx@`, `gk@`, ...) | OUT, follow-up. Record in `ROADMAP.md` at Phase 8. | Rewrites the retrieval path; the plan's out-of-scope list protects panel behaviour. Disclosure plus refusal make the current behaviour visible. |
+
+## Refinement: default collector vs named collector
+
+`parseAdvisorFlag` (`cli.ts:159`) defaults the collector to `"haiku"` when a
+panel has 2+ models and no `:`. Under a Claude Code OAuth session there is
+usually no `ANTHROPIC_API_KEY`, so "refuse when an Anthropic collector has no
+key" would refuse every default multi-model panel.
+
+| Collector | Cannot be called at launch | Result |
+|---|---|---|
+| Named by the user | refuse at startup | the user asked for it; predictable |
+| Defaulted (implicit `haiku`) | run with no collector (concatenate), notice says why | same end result as today's silent 401 fallback, now visible, one futile call fewer |
+
+Requires recording whether the collector was named or defaulted
+(launch-only config field; never in `ClaudishProfileConfig`).


### PR DESCRIPTION
Documentation only. No code, no version bump, nothing that npm publishes.

The any-model advisor work (#247, v9.3.0) kept its build report, its mutation proofs and its scope decisions in a gitignored session directory, which `git worktree remove` deletes. This PR archives all three verbatim under `ai-docs/reports/`, each behind a header that says what no longer exists, and points `ROADMAP.md` and `ai-docs/architecture/advisor.md` at the archives instead of the session path.

It also parks the three follow-ups the work left untracked, each with a trigger condition in `ROADMAP.md`:

- a reasoning-only panel reply is recorded as a stub (`native-handler-advisor.ts:2152`, `:2179`)
- the `openai-sse` parser drops every per-chunk error in one empty `catch` (`openai-sse.ts:534-896`)
- a local `bun run test` on bun 1.4.0 never reaches the macOS bridge suite; CI on the pinned bun 1.3.10 still runs it (run 34544453952)

And it adds `ai-docs/reports/advisor-followups-handoff-20260911.md`, a work order for those three plus the already-parked subscription-aware panel routing.

Crafted with agentic harness Magus (https://github.com/MadAppGang/magus)
