### PR TITLE
fix(providers): send x-opencode-session so OpenCode Go/Zen requests route

### DIFF
--- a/packages/cli/src/providers/transport/openai.test.ts
+++ b/packages/cli/src/providers/transport/openai.test.ts
@@ -182,3 +182,82 @@ describe("isTerminal429", () => {
     expect(isTerminal429(transient)).toBe(false);
   });
 });
+
+/**
+ * OpenCode Go rejects any request that carries no `x-opencode-session`:
+ *
+ *   400 {"type":"error","error":{"type":"MissingSessionID","message":
+ *        "Error from provider (Console Go): Request is missing
+ *         x-opencode-session and cannot be routed efficiently."}}
+ *
+ * Measured 2026-09-12 on `/v1/chat/completions`: `glm-5.3-flash` and
+ * `deepseek-v4.1-flash` both return 200 with the header and this 400 without
+ * it, so the header is the whole difference. Before the fix, every Go model
+ * failed in Claudish with `zengo@…` despite a valid key.
+ */
+describe("OpenAIProviderTransport OpenCode session header", () => {
+  const goProvider: RemoteProvider = {
+    name: "opencode-zen-go",
+    baseUrl: "https://opencode.ai/zen/go",
+    apiPath: "/v1/chat/completions",
+    apiKeyEnvVar: "OPENCODE_GO_API_KEY",
+    prefixes: ["zengo@"],
+  };
+
+  test("opencode-zen-go carries an x-opencode-session id and identifies itself", async () => {
+    const headers = await new OpenAIProviderTransport(
+      goProvider,
+      "deepseek-v4.1-flash",
+      "test-key"
+    ).getHeaders();
+
+    // A `claudish-<uuid>` shape, not an empty placeholder: the relay routes on
+    // the value, so a constant or empty string would collapse every user onto
+    // one routing bucket.
+    expect(headers["x-opencode-session"]).toMatch(/^claudish-[0-9a-f-]{36}$/);
+    // The relay asks clients to name themselves rather than present a generic
+    // HTTP-library User-Agent.
+    expect(headers["User-Agent"]).toMatch(/^claudish\//);
+  });
+
+  test("the id is stable across calls, so a retry cannot move routing mid-turn", async () => {
+    const transport = new OpenAIProviderTransport(goProvider, "deepseek-v4.1-flash", "test-key");
+
+    const first = await transport.getHeaders();
+    const second = await transport.getHeaders();
+
+    expect(second["x-opencode-session"]).toBe(first["x-opencode-session"]);
+  });
+
+  test("two conversations do not share an id", async () => {
+    const a = await new OpenAIProviderTransport(goProvider, "m", "k").getHeaders();
+    const b = await new OpenAIProviderTransport(goProvider, "m", "k").getHeaders();
+
+    expect(a["x-opencode-session"]).not.toBe(b["x-opencode-session"]);
+  });
+
+  test("other providers are not given the header", async () => {
+    const provider: RemoteProvider = {
+      name: "some-openai-compatible",
+      baseUrl: "https://gateway.example.com/v1",
+      apiPath: "/chat/completions",
+      apiKeyEnvVar: "CUSTOM_SOME_OPENAI_COMPATIBLE_KEY",
+      prefixes: ["some@"],
+    };
+
+    const headers = await new OpenAIProviderTransport(provider, "m", "k").getHeaders();
+
+    expect("x-opencode-session" in headers).toBe(false);
+  });
+
+  test("a provider-declared header still wins over the generated one", async () => {
+    const provider: RemoteProvider = {
+      ...goProvider,
+      headers: { "x-opencode-session": "pinned-by-config" },
+    };
+
+    const headers = await new OpenAIProviderTransport(provider, "m", "k").getHeaders();
+
+    expect(headers["x-opencode-session"]).toBe("pinned-by-config");
+  });
+});

--- a/packages/cli/src/providers/transport/openai.ts
+++ b/packages/cli/src/providers/transport/openai.ts
@@ -6,12 +6,38 @@
  * Includes 30-second timeout with detailed error reporting.
  */
 
+import { randomUUID } from "node:crypto";
 import { isQuotaExhaustionError } from "../../handlers/shared/quota-exhaustion.js";
 import type { RemoteProvider } from "../../handlers/shared/remote-provider-types.js";
 import { log } from "../../logger.js";
+import { VERSION } from "../../version.js";
 import type { DiscoveryOutcome } from "./probe-discovery.js";
 import { discoverProviderProbeModel } from "./provider-model-discovery.js";
 import type { ProviderTransport, StreamFormat } from "./types.js";
+
+/**
+ * Providers that reject a request carrying no per-conversation session id.
+ *
+ * OpenCode Go answers `400 {"type":"error","error":{"type":"MissingSessionID",
+ * "message":"… Request is missing x-opencode-session and cannot be routed
+ * efficiently."}}` to every request that omits the header. Measured 2026-09-12
+ * against `/v1/chat/completions`, one POST per row: a model the tier serves
+ * (`glm-5.3-flash`, `deepseek-v4.1-flash`) returns 200 with the header and 400
+ * without it, so the header is the only difference between the two outcomes.
+ *
+ * The relay's "Where can I use it" section states the contract: a client should
+ * send "a stable session ID in `x-opencode-session` for each conversation so we
+ * can optimize routing and prompt caching", and should "identify itself with
+ * its own user agent … rather than a generic SDK or HTTP-library name". Both are
+ * emitted below. The User-Agent half is not decoration: the same Cloudflare edge
+ * answered a UA-less roster request with `403 error code: 1010` — see the
+ * measured note in `model-discovery.ts` — and the chat endpoint sits behind it.
+ *
+ * `opencode-zen` (the metered sibling) shares the apiPath and the transport and
+ * is expected to share the contract; it is listed alongside Go rather than
+ * waiting for a separate measurement.
+ */
+const SESSION_ID_PROVIDERS = new Set(["opencode-zen-go", "opencode-zen"]);
 
 export class OpenAIProviderTransport implements ProviderTransport {
   readonly name: string;
@@ -21,6 +47,23 @@ export class OpenAIProviderTransport implements ProviderTransport {
   protected provider: RemoteProvider;
   private apiKey: string;
   protected modelName: string;
+
+  /**
+   * The `x-opencode-session` value sent with every request (see
+   * `SESSION_ID_PROVIDERS`).
+   *
+   * Generated once per transport and therefore stable for the life of the
+   * conversation this transport serves: a retry re-sends the SAME id, which is
+   * the point — the relay uses it to keep a turn pinned to one backend and one
+   * prompt cache, so an id that changed between the first attempt and its retry
+   * would move both mid-turn. Two concurrent conversations hold two transports
+   * and so get two ids, which is what keeps their routing independent.
+   *
+   * A `claudish-` prefix keeps the value identifiable in relay logs without
+   * implying it is a Claude Code session id — it is not, and must not be
+   * confused with the `metadata.user_id`-derived id used for codex caching.
+   */
+  private readonly sessionId = `claudish-${randomUUID()}`;
 
   constructor(provider: RemoteProvider, modelName: string, apiKey: string) {
     this.provider = provider;
@@ -83,6 +126,14 @@ export class OpenAIProviderTransport implements ProviderTransport {
       } else {
         headers.Authorization = `Bearer ${this.apiKey}`;
       }
+    }
+    // A relay that routes on a session id gets one, plus an identifying
+    // User-Agent. Emitted BEFORE the provider merge below so a definition that
+    // declares its own value still wins — the same precedence
+    // `model-discovery.ts` uses for its roster request.
+    if (SESSION_ID_PROVIDERS.has(this.provider.name)) {
+      headers["User-Agent"] = `claudish/${VERSION}`;
+      headers["x-opencode-session"] = this.sessionId;
     }
     // Provider headers are merged whether or not a key resolved: for a gateway
     // whose auth lives in a custom header, they ARE the credential.


### PR DESCRIPTION
# fix(providers): send `x-opencode-session` so OpenCode Go/Zen requests route

## Problem

Every model on the OpenCode Go tier fails in Claudish — `zengo@glm-5.3-flash`,
`zengo@deepseek-v4.1-flash`, all of them — with a valid key:

```
claudish --model zengo@deepseek-v4.1-flash "say hello"
# → 400 {"type":"error","error":{"type":"MissingSessionID",
#      "message":"Error from provider (Console Go): Request is missing
#                 x-opencode-session and cannot be routed efficiently.
#                 Please see https://opencode.ai/docs/go/#where-can-i-use-it"}}
```

The failure reads like a credential or model-gating problem, so it sends users
to check a key that is fine.

## Root cause

OpenCode Go requires a session id on every request. From the relay's own docs
("Where can I use it"), a client should:

> send a stable session ID in `x-opencode-session` for each conversation so we
> can optimize routing and prompt caching

and

> Identify itself with its own user agent … rather than a generic SDK or
> HTTP-library name.

`OpenAIProviderTransport.getHeaders()` emitted auth plus the provider's declared
`headers` and nothing else, and the `opencode-zen-go` definition declares no
`headers` — so the header was never sent. A grep for `x-opencode-session` across
the repository returns no hits.

Note that `model-discovery.ts` already carries a dated note about this exact
provider needing a `User-Agent` (a UA-less roster request returns Cloudflare
`403 error code: 1010`). The chat path sits behind the same edge and never got
the equivalent treatment.

## Change

`packages/cli/src/providers/transport/openai.ts`

- emits `x-opencode-session: claudish-<uuid>` for `opencode-zen-go` and
  `opencode-zen`;
- emits `User-Agent: claudish/<VERSION>` alongside it;
- both are written **before** the provider `headers` merge, so a definition that
  pins its own value still wins — the same precedence `model-discovery.ts` uses
  for its roster request.

The id is generated once per transport, which is the life of the conversation it
serves. That matters in both directions: a retry re-sends the **same** id, so a
turn cannot be re-routed mid-flight, while two concurrent conversations hold two
transports and get two ids, keeping their routing independent.

Nothing changes for any other provider: the block is gated on the provider name
and the emitted header set is otherwise identical.

## Verification

**Measured 2026-09-12**, one `POST /v1/chat/completions` per row, same key, same
body, the header the only difference:

| model | without `x-opencode-session` | with it |
|---|---|---|
| `glm-5.3-flash` | `400 MissingSessionID` | `200` |
| `deepseek-v4.1-flash` | `400 MissingSessionID` | `200` |

**Against the patched transport source** (the real `OpenAIProviderTransport`
compiled from the changed file, not a reimplementation), all checks pass:

```
PASS  x-opencode-session present — "claudish-519513ff-78bd-42b9-8a9d-a1dc76f0a21f"
PASS  id shape claudish-<uuid>
PASS  id stable across calls
PASS  User-Agent identifies the client — "claudish/9.3.0"
PASS  bearer auth still emitted
PASS  distinct id per conversation
PASS  header absent for other providers — ["Authorization"]
PASS  provider-declared value wins — "pinned"
PASS  live relay answers 200 — 200          (deepseek-v4.1-flash)
PASS  live body is a completion, not MissingSessionID
PASS  control (header removed) reproduces the 400 — 400
```

**Unit coverage added** in `openai.test.ts`: the header and its shape, its
stability across calls, its uniqueness per conversation, its absence for other
providers, and the definition-override precedence.

## Follow-ups (out of scope here)

- `opencode-zen` (the metered sibling) is included on the strength of sharing
  the apiPath, transport and relay; it has not been measured separately the way
  Go has.
- The Anthropic-format custom-endpoint path (`anthropic-compat` transport) would
  need the same header if someone points it at OpenCode Go.
